### PR TITLE
Restructured article components for preview

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -1,0 +1,184 @@
+import ArticleNav from './nav/ArticleNav.js';
+import ArticleFooter from './nav/ArticleFooter.js';
+import Coral from './plugins/Coral.js';
+import MailchimpSubscribe from './plugins/MailchimpSubscribe.js';
+import EmbedNode from './nodes/EmbedNode.js';
+import ImageNode from './nodes/ImageNode.js';
+import ListNode from './nodes/ListNode.js';
+import TextNode from './nodes/TextNode.js';
+import ImageWithTextAd from './ads/ImageWithTextAd.js';
+import { useAmp } from 'next/amp';
+import { parseISO } from 'date-fns';
+import { siteMetadata } from '../lib/siteMetadata.js';
+import Link from 'next/link';
+import Layout from './Layout.js';
+import kebabCase from 'lodash/kebabCase';
+
+export default function Article({ article, sections, tags }) {
+  const mainImageNode = article.content.find(
+    (node) => node.type === 'mainImage'
+  );
+  let mainImage = null;
+
+  if (mainImageNode) {
+    mainImage = mainImageNode.children[0];
+  }
+
+  siteMetadata.searchTitle = article.searchTitle;
+  siteMetadata.searchDescription = article.searchDescription;
+  siteMetadata.facebookTitle = article.facebookTitle;
+  siteMetadata.facebookDescription = article.facebookDescription;
+  siteMetadata.twitterTitle = article.twitterTitle;
+  siteMetadata.twitterDescription = article.twitterDescription;
+  siteMetadata.tags = tags;
+  siteMetadata.firstPublishedOn = article.firstPublishedOn;
+  siteMetadata.lastPublishedOn = article.lastPublishedOn;
+  if (mainImage !== null) {
+    siteMetadata.coverImage = mainImage.imageUrl;
+  }
+
+  const isAmp = useAmp();
+
+  const ad_placement = 5;
+  let adComponent = (
+    <ImageWithTextAd
+      ad={{
+        brand: 'test',
+        image: {
+          url: 'https://placehold.it/300x300',
+          alt: 'Alt text',
+        },
+        header: 'test header',
+        body: 'This is the body text of an advertisement.',
+        call: 'Call to action',
+        url: 'https://www.w3schools.com/',
+      }}
+    />
+  );
+
+  const serialize = (node, i) => {
+    if (i != ad_placement) {
+      switch (node.type) {
+        case 'list':
+          return <ListNode node={node} key={i} />;
+        case 'text':
+          return <TextNode node={node} key={i} />;
+        case 'paragraph':
+          return <TextNode node={node} key={i} />;
+        case 'image':
+          return <ImageNode node={node} amp={isAmp} key={i} />;
+        case 'embed':
+          return <EmbedNode node={node} amp={isAmp} key={i} />;
+        default:
+          return null;
+      }
+    } else {
+      switch (node.type) {
+        case 'list':
+          return [<ListNode node={node} key={i} />, adComponent];
+        case 'text':
+          return [<TextNode node={node} key={i} />, adComponent];
+        case 'paragraph':
+          return [<TextNode node={node} key={i} />, adComponent];
+        case 'image':
+          return [<ImageNode node={node} amp={isAmp} key={i} />, adComponent];
+        case 'embed':
+          return [<EmbedNode node={node} amp={isAmp} key={i} />, adComponent];
+        default:
+          return null;
+      }
+    }
+  };
+
+  const serializedBody = article.content.map((node, i) => serialize(node, i));
+
+  let tagLinks;
+  if (article.tags) {
+    tagLinks = article.tags.map((tag, index) => (
+      <Link href={`/tags/${tag.slug}`} key={`${tag.slug}-${index}`}>
+        <a className="is-link tag">{tag.title}</a>
+      </Link>
+    ));
+  }
+
+  var Dateline = require('dateline');
+  let parsedDate = parseISO(article.firstPublishedOn);
+  let firstPublishedOn =
+    Dateline(parsedDate).getAPDate() +
+    ' at ' +
+    Dateline(parsedDate).getAPTime();
+  parsedDate = parseISO(article.lastPublishedOn);
+  let lastPublishedOn =
+    Dateline(parsedDate).getAPDate() +
+    ' at ' +
+    Dateline(parsedDate).getAPTime();
+
+  return (
+    <Layout meta={siteMetadata}>
+      <ArticleNav metadata={siteMetadata} sections={sections} />
+      <article>
+        <section className="hero is-bold" key="title">
+          <div className="hero-body">
+            <div
+              className={article.cover ? 'container head-margin' : 'container'}
+            >
+              <h1 className="title is-size-1">{article.headline}</h1>
+              <h2 className="subtitle" key="byline">
+                By {article.byline} | Published {firstPublishedOn}
+              </h2>
+              <h2 className="subtitle" key="last-updated">
+                Last updated: {lastPublishedOn}
+              </h2>
+            </div>
+          </div>
+        </section>
+        {mainImage && isAmp && (
+          <amp-img
+            width={mainImage.width}
+            height={mainImage.height}
+            src={mainImage.imageUrl}
+            alt={mainImage.imageAlt}
+            layout="responsive"
+          />
+        )}
+
+        {mainImage && !isAmp && (
+          <img
+            src={mainImage.imageUrl}
+            alt={mainImage.imageAlt}
+            className="image"
+          />
+        )}
+        <section className="section" key="body">
+          <div id="articleText" className="content">
+            {serializedBody}
+          </div>
+        </section>
+      </article>
+      <aside>
+        <section className="section" key="sidebar">
+          <div className="align-content">
+            {tagLinks && <p className="subtitle">Tags</p>}
+            <div className="tags">{tagLinks}</div>
+          </div>
+        </section>
+      </aside>
+      <section className="section" key="plugins">
+        <div className="align-content medium-margin-top">
+          <h1 className="title media-left">
+            {siteMetadata.subscribe.subtitle}
+          </h1>
+          <MailchimpSubscribe />
+          <div className="comments">
+            {isAmp ? (
+              <div>Coral AMP</div>
+            ) : (
+              <Coral storyURL={`/articles/${article.id}`} />
+            )}
+          </div>
+        </div>
+      </section>
+      <ArticleFooter metadata={siteMetadata} />
+    </Layout>
+  );
+}

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -285,8 +285,11 @@ export async function getArticle(id) {
   return articlesData.getBasicArticle.data;
 }
 
