### PR TITLE
Feature/render selected homepage layout

### DIFF
--- a/components/homepage/ArticleCard.js
+++ b/components/homepage/ArticleCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { parseISO } from 'date-fns';
 
-export default function ArticleLink(props) {
+export default function ArticleCard(props) {
   let mainImage = null;
   let parsedContent = [];
   try {
@@ -29,10 +29,10 @@ export default function ArticleLink(props) {
     mainImage = mainImageNode.children[0];
   }
   return (
-    <article className="media">
+    <div className="card">
       {mainImage && (
-        <figure className="media-left">
-          <p className="image article-link-img">
+        <div className="card-image">
+          <figure className="image is-4by3">
             {props.amp ? (
               <amp-img
                 width={mainImage.width}
@@ -42,13 +42,18 @@ export default function ArticleLink(props) {
                 layout="responsive"
               />
             ) : (
-              <img src={mainImage.imageUrl} />
+              <img
+                src={mainImage.imageUrl}
+                alt={mainImage.imageAlt}
+                width={mainImage.width}
+                height={mainImage.height}
+              />
             )}
-          </p>
-        </figure>
+          </figure>
+        </div>
       )}
-      <div className="media-content small-margin-left">
-        <div className="content">
+      <div className="card-content">
+        <div className="content" style={{ padding: '5px' }}>
           <h1 className="title">
             <Link
               href="/articles/[category]/[slug]"
@@ -61,6 +66,8 @@ export default function ArticleLink(props) {
           <p>{props.article.byline}</p>
           {props.article.firstPublishedOn && <p>{firstPublishedOn}</p>}
         </div>
+      </div>
+      <footer className="card-footer">
         <nav className="level is-mobile">
           <div className="level-left">
             <a className="level-item">
@@ -80,7 +87,7 @@ export default function ArticleLink(props) {
             </a>
           </div>
         </nav>
-      </div>
-    </article>
+      </footer>
+    </div>
   );
 }

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import { parseISO } from 'date-fns';
 
 export default function ArticleLink(props) {
+  console.log('props.article:', props.article);
+  console.log('props.article.category:', props.article.category);
   let mainImage = null;
   let parsedContent = [];
   try {

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -1,10 +1,80 @@
-import React from 'react';
+import _ from 'lodash';
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+import { useAmp } from 'next/amp';
+import { siteMetadata } from '../../lib/siteMetadata.js';
+import { getArticleBySlug } from '../../lib/articles.js';
+import Layout from '../Layout.js';
+import ArticleNav from '../nav/ArticleNav.js';
+import FeaturedArticleLink from './FeaturedArticleLink.js';
+import ArticleLink from './ArticleLink.js';
+import ArticleFooter from '../nav/ArticleFooter.js';
 
 export default function BigFeaturedStory(props) {
+  const [featuredArticle, setFeaturedArticle] = useState(
+    props.articles['featured']
+  );
+  const [streamArticles, setStreamArticles] = useState(
+    props.articles['stream']
+  );
+
   console.log('BigFeaturedStory', props);
+  streamArticles.map((streamArticle) => {
+    console.log('streamArticle:', streamArticle);
+  });
+  const isAmp = useAmp();
+
+  const tagLinks = props.tags.map((tag) => (
+    <Link key={tag.title} href={`/tags/${tag.title}`}>
+      <a className="panel-block is-active">{_.startCase(tag.title)}</a>
+    </Link>
+  ));
   return (
-    <div>
-      <h1>BigFeaturedStory</h1>
+    <div className="homepage">
+      <ArticleNav
+        metadata={siteMetadata}
+        tags={props.tags}
+        sections={props.sections}
+      />
+      <Layout meta={siteMetadata}>
+        <section className="hero is-dark is-bold">
+          <div className="hero-body">
+            <div className="container">
+              <h1 className="title">{siteMetadata.homepageTitle}</h1>
+              <h2 className="subtitle">{siteMetadata.homepageSubtitle}</h2>
+            </div>
+          </div>
+        </section>
+        <div className="featured-article">
+          {featuredArticle && (
+            <FeaturedArticleLink
+              key={featuredArticle.id}
+              article={featuredArticle}
+              amp={isAmp}
+            />
+          )}
+        </div>
+        <section className="section">
+          <div className="columns">
+            <div className="column is-four-fifths">
+              {streamArticles.map((streamArticle) => (
+                <ArticleLink
+                  key={streamArticle.id}
+                  article={streamArticle}
+                  amp={isAmp}
+                />
+              ))}
+            </div>
+            <div className="column">
+              <nav className="panel">
+                <p className="panel-heading">{siteMetadata.labels.topics}</p>
+                {tagLinks}
+              </nav>
+            </div>
+          </div>
+        </section>
+      </Layout>
+      <ArticleFooter post_type="home" metadata={siteMetadata} />
     </div>
   );
 }

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function BigFeaturedStory(props) {
+  console.log('BigFeaturedStory', props);
+  return (
+    <div>
+      <h1>BigFeaturedStory</h1>
+    </div>
+  );
+}

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -2,15 +2,22 @@ import React from 'react';
 import Link from 'next/link';
 import { parseISO } from 'date-fns';
 
-export default function ArticleLink(props) {
-  const mainImageNode = props.article.content.find(
-    (node) => node.type === 'mainImage'
-  );
-  let mainImage = null;
+export default function FeaturedArticleLink(props) {
+  console.log('FeaturedArticleLink props.article:', props.article);
 
-  if (mainImageNode) {
-    mainImage = mainImageNode.children[0];
+  let mainImage = null;
+  let mainImageNode = null;
+
+  if (props.article && props.article.content) {
+    mainImageNode = props.article.content.find(
+      (node) => node.type === 'mainImage'
+    );
+
+    if (mainImageNode) {
+      mainImage = mainImageNode.children[0];
+    }
   }
+
   var Dateline = require('dateline');
   let parsedDate = parseISO(props.article.firstPublishedOn);
   let firstPublishedOn =

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -1,10 +1,96 @@
-import React from 'react';
+import _ from 'lodash';
+import Link from 'next/link';
+import React, { useState } from 'react';
+import { useAmp } from 'next/amp';
+import { siteMetadata } from '../../lib/siteMetadata.js';
+import Layout from '../Layout.js';
+import ArticleNav from '../nav/ArticleNav.js';
+import FeaturedArticleLink from './FeaturedArticleLink.js';
+import ArticleCard from './ArticleCard.js';
+import ArticleFooter from '../nav/ArticleFooter.js';
+
+export const config = { amp: 'hybrid' };
 
 export default function LargePackageStoryLead(props) {
-  console.log('LargePackageStoryLead', props);
+  const isAmp = useAmp();
+
+  const [featuredArticle, setFeaturedArticle] = useState(
+    props.articles['featured']
+  );
+
+  const [subfeaturedLeftArticle, setSubFeaturedLeftArticle] = useState(
+    props.articles['subfeatured-left']
+  );
+  const [subfeaturedMiddleArticle, setSubFeaturedMiddleArticle] = useState(
+    props.articles['subfeatured-middle']
+  );
+  const [subfeaturedRightArticle, setSubFeaturedRightArticle] = useState(
+    props.articles['subfeatured-right']
+  );
+
+  const tagLinks = props.tags.map((tag) => (
+    <Link key={tag.title} href={`/tags/${tag.title}`}>
+      <a className="panel-block is-active">{_.startCase(tag.title)}</a>
+    </Link>
+  ));
   return (
-    <div>
-      <h1>LargePackageStoryLead</h1>
+    <div className="homepage">
+      <ArticleNav
+        metadata={siteMetadata}
+        tags={props.tags}
+        sections={props.sections}
+      />
+      <Layout meta={siteMetadata}>
+        <section className="hero is-dark is-bold">
+          <div className="hero-body">
+            <div className="container">
+              <h1 className="title">{siteMetadata.homepageTitle}</h1>
+              <h2 className="subtitle">{siteMetadata.homepageSubtitle}</h2>
+            </div>
+          </div>
+        </section>
+        <div className="featured-article">
+          {featuredArticle && (
+            <FeaturedArticleLink
+              key={featuredArticle.id}
+              article={featuredArticle}
+              amp={isAmp}
+            />
+          )}
+        </div>
+        <section className="section">
+          <div className="columns">
+            <div className="column is-one-third">
+              {subfeaturedLeftArticle && (
+                <ArticleCard
+                  key={subfeaturedLeftArticle.id}
+                  article={subfeaturedLeftArticle}
+                  amp={isAmp}
+                />
+              )}
+            </div>
+            <div className="column is-one-third">
+              {subfeaturedMiddleArticle && (
+                <ArticleCard
+                  key={subfeaturedMiddleArticle.id}
+                  article={subfeaturedMiddleArticle}
+                  amp={isAmp}
+                />
+              )}
+            </div>
+            <div className="column is-one-third">
+              {subfeaturedRightArticle && (
+                <ArticleCard
+                  key={subfeaturedRightArticle.id}
+                  article={subfeaturedRightArticle}
+                  amp={isAmp}
+                />
+              )}
+            </div>
+          </div>
+        </section>
+      </Layout>
+      <ArticleFooter post_type="home" metadata={siteMetadata} />
     </div>
   );
 }

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function LargePackageStoryLead(props) {
+  console.log('LargePackageStoryLead', props);
+  return (
+    <div>
+      <h1>LargePackageStoryLead</h1>
+    </div>
+  );
+}

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -28,6 +28,33 @@ const LIST_ARTICLES = `
   }
 `;
 
+const LIST_ARTICLES_BY_SLUG = `
+  query listBasicArticles($where: BasicArticleListWhereInput) {
+    content: listBasicArticles(where: $where) {
+      data {
+        id
+        headline
+        byline
+        content
+        tags {
+          title
+        }
+        category {
+          slug
+          title
+        }
+        firstPublishedOn
+        lastPublishedOn
+        searchTitle
+        searchDescription
+        facebookTitle
+        facebookDescription
+        twitterTitle
+        twitterDescription
+      }
+    }
+  }`;
+
 const LIST_IDS = `
 {
   listBasicArticles {
@@ -152,6 +179,32 @@ export async function listAllArticles() {
     article.content = JSON.parse(article.content);
   });
   return articlesData.listBasicArticles.data;
+}
+
+export async function listArticlesBySlug(slugs) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const variables = {
+    where: {
+      slug_in: slugs,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES_BY_SLUG,
+    variables
+  );
+  articlesData.content.data.map((article) => {
+    try {
+      article.content = JSON.parse(article.content);
+    } catch (e) {
+      console.log('error parsing json:', e);
+    }
+  });
+  return articlesData.content.data;
 }
 
 export async function listAllArticlesByTag(tag) {
@@ -302,4 +355,26 @@ export async function getArticleBySlug(slug, apiUrl) {
     articlesData.getBasicArticle.data.content
   );
   return articlesData.getBasicArticle.data;
+}
+
+export async function getHomepageArticles(hpArticleData) {
+  let hpArticles = {};
+  Object.entries(hpArticleData).map(([key, values]) => {
+    if (typeof values === 'string') {
+      console.log('looking up one article:', values);
+      let foundArticle;
+      (async () => {
+        foundArticle = await getArticleBySlug(values);
+        hpArticles[key] = foundArticle;
+      })();
+    } else {
+      console.log('looking up multiple articles:', values);
+      let foundArticles;
+      (async () => {
+        foundArticles = await listArticlesBySlug(values);
+        hpArticles[key] = foundArticles;
+      })();
+    }
+  });
+  return hpArticles;
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -351,24 +351,32 @@ export async function getArticleBySlug(slug, apiUrl) {
   const articlesData = await webinyHeadlessCms.request(GET_ARTICLE_BY_SLUG, {
     slug,
   });
-  articlesData.getBasicArticle.data.content = JSON.parse(
-    articlesData.getBasicArticle.data.content
-  );
+  try {
+    articlesData.getBasicArticle.data.content = JSON.parse(
+      articlesData.getBasicArticle.data.content
+    );
+  } catch (e) {
+    console.log(slug, 'failed parsing json:', e);
+  }
   return articlesData.getBasicArticle.data;
 }
 
 export async function getHomepageArticles(hpArticleData) {
   let hpArticles = {};
+  // console.log("hpArticleData:", hpArticleData);
+  // console.log("hpArticleData keys:", Object.keys(hpArticleData));
   Object.entries(hpArticleData).map(([key, values]) => {
+    // console.log(" looking for article in section:", key);
     if (typeof values === 'string') {
       console.log('looking up one article:', values);
       let foundArticle;
       (async () => {
         foundArticle = await getArticleBySlug(values);
+        console.log('foundArticle: ', foundArticle);
         hpArticles[key] = foundArticle;
       })();
     } else {
-      console.log('looking up multiple articles:', values);
+      // console.log('looking up multiple articles:', values);
       let foundArticles;
       (async () => {
         foundArticles = await listArticlesBySlug(values);

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -1,0 +1,56 @@
+import { GraphQLClient } from 'graphql-request';
+import _ from 'lodash';
+
+const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
+const CONTENT_DELIVERY_API_ACCESS_TOKEN =
+  process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+const LIST_HOMEPAGE_DATA = `
+{
+  listHomepageLayoutData	{
+    data {
+      id
+      layoutSchema {
+          id
+          name
+			}
+      data
+      createdOn
+      updatedOn
+    }
+  }
+}`;
+
+export async function getHomepageData() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const homepageData = await webinyHeadlessCms.request(LIST_HOMEPAGE_DATA);
+  console.log('all hp data found: ', homepageData);
+
+  // sort by date
+  homepageData.listHomepageLayoutData.data.sort(function (a, b) {
+    var aDate = new Date(a.updatedOn);
+    var bDate = new Date(b.updatedOn);
+    return aDate > bDate;
+  });
+  // let articlesBySection = [];
+  let currentHomepageData = homepageData.listHomepageLayoutData.data[0];
+  let layoutComponentName = _.upperFirst(
+    _.camelCase(currentHomepageData.layoutSchema.name)
+  );
+
+  // parse JSON data
+  let articleConfig = JSON.parse(currentHomepageData.data);
+
+  let homepageSetup = {
+    layoutComponent: layoutComponentName,
+    articles: articleConfig,
+  };
+
+  console.log('homepage setup: ', homepageSetup);
+  return homepageSetup;
+}

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -29,7 +29,6 @@ export async function getHomepageData() {
   });
 
   const homepageData = await webinyHeadlessCms.request(LIST_HOMEPAGE_DATA);
-  console.log('all hp data found: ', homepageData);
 
   // sort by date
   homepageData.listHomepageLayoutData.data.sort(function (a, b) {
@@ -51,6 +50,5 @@ export async function getHomepageData() {
     articles: articleConfig,
   };
 
-  console.log('homepage setup: ', homepageSetup);
   return homepageSetup;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,13 @@
 import _ from 'lodash';
 import Link from 'next/link';
 import { getHomepageData } from '../lib/homepage.js';
-import { listAllArticles } from '../lib/articles.js';
-import { listAllTags } from '../lib/articles.js';
-import { listAllSections } from '../lib/articles.js';
+import {
+  getArticleBySlug,
+  listAllArticles,
+  listAllTags,
+  listAllSections,
+  getHomepageArticles,
+} from '../lib/articles.js';
 import Layout from '../components/Layout.js';
 import ArticleNav from '../components/nav/ArticleNav.js';
 import FeaturedArticleLink from '../components/homepage/FeaturedArticleLink.js';
@@ -24,14 +28,18 @@ const LargePackageStoryLead = dynamic(() =>
 
 export const config = { amp: 'hybrid' };
 
-export default function Home({ hpData, articles, tags, sections }) {
+export default function Home({ hpData, hpArticles, articles, tags, sections }) {
   const isAmp = useAmp();
 
   console.log('hpdata:', hpData);
   return (
     <>
       {hpData.layoutComponent === 'BigFeaturedStory' && (
-        <BigFeaturedStory articles={hpData.articles} />
+        <BigFeaturedStory
+          articles={hpArticles}
+          tags={tags}
+          sections={sections}
+        />
       )}
       {hpData.layoutComponent === 'LargePackageStoryLead' && (
         <LargePackageStoryLead articles={hpData.articles} />
@@ -105,6 +113,8 @@ export async function getStaticProps() {
   //    get selected homepage layout / data
   const hpData = await getHomepageData();
   //    look up selected homepage articles
+  const hpArticles = await getHomepageArticles(hpData.articles);
+  console.log('hpArticles:', hpArticles);
   //    render correct layout components (above)
 
   const articles = await listAllArticles();
@@ -114,6 +124,7 @@ export async function getStaticProps() {
   return {
     props: {
       hpData,
+      hpArticles,
       articles,
       tags,
       sections,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import Link from 'next/link';
+import { getHomepageData } from '../lib/homepage.js';
 import { listAllArticles } from '../lib/articles.js';
 import { listAllTags } from '../lib/articles.js';
 import { listAllSections } from '../lib/articles.js';
@@ -12,10 +13,34 @@ import ArticleFooter from '../components/nav/ArticleFooter.js';
 import { useAmp } from 'next/amp';
 import { siteMetadata } from '../lib/siteMetadata.js';
 
+import dynamic from 'next/dynamic';
+
+const BigFeaturedStory = dynamic(() =>
+  import(`../components/homepage/BigFeaturedStory`)
+);
+const LargePackageStoryLead = dynamic(() =>
+  import(`../components/homepage/LargePackageStoryLead`)
+);
+
 export const config = { amp: 'hybrid' };
 
-export default function Home({ articles, tags, sections }) {
+export default function Home({ hpData, articles, tags, sections }) {
   const isAmp = useAmp();
+
+  console.log('hpdata:', hpData);
+  return (
+    <>
+      {hpData.layoutComponent === 'BigFeaturedStory' && (
+        <BigFeaturedStory articles={hpData.articles} />
+      )}
+      {hpData.layoutComponent === 'LargePackageStoryLead' && (
+        <LargePackageStoryLead articles={hpData.articles} />
+      )}
+    </>
+  );
+
+  // let hpComponent = `<${hpData.layoutComponent} articles=${hpData.articles} />`;
+  // console.log("HP component: ", hpComponent);
 
   siteMetadata.tags = tags;
 
@@ -76,12 +101,19 @@ export default function Home({ articles, tags, sections }) {
 }
 
 export async function getStaticProps() {
+  // to-do:
+  //    get selected homepage layout / data
+  const hpData = await getHomepageData();
+  //    look up selected homepage articles
+  //    render correct layout components (above)
+
   const articles = await listAllArticles();
   const tags = await listAllTags();
   const sections = await listAllSections();
 
   return {
     props: {
+      hpData,
       articles,
       tags,
       sections,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,23 +1,11 @@
 import _ from 'lodash';
-import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { getHomepageData } from '../lib/homepage.js';
 import {
-  getArticleBySlug,
-  listAllArticles,
   listAllTags,
   listAllSections,
   getHomepageArticles,
 } from '../lib/articles.js';
-import Layout from '../components/Layout.js';
-import ArticleNav from '../components/nav/ArticleNav.js';
-import FeaturedArticleLink from '../components/homepage/FeaturedArticleLink.js';
-import ArticleLink from '../components/homepage/ArticleLink.js';
-import ArticleFooter from '../components/nav/ArticleFooter.js';
-// import HomepageSearchPanel from '../components/homepage/HomepageSearchPanel.js'
-import { useAmp } from 'next/amp';
-import { siteMetadata } from '../lib/siteMetadata.js';
-
-import dynamic from 'next/dynamic';
 
 const BigFeaturedStory = dynamic(() =>
   import(`../components/homepage/BigFeaturedStory`)
@@ -26,12 +14,7 @@ const LargePackageStoryLead = dynamic(() =>
   import(`../components/homepage/LargePackageStoryLead`)
 );
 
-export const config = { amp: 'hybrid' };
-
-export default function Home({ hpData, hpArticles, articles, tags, sections }) {
-  const isAmp = useAmp();
-
-  console.log('hpdata:', hpData);
+export default function Home({ hpData, hpArticles, tags, sections }) {
   return (
     <>
       {hpData.layoutComponent === 'BigFeaturedStory' && (
@@ -42,82 +25,23 @@ export default function Home({ hpData, hpArticles, articles, tags, sections }) {
         />
       )}
       {hpData.layoutComponent === 'LargePackageStoryLead' && (
-        <LargePackageStoryLead articles={hpData.articles} />
+        <LargePackageStoryLead
+          articles={hpArticles}
+          tags={tags}
+          sections={sections}
+        />
       )}
     </>
-  );
-
-  // let hpComponent = `<${hpData.layoutComponent} articles=${hpData.articles} />`;
-  // console.log("HP component: ", hpComponent);
-
-  siteMetadata.tags = tags;
-
-  let featuredArticles = articles.slice(0, 1);
-  let unfeaturedArticles = articles.slice(1);
-
-  const tagLinks = tags.map((tag) => (
-    <Link key={tag.title} href={`/tags/${tag.title}`}>
-      <a className="panel-block is-active">{_.startCase(tag.title)}</a>
-    </Link>
-  ));
-
-  return (
-    <div className="homepage">
-      <ArticleNav metadata={siteMetadata} tags={tags} sections={sections} />
-      <Layout meta={siteMetadata}>
-        <section className="hero is-dark is-bold">
-          <div className="hero-body">
-            <div className="container">
-              <h1 className="title">{siteMetadata.homepageTitle}</h1>
-              <h2 className="subtitle">{siteMetadata.homepageSubtitle}</h2>
-            </div>
-          </div>
-        </section>
-        <div className="featured-article">
-          {featuredArticles.map((featuredArticle) => (
-            <FeaturedArticleLink
-              key={featuredArticle.id}
-              article={featuredArticle}
-              amp={isAmp}
-            />
-          ))}
-        </div>
-        <section className="section">
-          <div className="columns">
-            <div className="column is-four-fifths">
-              {unfeaturedArticles.map((unfeaturedArticle) => (
-                <ArticleLink
-                  key={unfeaturedArticle.id}
-                  article={unfeaturedArticle}
-                  amp={isAmp}
-                />
-              ))}
-            </div>
-            <div className="column">
-              {/* <HomepageSearchPanel metadata={siteMetadata} query={query} setQuery={setQuery} /> */}
-              <nav className="panel">
-                <p className="panel-heading">{siteMetadata.labels.topics}</p>
-                {tagLinks}
-              </nav>
-            </div>
-          </div>
-        </section>
-      </Layout>
-      <ArticleFooter post_type="home" metadata={siteMetadata} />
-    </div>
   );
 }
 
 export async function getStaticProps() {
-  // to-do:
   //    get selected homepage layout / data
   const hpData = await getHomepageData();
   //    look up selected homepage articles
   const hpArticles = await getHomepageArticles(hpData.articles);
-  console.log('hpArticles:', hpArticles);
-  //    render correct layout components (above)
+  console.log('found hpArticles keys:', Object.keys(hpArticles));
 
-  const articles = await listAllArticles();
   const tags = await listAllTags();
   const sections = await listAllSections();
 
@@ -125,7 +49,6 @@ export async function getStaticProps() {
     props: {
       hpData,
       hpArticles,
-      articles,
       tags,
       sections,
     },


### PR DESCRIPTION
Issue #81 

This PR uses homepage data from the homepage editor to render the index page of the site. Making this happen required a fair amount of code rewriting for the homepage, in particular:

* instead of listing all articles, the first thing that is requested is the current homepage config with `getHomepageData`
  * this returns info including the selected layout and article slugs
* next, each article included in the homepage data is retrieved
* then all tags & sections
* instead of using a single `page`, the index renders the matching layout; there are two layouts currently supported, each with its own component:
  * BigFeaturedStory
  * LargePackageStoryLead

We can add more layout options by adding more components & updating the homepage editor. We need to actually give some thought to the design of these layouts. I kept it very simple - the right content is rendered in approximately reasonable places.