### PR TITLE
Use referenced authors data in articles

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -13,6 +13,41 @@ import { siteMetadata } from '../lib/siteMetadata.js';
 import Link from 'next/link';
 import Layout from './Layout.js';
 
+const renderAuthor = (author, i) => {
+  if (author.slug !== null) {
+    return (
+      <Link href={`/authors/${author.slug}`} key={`${author.slug}-${index}`}>
+        <a className="is-link">{author.name}</a>
+      </Link>
+    );
+  } else {
+    return (
+      <span className="author" key={author.id}>
+        {author.name}
+      </span>
+    );
+  }
+};
+
+// solution from https://stackoverflow.com/questions/53879088/join-an-array-by-commas-and-and
+const renderAuthors = (authors) => {
+  authors = authors.map(renderAuthor);
+
+  var output = [];
+  authors.forEach(function (author, i) {
+    // if list is more than one item and this is the last item, prefix with 'and '
+    if (authors.length > 1 && i === authors.length - 1) output.push('and ');
+    // output the item
+    output.push(author);
+    // if list is more than 2 items, append a comma to all but the last item
+    if (authors.length > 2 && i < authors.length - 1) output.push(',');
+    // if list is more than 1 item, append a space to all but the last item
+    if (authors.length > 1 && i < authors.length - 1) output.push(' ');
+  });
+
+  return output;
+};
+
 export default function Article({ article, sections, tags }) {
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'
@@ -99,30 +134,9 @@ export default function Article({ article, sections, tags }) {
       </Link>
     ));
   }
-  let authorLinks = null;
+  let authorLinks;
   if (article.authors) {
-    authorLinks = article.authors
-      .map((author, index) => {
-        if (author.slug !== null) {
-          return (
-            <Link
-              href={`/authors/${author.slug}`}
-              key={`${author.slug}-${index}`}
-            >
-              <a className="is-link">{author.name}</a>
-            </Link>
-          );
-        } else {
-          return (
-            <span className="author" key={author.id}>
-              {author.name}
-            </span>
-          );
-        }
-      })
-      .reduce((accu, elem) => {
-        return accu === null ? [elem] : [...accu, ' & ', elem];
-      }, null);
+    authorLinks = renderAuthors(article.authors);
   } else if (article.byline !== undefined) {
     authorLinks = article.byline;
   }

--- a/components/Article.js
+++ b/components/Article.js
@@ -12,41 +12,7 @@ import { parseISO } from 'date-fns';
 import { siteMetadata } from '../lib/siteMetadata.js';
 import Link from 'next/link';
 import Layout from './Layout.js';
-
-const renderAuthor = (author, i) => {
-  if (author.slug !== null) {
-    return (
-      <Link href={`/authors/${author.slug}`} key={`${author.slug}-${index}`}>
-        <a className="is-link">{author.name}</a>
-      </Link>
-    );
-  } else {
-    return (
-      <span className="author" key={author.id}>
-        {author.name}
-      </span>
-    );
-  }
-};
-
-// solution from https://stackoverflow.com/questions/53879088/join-an-array-by-commas-and-and
-const renderAuthors = (authors) => {
-  authors = authors.map(renderAuthor);
-
-  var output = [];
-  authors.forEach(function (author, i) {
-    // if list is more than one item and this is the last item, prefix with 'and '
-    if (authors.length > 1 && i === authors.length - 1) output.push('and ');
-    // output the item
-    output.push(author);
-    // if list is more than 2 items, append a comma to all but the last item
-    if (authors.length > 2 && i < authors.length - 1) output.push(',');
-    // if list is more than 1 item, append a space to all but the last item
-    if (authors.length > 1 && i < authors.length - 1) output.push(' ');
-  });
-
-  return output;
-};
+import { renderAuthors } from '../lib/utils.js';
 
 export default function Article({ article, sections, tags }) {
   const mainImageNode = article.content.find(

--- a/components/Article.js
+++ b/components/Article.js
@@ -99,18 +99,49 @@ export default function Article({ article, sections, tags }) {
       </Link>
     ));
   }