-export async function getArticleBySlug(slug) {
-  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+export async function getArticleBySlug(slug, apiUrl) {
+  if (apiUrl === undefined) {
+    apiUrl = CONTENT_DELIVERY_API_URL;
+  }
+  const webinyHeadlessCms = new GraphQLClient(apiUrl, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
     },

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -25,7 +25,7 @@ export default async (req, res) => {
   // (https://nextjs.org/docs/advanced-features/preview-mode)
   // res.redirect(article.slug)
 
-  const articlePath = '/articles/' + article.category.slug + '/' + article.slug;
+  const articlePath = '/preview/' + article.category.slug + '/' + article.slug;
 
   // this approach to the redirect does work
   res.writeHead(301, {

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -4,12 +4,9 @@ import {
   listAllSections,
   listAllTags,
 } from '../../../lib/articles.js';
-
 import Article from '../../../components/Article.js';
 
-export const config = { amp: 'hybrid' };
-
-export default function ArticlePage(props) {
+export default function PreviewArticle(props) {
   return <Article {...props} />;
 }
 
@@ -22,10 +19,12 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-  const article = await getArticleBySlug(params.slug);
+  const article = await getArticleBySlug(
+    params.slug,
+    process.env.PREVIEW_API_URL
+  );
   const sections = await listAllSections();
   const tags = await listAllTags();
-
   return {
     props: {
       article,


### PR DESCRIPTION
Issue #47 

This PR rounds out the preview work (I think) - `Article` is now a component, and it's shared between these two routes:

* `/articles/[category]/[slug].js`
* `/preview/[category]/[slug].js`

The `/articles` version works as before. The `/preview` version passes a new env var - `PREVIEW_API_URL` - to the article lookup function. Note: this is just the `CONTENT_DELIVERY_API_URL` with `read` replaced by `preview`.

I updated the byline in my current fave article for testing, "The 3 Greatest American Novels" and saw both a changed byline and last updated date in the preview version. Preview (Ace Reporter) and published (Ernest Hemingway) article refreshed for the screenshots below.

<img width="862" alt="preview" src="https://user-images.githubusercontent.com/3397/90698865-31ca5600-e2c5-11ea-84db-a08534dd28a3.png">
<img width="938" alt="published" src="https://user-images.githubusercontent.com/3397/90698868-34c54680-e2c5-11ea-9ef8-65f662c5e0c2.png">
