### PR TITLE
Articles now retrieved via slug, urls use category and slug

### DIFF
--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -40,7 +40,10 @@ export default function ArticleLink(props) {
       <div className="media-content small-margin-left">
         <div className="content">
           <h1 className="title">
-            <Link href="/articles/[id]/" as={`/articles/${props.article.id}`}>
+            <Link
+              href="/articles/[category]/[slug]"
+              as={`/articles/${props.article.category.slug}/${props.article.slug}`}
+            >
               <a>{props.article.headline}</a>
             </Link>
           </h1>

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -38,7 +38,10 @@ export default function ArticleLink(props) {
       )}
       <div className="media-left">
         <h1 className="title">
-          <Link href="/articles/[id]/" as={`/articles/${props.article.id}`}>
+          <Link
+            href="/articles/[category]/[slug]"
+            as={`/articles/${props.article.category.slug}/${props.article.slug}`}
+          >
             <a className="featured">{props.article.headline}</a>
           </Link>
         </h1>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -7,16 +7,20 @@ const CONTENT_DELIVERY_API_ACCESS_TOKEN =
 const LIST_ARTICLES = `
   {
     listBasicArticles {
-    data {
-      id
-      headline
-      byline
-      body
-      firstPublishedOn
-      lastPublishedOn
+      data {
+        id
+        slug 
+        category {
+          slug
+        }
+        headline
+        byline
+        body
+        firstPublishedOn
+        lastPublishedOn
+      }
     }
   }
-}
 `;
 
 const LIST_IDS = `
@@ -24,6 +28,18 @@ const LIST_IDS = `
   listBasicArticles {
     data {
       id
+    }
+  }
+}
+`;
+const LIST_SLUGS = `
+{
+  listBasicArticles {
+    data {
+      category {
+        slug
+      }
+      slug
     }
   }
 }
@@ -81,11 +97,56 @@ export async function listAllArticleIds() {
   return ids;
 }
 
+export async function listAllArticleSlugs() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(LIST_SLUGS);
+  const slugs = articlesData.listBasicArticles.data.map((article) => {
+    return {
+      params: {
+        category: article.category.slug,
+        slug: article.slug,
+      },
+    };
+  });
+  console.log('slugs: ', slugs);
+  return slugs;
+}
+
 const GET_ARTICLE = `
   query Article($id: ID!) {
     getBasicArticle(where: {id: $id}) {
       data {
         id
+        headline
+        byline
+        body
+        tags { 
+          title
+        }
+        firstPublishedOn
+        lastPublishedOn
+        searchTitle
+        searchDescription
+        facebookTitle
+        facebookDescription
+        twitterTitle
+        twitterDescription
+      }
+    }
+  }
+`;
+
+const GET_ARTICLE_BY_SLUG = `
+  query Article($slug: String) {
+    getBasicArticle(where: {slug: $slug}) {
+      data {
+        id
+        slug
         headline
         byline
         body 
@@ -113,5 +174,18 @@ export async function getArticle(id) {
   });
 
   const articlesData = await webinyHeadlessCms.request(GET_ARTICLE, { id });
+  return articlesData.getBasicArticle.data;
+}
+
+export async function getArticleBySlug(slug) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(GET_ARTICLE_BY_SLUG, {
+    slug,
+  });
   return articlesData.getBasicArticle.data;
 }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -1,18 +1,21 @@
-import Layout from '../../components/Layout.js';
+import Layout from '../../../components/Layout.js';
 import Link from 'next/Link';
 import kebabCase from 'lodash/kebabCase';
-import { getArticle, listAllArticleIds } from '../../lib/articles.js';
-import ArticleNav from '../../components/nav/ArticleNav.js';
-import ArticleFooter from '../../components/nav/ArticleFooter.js';
-import Coral from '../../components/plugins/Coral.js';
-import MailchimpSubscribe from '../../components/plugins/MailchimpSubscribe.js';
-import EmbedNode from '../../components/nodes/EmbedNode.js';
-import ImageNode from '../../components/nodes/ImageNode.js';
-import ListNode from '../../components/nodes/ListNode.js';
-import TextNode from '../../components/nodes/TextNode.js';
+import {
+  getArticleBySlug,
+  listAllArticleSlugs,
+} from '../../../lib/articles.js';
+import ArticleNav from '../../../components/nav/ArticleNav.js';
+import ArticleFooter from '../../../components/nav/ArticleFooter.js';
+import Coral from '../../../components/plugins/Coral.js';
+import MailchimpSubscribe from '../../../components/plugins/MailchimpSubscribe.js';
+import EmbedNode from '../../../components/nodes/EmbedNode.js';
+import ImageNode from '../../../components/nodes/ImageNode.js';
+import ListNode from '../../../components/nodes/ListNode.js';
+import TextNode from '../../../components/nodes/TextNode.js';
 import { useAmp } from 'next/amp';
 import { parseISO } from 'date-fns';
-import { siteMetadata } from '../../lib/siteMetadata.js';
+import { siteMetadata } from '../../../lib/siteMetadata.js';
 
 let sections = [
   { label: 'News', link: '/news' },
@@ -145,7 +148,7 @@ export default function Article({ article }) {
 }
 
 export async function getStaticPaths() {
-  const paths = await listAllArticleIds();
+  const paths = await listAllArticleSlugs();
   return {
     paths,
     fallback: false,
@@ -153,7 +156,7 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const article = await getArticle(params.id);
+  const article = await getArticleBySlug(params.slug);
 
   return {
     props: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -82,6 +82,7 @@ export default function Home({ articles, tags }) {
 
 export async function getStaticProps() {
   const articles = await listAllArticles();
+  console.log('articles: ', articles);
   const tags = await listAllTags();
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,6 +2541,11 @@ date-fns@^2.14.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
   integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
+dateline@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/dateline/-/dateline-2.2.1.tgz#36ed3a25663329f320271f23ec406a05966d8e9f"
+  integrity sha512-qAiapbRcNx2kjUFAOaNoT2MlpX18JNvb6quL9viDAC6KWAUQ6c25qLTm/4RrROdOrjeTMVnZ4X8wBH2r1G75sg==
+
 debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -6855,6 +6860,11 @@ web-vitals@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.1.tgz#60782fa690243fe35613759a0c26431f57ba7b2d"
   integrity sha512-2pdRlp6gJpOCg0oMMqwFF0axjk5D9WInc09RSYtqFgPXQ15+YKNQ7YnBBEqAL5jvmfH9WvoXDMb8DHwux7pIew==
+
+web-vitals@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Issue #42 

I've changed the routing for article pages so that they're loaded based on their category/section and slug.

The article template is now located at `pages/articles/[category]/[slug].js`

Articles are listed to include their category and slug. Articles are now looked up by slug. I had to make this `slug` field the article entry's `title` in webiny to allow this lookup. I'm pretty sure that also adds a unique constraint to the field.