+  let authorLinks = null;
+  if (article.authors) {
+    authorLinks = article.authors
+      .map((author, index) => {
+        if (author.slug !== null) {
+          return (
+            <Link
+              href={`/authors/${author.slug}`}
+              key={`${author.slug}-${index}`}
+            >
+              <a className="is-link">{author.name}</a>
+            </Link>
+          );
+        } else {
+          return (
+            <span className="author" key={author.id}>
+              {author.name}
+            </span>
+          );
+        }
+      })
+      .reduce((accu, elem) => {
+        return accu === null ? [elem] : [...accu, ' & ', elem];
+      }, null);
+  } else if (article.byline !== undefined) {
+    authorLinks = article.byline;
+  }
 
-  var Dateline = require('dateline');
-  let parsedDate = parseISO(article.firstPublishedOn);
-  let firstPublishedOn =
-    Dateline(parsedDate).getAPDate() +
-    ' at ' +
-    Dateline(parsedDate).getAPTime();
-  parsedDate = parseISO(article.lastPublishedOn);
-  let lastPublishedOn =
-    Dateline(parsedDate).getAPDate() +
-    ' at ' +
-    Dateline(parsedDate).getAPTime();
+  let firstPublishedOn = null;
+  let lastPublishedOn = null;
+  if (article.firstPublishedOn !== null) {
+    var Dateline = require('dateline');
+    let parsedDate = parseISO(article.firstPublishedOn);
+    firstPublishedOn =
+      Dateline(parsedDate).getAPDate() +
+      ' at ' +
+      Dateline(parsedDate).getAPTime();
+    parsedDate = parseISO(article.lastPublishedOn);
+    lastPublishedOn =
+      Dateline(parsedDate).getAPDate() +
+      ' at ' +
+      Dateline(parsedDate).getAPTime();
+  }
 
   return (
     <Layout meta={siteMetadata}>
@@ -131,10 +162,11 @@ export default function Article({ article, sections, tags }) {
               </h2>
               <h1 className="title is-size-1">{article.headline}</h1>
               <h2 className="subtitle" key="byline">
-                By {article.byline} | Published {firstPublishedOn}
+                By {authorLinks} |
+                {firstPublishedOn !== null && ` Published ${firstPublishedOn}`}
               </h2>
               <h2 className="subtitle" key="last-updated">
-                Last updated: {lastPublishedOn}
+                {lastPublishedOn !== null && `Last updated: ${lastPublishedOn}`}
               </h2>
             </div>
           </div>

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
 import { parseISO } from 'date-fns';
+import { renderAuthors } from '../../lib/utils.js';
 
 export default function ArticleLink(props) {
+  console.log('ArticleLink props.article.authors:', props.article.authors);
   let mainImage = null;
   let parsedContent = [];
   try {
@@ -27,6 +29,13 @@ export default function ArticleLink(props) {
 
   if (mainImageNode) {
     mainImage = mainImageNode.children[0];
+  }
+
+  let authorLinks;
+  if (props.article.authors) {
+    authorLinks = renderAuthors(props.article.authors);
+  } else if (props.article.byline !== undefined) {
+    authorLinks = props.article.byline;
   }
 
   return (
@@ -59,7 +68,7 @@ export default function ArticleLink(props) {
             </Link>
           </h1>
           <p>{props.article.excerpt}</p>
-          <p>{props.article.byline}</p>
+          <p>{authorLinks}</p>
           {props.article.firstPublishedOn && <p>{firstPublishedOn}</p>}
         </div>
         <nav className="level is-mobile">

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -28,6 +28,7 @@ export default function ArticleLink(props) {
   if (mainImageNode) {
     mainImage = mainImageNode.children[0];
   }
+
   return (
     <article className="media">
       {mainImage && (

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import Link from 'next/link';
 import { parseISO } from 'date-fns';
+import { renderAuthors } from '../../lib/utils.js';
 
 export default function FeaturedArticleLink(props) {
-  // console.log('FeaturedArticleLink props.article:', props.article);
+  console.log(
+    'FeaturedArticleLink props.article.authors:',
+    props.article.authors
+  );
 
   let mainImage = null;
   let mainImageNode = null;
@@ -24,6 +28,14 @@ export default function FeaturedArticleLink(props) {
     Dateline(parsedDate).getAPDate() +
     ' at ' +
     Dateline(parsedDate).getAPTime();
+
+  let authorLinks;
+  if (props.article.authors) {
+    authorLinks = renderAuthors(props.article.authors);
+  } else if (props.article.byline !== undefined) {
+    authorLinks = props.article.byline;
+  }
+
   return (
     <article>
       {mainImage && (
@@ -53,7 +65,7 @@ export default function FeaturedArticleLink(props) {
           </Link>
         </h1>
         <p className="featured">{props.article.excerpt}</p>
-        <p className="featured">{props.article.byline}</p>
+        <p className="featured">{authorLinks}</p>
         {props.article.firstPublishedOn && <p>{firstPublishedOn}</p>}
       </div>
       <nav className="level is-mobile">

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -16,6 +16,9 @@ const LIST_ARTICLES = `
         }
         headline
         byline
+        authors {
+          name
+        }
         content
         firstPublishedOn
         lastPublishedOn
@@ -35,6 +38,10 @@ const LIST_ARTICLES_BY_SLUG = `
         id
         headline
         byline
+        slug
+        authors {
+          name
+        }
         content
         tags {
           title
@@ -327,6 +334,10 @@ const GET_ARTICLE_BY_SLUG = `
       data {
         id
         slug
+        authors {
+          name
+          slug
+        }
         category {
           title
           slug

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -17,7 +17,9 @@ const LIST_ARTICLES = `
         headline
         byline
         authors {
+          id
           name
+          slug
         }
         content
         firstPublishedOn
@@ -40,7 +42,9 @@ const LIST_ARTICLES_BY_SLUG = `
         byline
         slug
         authors {
+          id
           name
+          slug
         }
         content
         tags {
@@ -315,6 +319,11 @@ const GET_ARTICLE = `
         tags {
           title
         }
+        authors {
+          id
+          name
+          slug
+        }
         firstPublishedOn
         lastPublishedOn
         searchTitle
@@ -335,6 +344,7 @@ const GET_ARTICLE_BY_SLUG = `
         id
         slug
         authors {
+          id
           name
           slug
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+export const renderAuthor = (author, i) => {
+  if (author.slug !== null && author.slug !== undefined) {
+    return (
+      <Link href={`/authors/${author.slug}`} key={`${author.slug}-${i}`}>
+        <a className="is-link">{author.name}</a>
+      </Link>
+    );
+  } else {
+    return (
+      <span className="author" key={author.id}>
+        {author.name}
+      </span>
+    );
+  }
+};
+
+// solution that works with react elements from https://codepen.io/pascalpp/pen/MKRwjP
+export const renderAuthors = (authors) => {
+  authors = authors.map(renderAuthor);
+
+  var output = [];
+  authors.forEach(function (author, i) {
+    // if list is more than one item and this is the last item, prefix with 'and '
+    if (authors.length > 1 && i === authors.length - 1) output.push('and ');
+    // output the item
+    output.push(author);
+    // if list is more than 2 items, append a comma to all but the last item
+    if (authors.length > 2 && i < authors.length - 1) output.push(',');
+    // if list is more than 1 item, append a space to all but the last item
+    if (authors.length > 1 && i < authors.length - 1) output.push(' ');
+  });
+
+  return output;
+};


### PR DESCRIPTION
I've added support for a list of authors to the article page (related to issue #86):

* if article has authors, map / reduce them to a list of names separated by ampersand (what do we want to do with the list, in reality?)
* if each author has a slug, use it to link to an authors page (note: this doesn't exist yet)
* otherwise, if the byline field has content, use that instead 
