### PR TITLE
Support for previewing articles

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -22,10 +22,12 @@ export default function Layout({ children, meta }) {
   };
 
   let tagList = [];
-  for (const [index, value] of metaValues.tags.entries()) {
-    tagList.push(
-      <meta property="article:tag" content={value.title} key={value.title} />
-    );
+  if (metaValues.tags) {
+    for (const [index, value] of metaValues.tags.entries()) {
+      tagList.push(
+        <meta property="article:tag" content={value.title} key={value.slug} />
+      );
+    }
   }
 
   const isAmp = useAmp();

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -3,17 +3,16 @@ import Link from 'next/link';
 import { parseISO } from 'date-fns';
 
 export default function ArticleLink(props) {
+  let mainImage = null;
+  let parsedContent = JSON.parse(props.article.content);
+  const mainImageNode = parsedContent.find((node) => node.type === 'mainImage');
+
   var Dateline = require('dateline');
   let parsedDate = parseISO(props.article.firstPublishedOn);
   let firstPublishedOn =
     Dateline(parsedDate).getAPDate() +
     ' at ' +
     Dateline(parsedDate).getAPTime();
-
-  const mainImageNode = props.article.content.find(
-    (node) => node.type === 'mainImage'
-  );
-  let mainImage = null;
 
   if (mainImageNode) {
     mainImage = mainImageNode.children[0];

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -4,7 +4,18 @@ import { parseISO } from 'date-fns';
 
 export default function ArticleLink(props) {
   let mainImage = null;
-  let parsedContent = JSON.parse(props.article.content);
+  let parsedContent = [];
+  try {
+    if (typeof props.article.content === 'string') {
+      parsedContent = JSON.parse(props.article.content);
+    } else if (typeof props.article.content !== 'undefined') {
+      // assuming it was parsed elsewhere? confusing.
+      parsedContent = props.article.content;
+    }
+  } catch (e) {
+    console.log('error parsing JSON: ', e);
+  }
+
   const mainImageNode = parsedContent.find((node) => node.type === 'mainImage');
 
   var Dateline = require('dateline');

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -247,6 +247,9 @@ const GET_ARTICLE_BY_SLUG = `
       data {
         id
         slug
+        category {
+          slug
+        }
         headline
         byline
         content

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -21,6 +21,7 @@ const LIST_ARTICLES = `
         lastPublishedOn
         tags {
           title
+          slug
         }
       }
     }
@@ -65,6 +66,7 @@ const LIST_TAGS = `
   listTags {
     data {
       title
+      slug
     }
   }
 }
@@ -128,14 +130,14 @@ export async function listAllTags() {
 
   const tagsData = await webinyHeadlessCms.request(LIST_TAGS);
 
-  const titles = tagsData.listTags.data.map((tag) => {
+  const slugs = tagsData.listTags.data.map((tag) => {
     return {
       params: {
-        title: tag.title,
+        slug: tag.slug,
       },
     };
   });
-  return titles;
+  return slugs;
 }
 
 export async function listAllArticles() {
@@ -162,10 +164,16 @@ export async function listAllArticlesByTag(tag) {
   const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
   let articlesByTag = [];
   articlesData.listBasicArticles.data.map((article) => {
-    for (var i = 0; i < article.tags.length; i++) {
-      if (article.tags[i].title == tag) {
-        articlesByTag.push(article);
-        break;
+    if (article.tags !== null && article.tags !== undefined) {
+      for (var i = 0; i < article.tags.length; i++) {
+        if (
+          article.tags[i] &&
+          article.tags[i] !== null &&
+          article.tags[i].slug == tag
+        ) {
+          articlesByTag.push(article);
+          break;
+        }
       }
     }
   });
@@ -244,6 +252,7 @@ const GET_ARTICLE_BY_SLUG = `
         content
         tags {
           title
+          slug
         }
         firstPublishedOn
         lastPublishedOn

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -14,6 +14,9 @@ const LIST_ARTICLES = `
       body
       firstPublishedOn
       lastPublishedOn
+      tags {
+        title
+      }
     }
   }
 }
@@ -48,7 +51,14 @@ export async function listAllTags() {
 
   const tagsData = await webinyHeadlessCms.request(LIST_TAGS);
 
-  return tagsData.listTags.data;
+  const titles = tagsData.listTags.data.map((tag) => {
+    return {
+      params: {
+        title: tag.title,
+      },
+    };
+  });
+  return titles;
 }
 
 export async function listAllArticles() {
@@ -61,6 +71,26 @@ export async function listAllArticles() {
   const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
 
   return articlesData.listBasicArticles.data;
+}
+
+export async function listAllArticlesByTag(tag) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
+  let articlesByTag = [];
+  articlesData.listBasicArticles.data.map((article) => {
+    for (var i = 0; i < article.tags.length; i++) {
+      if (article.tags[i].title == tag) {
+        articlesByTag.push(article);
+        break;
+      }
+    }
+  });
+  return articlesByTag;
 }
 
 export async function listAllArticleIds() {

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,35 @@
+import { getArticleBySlug } from '../../lib/articles.js';
+
+export default async (req, res) => {
+  // Check the secret and next parameters
+  // This secret should only be known to this API route and the CMS
+  if (req.query.secret !== process.env.PREVIEW_TOKEN || !req.query.slug) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Fetch the headless CMS to check if the provided `slug` exists
+  const article = await getArticleBySlug(req.query.slug);
+
+  // If the slug doesn't exist prevent preview mode from being enabled
+  if (!article) {
+    return res.status(401).json({ message: 'Invalid slug' });
+  }
+
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({});
+
+  // Redirect to the path from the fetched post
+  // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+
+  // BUG: this line of code taken from the nextjs docs doesn't work - throws a typeerror: res.redirect is not a function (??)
+  // (https://nextjs.org/docs/advanced-features/preview-mode)
+  // res.redirect(article.slug)
+
+  const articlePath = '/articles/' + article.category.slug + '/' + article.slug;
+
+  // this approach to the redirect does work
+  res.writeHead(301, {
+    Location: articlePath,
+  });
+  res.end();
+};

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -5,6 +5,7 @@ import {
   getArticleBySlug,
   listAllArticleSlugs,
   listAllSections,
+  listAllTags,
 } from '../../../lib/articles.js';
 import ArticleNav from '../../../components/nav/ArticleNav.js';
 import ArticleFooter from '../../../components/nav/ArticleFooter.js';
@@ -21,7 +22,7 @@ import { siteMetadata } from '../../../lib/siteMetadata.js';
 
 export const config = { amp: 'hybrid' };
 
-export default function Article({ article, sections }) {
+export default function Article({ article, sections, tags }) {
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'
   );
@@ -37,7 +38,7 @@ export default function Article({ article, sections }) {
   siteMetadata.facebookDescription = article.facebookDescription;
   siteMetadata.twitterTitle = article.twitterTitle;
   siteMetadata.twitterDescription = article.twitterDescription;
-  siteMetadata.tags = article.tags;
+  siteMetadata.tags = tags;
   siteMetadata.firstPublishedOn = article.firstPublishedOn;
   siteMetadata.lastPublishedOn = article.lastPublishedOn;
   if (mainImage !== null) {
@@ -102,10 +103,7 @@ export default function Article({ article, sections }) {
   let tagLinks;
   if (article.tags) {
     tagLinks = article.tags.map((tag, index) => (
-      <Link
-        href={`/topics/${kebabCase(tag.title)}`}
-        key={`${tag.title}-${index}`}
-      >
+      <Link href={`/tags/${tag.slug}`} key={`${tag.slug}-${index}`}>
         <a className="is-link tag">{tag.title}</a>
       </Link>
     ));
@@ -204,11 +202,13 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params }) {
   const article = await getArticleBySlug(params.slug);
   const sections = await listAllSections();
+  const tags = await listAllTags();
 
   return {
     props: {
       article,
       sections,
+      tags,
     },
   };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,7 +26,7 @@ export default function Home({ articles, tags }) {
   let unfeaturedArticles = articles.slice(1);
 
   const tagLinks = tags.map((tag) => (
-    <Link key={tag.title} href={`/topics/${tag.title}`}>
+    <Link key={tag.title} href={`/tags/${tag.title}`}>
       <a className="panel-block is-active">{_.startCase(tag.title)}</a>
     </Link>
   ));

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -1,8 +1,8 @@
 import Layout from '../../components/Layout.js';
 import ArticleLink from '../../components/homepage/ArticleLink.js';
 import {
-  getArticle,
   listAllArticlesByTag,
+  listAllSections,
   listAllTags,
 } from '../../lib/articles.js';
 import { siteMetadata } from '../../lib/siteMetadata.js';
@@ -10,19 +10,13 @@ import ArticleNav from '../../components/nav/ArticleNav.js';
 import ArticleFooter from '../../components/nav/ArticleFooter.js';
 import { useAmp } from 'next/amp';
 
-let sections = [
-  { label: 'News', link: '/news' },
-  { label: 'Features', link: '/features' },
-  { label: 'Pandemic', link: '/pandemic' },
-];
-
 export default function TagPage(props) {
   const isAmp = useAmp();
   return (
     <Layout meta={siteMetadata}>
-      <ArticleNav metadata={siteMetadata} sections={sections} />
+      <ArticleNav metadata={siteMetadata} sections={props.sections} />
       <section className="section">
-        <h1 className="title">{props.title}</h1>
+        <h1 className="title">{props.slug}</h1>
         <div className="columns">
           <div className="column is-four-fifths">
             {props.articles.map((article) => (
@@ -45,12 +39,14 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const articles = await listAllArticlesByTag(params.title);
-  const title = params.title;
+  const articles = await listAllArticlesByTag(params.slug);
+  const sections = await listAllSections();
+  const slug = params.slug;
   return {
     props: {
       articles,
-      title,
+      slug,
+      sections,
     },
   };
 }

--- a/pages/tags/[title].js
+++ b/pages/tags/[title].js
@@ -1,0 +1,56 @@
+import Layout from '../../components/Layout.js';
+import ArticleLink from '../../components/homepage/ArticleLink.js';
+import {
+  getArticle,
+  listAllArticlesByTag,
+  listAllTags,
+} from '../../lib/articles.js';
+import { siteMetadata } from '../../lib/siteMetadata.js';
+import ArticleNav from '../../components/nav/ArticleNav.js';
+import ArticleFooter from '../../components/nav/ArticleFooter.js';
+import { useAmp } from 'next/amp';
+
+let sections = [
+  { label: 'News', link: '/news' },
+  { label: 'Features', link: '/features' },
+  { label: 'Pandemic', link: '/pandemic' },
+];
+
+export default function TagPage(props) {
+  const isAmp = useAmp();
+  return (
+    <Layout meta={siteMetadata}>
+      <ArticleNav metadata={siteMetadata} sections={sections} />
+      <section className="section">
+        <h1 className="title">{props.title}</h1>
+        <div className="columns">
+          <div className="column is-four-fifths">
+            {props.articles.map((article) => (
+              <ArticleLink key={article.id} article={article} amp={isAmp} />
+            ))}
+          </div>
+        </div>
+      </section>
+      <ArticleFooter metadata={siteMetadata} />
+    </Layout>
+  );
+}
+
+export async function getStaticPaths() {
+  const paths = await listAllTags();
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const articles = await listAllArticlesByTag(params.title);
+  const title = params.title;
+  return {
+    props: {
+      articles,
+      title,
+    },
+  };
+}


### PR DESCRIPTION
Issue #47 

This PR adds support for previewing articles, which is part of the work the linked issue above requires.

Now I need to figure out how this would work with regards to the data in webiny... I'll put my thoughts on the remaining to-dos in issue #47 

How to test this:

* make sure you add a token to your .env.local: `PREVIEW_TOKEN="SOMETHINGSECRET_GOES_HERE"`
* open the url: http://localhost:3000/api/preview?secret=SOMETHINGSECRET_GOES_HERE&slug=heres-how-philadelphia-public-schools-will-operate-this-fall

You should be redirected to the correct article page. Next will have set some preview cookies.