### PR TITLE
Feature/author pages

### DIFF
--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAmp } from 'next/amp';
 import { siteMetadata } from '../../lib/siteMetadata.js';
 import Layout from '../Layout.js';
@@ -18,6 +18,14 @@ export default function BigFeaturedStory(props) {
   );
 
   const isAmp = useAmp();
+
+  // I noticed that `streamArticles` were null or undefined on occasional page loads
+  // using this hook seems to fix the load order issue; the useState calls could probably
+  // default to `useState(null)` but I figured I'd leave them as-is.
+  useEffect(() => {
+    setFeaturedArticle(props.articles['featured']);
+    setStreamArticles(props.articles['stream']);
+  }, [props.articles]);
 
   const tagLinks = props.tags.map((tag) => (
     <Link key={tag.title} href={`/tags/${tag.slug}`}>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -66,6 +66,38 @@ const LIST_ARTICLES_BY_SLUG = `
     }
   }`;
 
+const LIST_ARTICLES_BY_AUTHOR = `
+  query listBasicArticles($where: BasicArticleListWhereInput) {
+    content: listBasicArticles(where: $where) {
+      data {
+        id
+        headline
+        byline
+        slug
+        authors {
+          id
+          name
+          slug
+        }
+        tags {
+          title
+        }
+        category {
+          slug
+          title
+        }
+        firstPublishedOn
+        lastPublishedOn
+        searchTitle
+        searchDescription
+        facebookTitle
+        facebookDescription
+        twitterTitle
+        twitterDescription
+      }
+    }
+}`;
+
 const LIST_IDS = `
 {
   listBasicArticles {
@@ -99,6 +131,17 @@ const LIST_SECTIONS = `
 }
 `;
 
+const LIST_AUTHORS = `
+{
+  listAuthors {
+    data {
+      name
+      slug
+    }
+  }
+}
+`;
+
 const LIST_TAGS = `
 {
   listTags {
@@ -109,6 +152,21 @@ const LIST_TAGS = `
   }
 }
 `;
+
+const GET_AUTHOR_BY_SLUG = `query getAuthor($slug: String) {
+  content: getAuthor(where: {slug: $slug}) {
+    data {
+      id
+      slug
+      name
+      title
+      twitter 
+      bio
+      staff
+      photoUrl
+    }
+  }
+}`;
 
 export async function listAllSections() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
@@ -157,6 +215,25 @@ export async function listAllArticlesBySection(section) {
     }
   });
   return articlesBySection;
+}
+
+export async function listAllAuthorPaths() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const authorData = await webinyHeadlessCms.request(LIST_AUTHORS);
+
+  const slugs = authorData.listAuthors.data.map((author) => {
+    return {
+      params: {
+        slug: author.slug,
+      },
+    };
+  });
+  return slugs;
 }
 
 export async function listAllTagPaths() {
@@ -269,6 +346,25 @@ export async function listAllArticlesByTag(tag) {
     }
   });
   return articlesByTag;
+}
+
+export async function listAllArticlesByAuthor(authorSlug) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const variables = {
+    where: {
+      byline_contains: authorSlug,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES_BY_AUTHOR,
+    variables
+  );
+  return articlesData.content.data;
 }
 
 export async function listAllArticleIds() {
@@ -461,4 +557,20 @@ export async function getTagBySlug(slug, apiUrl) {
     slug,
   });
   return tagsData.getTag.data;
+}
+
+export async function getAuthorBySlug(slug, apiUrl) {
+  if (apiUrl === undefined) {
+    apiUrl = CONTENT_DELIVERY_API_URL;
+  }
+  const webinyHeadlessCms = new GraphQLClient(apiUrl, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const authorData = await webinyHeadlessCms.request(GET_AUTHOR_BY_SLUG, {
+    slug,
+  });
+  return authorData.content.data;
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -16,6 +16,7 @@ const LIST_ARTICLES = `
         }
         headline
         byline
+        authorSlugs
         authors {
           id
           name
@@ -41,6 +42,7 @@ const LIST_ARTICLES_BY_SLUG = `
         headline
         byline
         slug
+        authorSlugs
         authors {
           id
           name
@@ -74,6 +76,7 @@ const LIST_ARTICLES_BY_AUTHOR = `
         headline
         byline
         slug
+        authorSlugs
         authors {
           id
           name
@@ -357,7 +360,7 @@ export async function listAllArticlesByAuthor(authorSlug) {
 
   const variables = {
     where: {
-      byline_contains: authorSlug,
+      authorSlugs_contains: authorSlug,
     },
   };
   const articlesData = await webinyHeadlessCms.request(
@@ -415,6 +418,7 @@ const GET_ARTICLE = `
         tags {
           title
         }
+        authorSlugs
         authors {
           id
           name
@@ -439,6 +443,7 @@ const GET_ARTICLE_BY_SLUG = `
       data {
         id
         slug
+        authorSlugs
         authors {
           id
           name

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -1,0 +1,53 @@
+import Layout from '../../components/Layout.js';
+import ArticleLink from '../../components/homepage/ArticleLink.js';
+import {
+  listAllArticlesByAuthor,
+  listAllSections,
+  listAllAuthorPaths,
+  getAuthorBySlug,
+} from '../../lib/articles.js';
+import { siteMetadata } from '../../lib/siteMetadata.js';
+import ArticleNav from '../../components/nav/ArticleNav.js';
+import ArticleFooter from '../../components/nav/ArticleFooter.js';
+import { useAmp } from 'next/amp';
+
+export default function AuthorPage(props) {
+  const isAmp = useAmp();
+  return (
+    <Layout meta={siteMetadata}>
+      <ArticleNav metadata={siteMetadata} sections={props.sections} />
+      <section className="section">
+        <h1 className="title">Articles by {props.author.name}</h1>
+        <div className="columns">
+          <div className="column is-four-fifths">
+            {props.articles.map((article) => (
+              <ArticleLink key={article.id} article={article} amp={isAmp} />
+            ))}
+          </div>
+        </div>
+      </section>
+      <ArticleFooter metadata={siteMetadata} />
+    </Layout>
+  );
+}
+
+export async function getStaticPaths() {
+  const paths = await listAllAuthorPaths();
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const articles = await listAllArticlesByAuthor(params.slug);
+  const sections = await listAllSections();
+  const author = await getAuthorBySlug(params.slug);
+  return {
+    props: {
+      articles,
+      author,
+      sections,
+    },
+  };
+}


### PR DESCRIPTION
This PR builds on all the other author-related work (sidebar, frontend, webiny) to add author pages to the app.

* `/authors/{slug}`
* uses the byline field to search by slug for articles by the author

Example:

<img width="803" alt="Screen Shot 2020-09-01 at 2 15 25 pm" src="https://user-images.githubusercontent.com/3397/91794420-57a91080-ec5e-11ea-8a98-a098a673bd63.png">

To see this in action for all authors, we'll have to:

* finalise & merge the changes to the add-on
* publish the add-on
* republish all articles
* review the front-end, author pages 🤞 should display properly, and they should be linked from any `ArticleLink`,  `FeaturedArticleLink`, or article page.