### PR TITLE
Articles now store contents in JSON string as 'content'

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -146,7 +146,7 @@ const GET_ARTICLE = `
         id
         headline
         byline
-        body
+        content
         tags { 
           title
         }
@@ -171,7 +171,7 @@ const GET_ARTICLE_BY_SLUG = `
         slug
         headline
         byline
-        body 
+        content 
         tags { 
           title
         }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -21,7 +21,24 @@ import { siteMetadata } from '../../../lib/siteMetadata.js';
 export const config = { amp: 'hybrid' };
 
 export default function Article({ article, sections }) {
-  const mainImageNode = article.body.find((node) => node.type === 'mainImage');
+  let articleBody = null;
+  try {
+    articleBody = JSON.parse(article.content);
+  } catch (e) {
+    console.log(
+      'failed parsing article contents, (TODO: actually handle this - 500 page?)'
+    );
+    console.log(e);
+  }
+
+  if (articleBody === null) {
+    console.log(
+      'article body is null, give up (TODO: actually handle this - 500 page?)'
+    );
+    return null;
+  }
+
+  const mainImageNode = articleBody.find((node) => node.type === 'mainImage');
   let mainImage = null;
 
   if (mainImageNode) {
@@ -60,7 +77,7 @@ export default function Article({ article, sections }) {
     }
   };
 
-  const serializedBody = article.body.map((node, i) => serialize(node, i));
+  const serializedBody = articleBody.map((node, i) => serialize(node, i));
 
   let tagLinks;
   if (article.tags) {


### PR DESCRIPTION
Issue #63 

This PR goes with [PR #73 in the Google apps script repo](https://github.com/news-catalyst/google-app-scripts/pull/73) that changes the article data from `body` (javascript object) to `content` (JSON string).

In order to work with the article data, this PR:

* requests the `content` field instead of `body`
* parses the `content` field
* catches any error in the JSON parsing - for now, this console.logs but we'll need a 500 page to redirect to... I guess
* renders the article as before (tested on the philly story)

To test:

* load up this app
* navigate to http://localhost:3000/articles/us/heres-how-philadelphia-public-schools-will-operate-this-fall

You should see the article render as before.