### PR TITLE
populate navbar with categories from webiny

### DIFF
--- a/components/nav/ArticleNav.js
+++ b/components/nav/ArticleNav.js
@@ -9,11 +9,11 @@ export default function ArticleNav(props) {
   if (props.sections) {
     sectionLinks = props.sections.slice(0, 4).map((section) => (
       <Link
-        key={`navbar-${_.kebabCase(section.label)}`}
-        href={section.link}
-        as={section.link}
+        key={`navbar-${_.kebabCase(section.title)}`}
+        href={section.slug}
+        as={section.slug}
       >
-        <a className="navbar-item">{_.startCase(section.label)}</a>
+        <a className="navbar-item">{_.startCase(section.title)}</a>
       </Link>
     ));
   }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -45,6 +45,17 @@ const LIST_SLUGS = `
 }
 `;
 
+const LIST_SECTIONS = `
+{
+  listCategories {
+  	data {
+      title
+      slug
+    }
+  }
+}
+`;
+
 const LIST_TAGS = `
 {
   listTags {
@@ -54,6 +65,18 @@ const LIST_TAGS = `
   }
 }
 `;
+
+export async function listAllSections() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const tagsData = await webinyHeadlessCms.request(LIST_SECTIONS);
+
+  return tagsData.listCategories.data;
+}
 
 export async function listAllTags() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import Link from 'next/link';
 import { listAllArticles } from '../lib/articles.js';
 import { listAllTags } from '../lib/articles.js';
+import { listAllSections } from '../lib/articles.js';
 import Layout from '../components/Layout.js';
 import ArticleNav from '../components/nav/ArticleNav.js';
 import FeaturedArticleLink from '../components/homepage/FeaturedArticleLink.js';
@@ -11,15 +12,9 @@ import ArticleFooter from '../components/nav/ArticleFooter.js';
 import { useAmp } from 'next/amp';
 import { siteMetadata } from '../lib/siteMetadata.js';
 
-let sections = [
-  { label: 'News', link: '/news' },
-  { label: 'Features', link: '/features' },
-  { label: 'Pandemic', link: '/pandemic' },
-];
-
 export const config = { amp: 'hybrid' };
 
-export default function Home({ articles, tags }) {
+export default function Home({ articles, tags, sections }) {
   const isAmp = useAmp();
 
   siteMetadata.tags = tags;
@@ -83,11 +78,13 @@ export default function Home({ articles, tags }) {
 export async function getStaticProps() {
   const articles = await listAllArticles();
   const tags = await listAllTags();
+  const sections = await listAllSections();
 
   return {
     props: {
       articles,
       tags,
+      sections,
     },
   };
 }


### PR DESCRIPTION
Issue #43 

This PR replaces the hardcoded site sections with real data from webiny:

* added a graphql query to list categories
* added a listAllSections function to articles lib
* update ArticleNav with new data format for generating links (title and slug instead of label and link)

