### PR TITLE
Implement news tagging guide

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -128,7 +128,7 @@ export default function Article({ article, sections, tags }) {
       trackEvent({
         action: '25%',
         category: 'NTG article milestone',
-        label: article.title,
+        label: article.headline,
         value: 25,
         non_interaction: true,
       });
@@ -139,7 +139,7 @@ export default function Article({ article, sections, tags }) {
       trackEvent({
         action: '50%',
         category: 'NTG article milestone',
-        label: article.title,
+        label: article.headline,
         value: 50,
         non_interaction: true,
       });
@@ -150,7 +150,7 @@ export default function Article({ article, sections, tags }) {
       trackEvent({
         action: '75%',
         category: 'NTG article milestone',
-        label: article.title,
+        label: article.headline,
         value: 75,
         non_interaction: true,
       });
@@ -161,7 +161,7 @@ export default function Article({ article, sections, tags }) {
       trackEvent({
         action: '100%',
         category: 'NTG article milestone',
-        label: article.title,
+        label: article.headline,
         value: 100,
         non_interaction: true,
       });
@@ -232,7 +232,7 @@ export default function Article({ article, sections, tags }) {
           <h1 className="title media-left">
             {siteMetadata.subscribe.subtitle}
           </h1>
-          <MailchimpSubscribe />
+          <MailchimpSubscribe articleTitle={article.headline} />
           <div className="comments">
             {isAmp ? (
               <div>Coral AMP</div>

--- a/components/Article.js
+++ b/components/Article.js
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import ArticleNav from './nav/ArticleNav.js';
 import ArticleFooter from './nav/ArticleFooter.js';
 import Coral from './plugins/Coral.js';
@@ -12,6 +13,8 @@ import { parseISO } from 'date-fns';
 import { siteMetadata } from '../lib/siteMetadata.js';
 import Link from 'next/link';
 import Layout from './Layout.js';
+import { useAnalytics } from '../lib/hooks/useAnalytics.js';
+import { useScrollPercentage } from 'react-scroll-percentage';
 
 export default function Article({ article, sections, tags }) {
   const mainImageNode = article.content.find(
@@ -112,6 +115,60 @@ export default function Article({ article, sections, tags }) {
     ' at ' +
     Dateline(parsedDate).getAPTime();
 
+  const { trackEvent } = useAnalytics();
+
+  const [ref, percentage] = useScrollPercentage();
+  const [oneQuarterReached, setOneQuarterReached] = useState(false);
+  const [oneHalfReached, setOneHalfReached] = useState(false);
+  const [threeQuartersReached, setThreeQuarterSReached] = useState(false);
+  const [fullReached, setFullReached] = useState(false);
+
+  useEffect(() => {
+    if (!oneQuarterReached && percentage >= 0.25) {
+      trackEvent({
+        action: '25%',
+        category: 'NTG article milestone',
+        label: article.title,
+        value: 25,
+        non_interaction: true,
+      });
+      setOneQuarterReached(true);
+    }
+
+    if (!oneHalfReached && percentage >= 0.5) {
+      trackEvent({
+        action: '50%',
+        category: 'NTG article milestone',
+        label: article.title,
+        value: 50,
+        non_interaction: true,
+      });
+      setOneHalfReached(true);
+    }
+
+    if (!threeQuartersReached && percentage >= 0.75) {
+      trackEvent({
+        action: '75%',
+        category: 'NTG article milestone',
+        label: article.title,
+        value: 75,
+        non_interaction: true,
+      });
+      setThreeQuarterSReached(true);
+    }
+
+    if (!fullReached && percentage >= 1) {
+      trackEvent({
+        action: '100%',
+        category: 'NTG article milestone',
+        label: article.title,
+        value: 100,
+        non_interaction: true,
+      });
+      setFullReached(true);
+    }
+  }, [percentage]);
+
   return (
     <Layout meta={siteMetadata}>
       <ArticleNav metadata={siteMetadata} sections={sections} />
@@ -156,7 +213,7 @@ export default function Article({ article, sections, tags }) {
             className="image"
           />
         )}
-        <section className="section" key="body">
+        <section className="section" key="body" ref={ref}>
           <div id="articleText" className="content">
             {serializedBody}
           </div>

--- a/components/plugins/MailchimpSubscribe.js
+++ b/components/plugins/MailchimpSubscribe.js
@@ -56,7 +56,7 @@ const CustomForm = ({ status, message, onValidated }) => {
   );
 };
 
-const Newsletter = () => {
+const Newsletter = ({ articleTitle }) => {
   const { trackEvent } = useAnalytics();
   const [ref, inView] = useInView({ triggerOnce: true });
   useEffect(() => {
@@ -64,7 +64,7 @@ const Newsletter = () => {
       trackEvent({
         action: 'newsletter modal impression 1',
         category: 'NTG newsletter',
-        label: 'article title',
+        label: articleTitle,
         non_interaction: true,
       });
     }

--- a/components/plugins/MailchimpSubscribe.js
+++ b/components/plugins/MailchimpSubscribe.js
@@ -1,8 +1,82 @@
 import MailchimpSubscribe from 'react-mailchimp-subscribe';
+import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
 
 // you can get this url from the embed code form action
 const url = process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL;
 
-const Newsletter = () => <MailchimpSubscribe url={url} />;
+const CustomForm = ({ status, message, onValidated }) => {
+  let email, name;
+  const submit = () =>
+    email &&
+    name &&
+    email.value.indexOf('@') > -1 &&
+    onValidated({
+      EMAIL: email.value,
+      NAME: name.value,
+    });
+
+  return (
+    <div
+      style={{
+        background: '#efefef',
+        borderRadius: 2,
+        padding: 10,
+        display: 'inline-block',
+      }}
+    >
+      {status === 'sending' && <div style={{ color: 'blue' }}>sending...</div>}
+      {status === 'error' && (
+        <div
+          style={{ color: 'red' }}
+          dangerouslySetInnerHTML={{ __html: message }}
+        />
+      )}
+      {status === 'success' && (
+        <div
+          style={{ color: 'green' }}
+          dangerouslySetInnerHTML={{ __html: message }}
+        />
+      )}
+      <input
+        ref={(node) => (name = node)}
+        type="text"
+        placeholder="Your name"
+      />
+      <br />
+      <input
+        ref={(node) => (email = node)}
+        type="email"
+        placeholder="Your email"
+      />
+      <br />
+      <button onClick={submit}>Submit</button>
+    </div>
+  );
+};
+
+const Newsletter = () => {
+  const { trackEvent } = useAnalytics();
+
+  return (
+    <MailchimpSubscribe
+      url={url}
+      render={({ subscribe, status, message }) => (
+        <CustomForm
+          status={status}
+          message={message}
+          onValidated={(formData) => {
+            subscribe(formData);
+            trackEvent({
+              action: 'newsletter signup',
+              category: 'NTG newsletter',
+              label: 'success',
+              non_interaction: false,
+            });
+          }}
+        />
+      )}
+    />
+  );
+};
 
 export default Newsletter;

--- a/components/plugins/MailchimpSubscribe.js
+++ b/components/plugins/MailchimpSubscribe.js
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import MailchimpSubscribe from 'react-mailchimp-subscribe';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
+import { useInView } from 'react-intersection-observer';
 
 // you can get this url from the embed code form action
 const url = process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL;
@@ -56,26 +58,39 @@ const CustomForm = ({ status, message, onValidated }) => {
 
 const Newsletter = () => {
   const { trackEvent } = useAnalytics();
+  const [ref, inView] = useInView({ triggerOnce: true });
+  useEffect(() => {
+    if (inView) {
+      trackEvent({
+        action: 'newsletter modal impression 1',
+        category: 'NTG newsletter',
+        label: 'article title',
+        non_interaction: true,
+      });
+    }
+  }, [inView]);
 
   return (
-    <MailchimpSubscribe
-      url={url}
-      render={({ subscribe, status, message }) => (
-        <CustomForm
-          status={status}
-          message={message}
-          onValidated={(formData) => {
-            subscribe(formData);
-            trackEvent({
-              action: 'newsletter signup',
-              category: 'NTG newsletter',
-              label: 'success',
-              non_interaction: false,
-            });
-          }}
-        />
-      )}
-    />
+    <div ref={ref}>
+      <MailchimpSubscribe
+        url={url}
+        render={({ subscribe, status, message }) => (
+          <CustomForm
+            status={status}
+            message={message}
+            onValidated={(formData) => {
+              subscribe(formData);
+              trackEvent({
+                action: 'newsletter signup',
+                category: 'NTG newsletter',
+                label: 'success',
+                non_interaction: false,
+              });
+            }}
+          />
+        )}
+      />
+    </div>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-intersection-observer": "^8.27.1",
     "react-mailchimp-subscribe": "^2.1.0",
     "react-player": "^2.5.0",
+    "react-scroll-percentage": "^4.2.0",
     "react-twitter-embed": "^3.0.3",
     "sass": "^1.26.9",
     "web-vitals": "^0.2.3"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-ga": "^3.1.2",
+    "react-intersection-observer": "^8.27.1",
     "react-mailchimp-subscribe": "^2.1.0",
     "react-player": "^2.5.0",
     "react-twitter-embed": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4986,6 +4986,13 @@ react-ga@^3.1.2:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.1.2.tgz#e13f211c51a2e5c401ea69cf094b9501fe3c51ce"
   integrity sha512-OJrMqaHEHbodm+XsnjA6ISBEHTwvpFrxco65mctzl/v3CASMSLSyUkFqz9yYrPDKGBUfNQzKCjuMJwctjlWBbw==
 
+react-intersection-observer@^8.27.1:
+  version "8.27.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.27.1.tgz#c641bf7594a0c06c1947ef1368812cb870c4bcfd"
+  integrity sha512-s70LKz+hm8wQY/4pvGVWs/gAfiLPlivyZiiUU1JdWDZj7vN8jbHYzJ8H1HWGvWpcudRg7g7kBWUUbcRjlloD0Q==
+  dependencies:
+    tiny-invariant "^1.1.0"
+
 react-is@16.13.1, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5887,6 +5894,11 @@ timers-browserify@^2.0.4:
   integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tiny-warning@^1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,7 +1006,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.8.4":
+"@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -4986,7 +4986,7 @@ react-ga@^3.1.2:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.1.2.tgz#e13f211c51a2e5c401ea69cf094b9501fe3c51ce"
   integrity sha512-OJrMqaHEHbodm+XsnjA6ISBEHTwvpFrxco65mctzl/v3CASMSLSyUkFqz9yYrPDKGBUfNQzKCjuMJwctjlWBbw==
 
-react-intersection-observer@^8.27.1:
+react-intersection-observer@^8.25.1, react-intersection-observer@^8.27.1:
   version "8.27.1"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.27.1.tgz#c641bf7594a0c06c1947ef1368812cb870c4bcfd"
   integrity sha512-s70LKz+hm8wQY/4pvGVWs/gAfiLPlivyZiiUU1JdWDZj7vN8jbHYzJ8H1HWGvWpcudRg7g7kBWUUbcRjlloD0Q==
@@ -5027,6 +5027,14 @@ react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-scroll-percentage@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-scroll-percentage/-/react-scroll-percentage-4.2.0.tgz#5f1b815b18c4959ee540c037eca142f0a00ad436"
+  integrity sha512-mJgX+YCRcEzX8jDkAm8pv+gfBFJFO+t8tIANOGcEjFfGFhLTNWs9OJakC4laL5LZXyImohFE5N30XLaA2Ng95g==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    react-intersection-observer "^8.25.1"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
So far, I've implemented Google's events for newsletter signup and for scroll depth. We'll want to do comments if we can hook into any Coral callbacks, and reader revenue once that's available to us. For now, I think we can merge this in as a start, pending review from @jacqui.