### PR TITLE
About page

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -139,7 +139,9 @@ const LIST_AUTHORS = `
 {
   listAuthors {
     data {
+      bio
       name
+      title
       slug
     }
   }
@@ -640,4 +642,16 @@ export async function getPage(slug) {
     console.log(slug, 'failed parsing json:', e);
   }
   return data.getPage.data;
+}
+
+export async function listAuthors() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const authorsData = await webinyHeadlessCms.request(LIST_AUTHORS);
+
+  return authorsData.listAuthors.data;
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -456,6 +456,25 @@ const GET_ARTICLE = `
   }
 `;
 
+const GET_PAGE_BY_SLUG = `
+  query Page($slug: String) {
+    getPage(where: {slug: $slug}) {
+      data {
+        id
+        slug
+        headline
+        content
+        searchTitle
+        searchDescription
+        facebookTitle
+        facebookDescription
+        twitterTitle
+        twitterDescription
+      }
+    }
+  }
+`;
+
 const GET_ARTICLE_BY_SLUG = `
   query Article($slug: String) {
     getBasicArticle(where: {slug: $slug}) {
@@ -597,4 +616,28 @@ export async function getAuthorBySlug(slug, apiUrl) {
     slug,
   });
   return authorData.content.data;
+}
+
+//MOVE TO lib/static.js?
+export async function getAboutPage() {
+  const data = getPage('about');
+  return data;
+}
+
+export async function getPage(slug) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const data = await webinyHeadlessCms.request(GET_PAGE_BY_SLUG, {
+    slug,
+  });
+  try {
+    data.getPage.data.content = JSON.parse(data.getPage.data.content);
+  } catch (e) {
+    console.log(slug, 'failed parsing json:', e);
+  }
+  return data.getPage.data;
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,11 +1,11 @@
 import { useAmp } from 'next/amp';
-import { getAboutPage, listAllSections } from '../lib/articles.js';
+import { getAboutPage, listAuthors, listAllSections } from '../lib/articles.js';
 import Layout from '../components/Layout';
 import GlobalNav from '../components/nav/GlobalNav';
 import GlobalFooter from '../components/nav/GlobalFooter';
 import { renderBody } from '../lib/utils.js';
 
-export default function About({ data, sections }) {
+export default function About({ data, authors, sections }) {
   const isAmp = useAmp();
   const body = renderBody(data, isAmp);
   return (
@@ -17,6 +17,19 @@ export default function About({ data, sections }) {
             {body}
           </div>
         </section>
+        <section className="section" key="authors">
+          <div className="content">
+            <h1 className="title">Authors</h1>
+            {authors.map((author) => (
+              <div className="author mb-4">
+                <h4 className="subtitle is-4">
+                  {author.name}, {author.title}
+                </h4>
+                <p className="content is-medium">{author.bio}</p>
+              </div>
+            ))}
+          </div>
+        </section>
       </article>
       <GlobalFooter />
     </Layout>
@@ -26,12 +39,13 @@ export default function About({ data, sections }) {
 export async function getStaticProps() {
   //    get about page contents
   const data = await getAboutPage();
-
+  const authors = await listAuthors();
   const sections = await listAllSections();
 
   return {
     props: {
       data,
+      authors,
       sections,
     },
   };

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,38 @@
+import { useAmp } from 'next/amp';
+import { getAboutPage, listAllSections } from '../lib/articles.js';
+import Layout from '../components/Layout';
+import GlobalNav from '../components/nav/GlobalNav';
+import GlobalFooter from '../components/nav/GlobalFooter';
+import { renderBody } from '../lib/utils.js';
+
+export default function About({ data, sections }) {
+  const isAmp = useAmp();
+  const body = renderBody(data, isAmp);
+  return (
+    <Layout meta={data}>
+      <GlobalNav sections={sections} />
+      <article>
+        <section className="section" key="body">
+          <div id="articleText" className="content">
+            {body}
+          </div>
+        </section>
+      </article>
+      <GlobalFooter />
+    </Layout>
+  );
+}
+
+export async function getStaticProps() {
+  //    get about page contents
+  const data = await getAboutPage();
+
+  const sections = await listAllSections();
+
+  return {
+    props: {
+      data,
+      sections,
+    },
+  };
+}

--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -1,0 +1,35 @@
+import { getArticleBySlug } from '../../lib/articles.js';
+
+export default async (req, res) => {
+  // Check the secret and next parameters
+  // This secret should only be known to this API route and the CMS
+  if (req.query.secret !== process.env.PREVIEW_TOKEN || !req.query.slug) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Fetch the headless CMS to check if the provided `slug` exists
+  const article = await getArticleBySlug(req.query.slug);
+
+  // If the slug doesn't exist prevent preview mode from being enabled
+  if (!article) {
+    return res.status(401).json({ message: 'Invalid slug' });
+  }
+
+  // Enable Preview Mode by setting the cookies
+  res.setPreviewData({});
+
+  // Redirect to the path from the fetched post
+  // We don't redirect to req.query.slug as that might lead to open redirect vulnerabilities
+
+  // BUG: this line of code taken from the nextjs docs doesn't work - throws a typeerror: res.redirect is not a function (??)
+  // (https://nextjs.org/docs/advanced-features/preview-mode)
+  // res.redirect(article.slug)
+
+  const articlePath = '/preview/' + article.category.slug + '/' + article.slug;
+
+  // this approach to the redirect does work
+  res.writeHead(301, {
+    Location: articlePath,
+  });
+  res.end();
+};

--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -1,4 +1,4 @@
-import { getArticleBySlug } from '../../lib/articles.js';
+import { getAboutPage } from '../../lib/articles.js';
 
 export default async (req, res) => {
   // Check the secret and next parameters
@@ -7,12 +7,15 @@ export default async (req, res) => {
     return res.status(401).json({ message: 'Invalid token' });
   }
 
-  // Fetch the headless CMS to check if the provided `slug` exists
-  const article = await getArticleBySlug(req.query.slug);
+  if (req.query.slug === 'about') {
+    // Fetch the headless CMS to check if the about page data exists
+    // TODO: generalise for all static pages?
+    const aboutData = await getAboutPage();
 
-  // If the slug doesn't exist prevent preview mode from being enabled
-  if (!article) {
-    return res.status(401).json({ message: 'Invalid slug' });
+    // If the above request fails prevent preview mode from being enabled
+    if (!aboutData) {
+      return res.status(401).json({ message: 'Invalid slug' });
+    }
   }
 
   // Enable Preview Mode by setting the cookies
@@ -25,11 +28,11 @@ export default async (req, res) => {
   // (https://nextjs.org/docs/advanced-features/preview-mode)
   // res.redirect(article.slug)
 
-  const articlePath = '/preview/' + article.category.slug + '/' + article.slug;
+  const nextPath = '/' + req.query.slug;
 
   // this approach to the redirect does work
   res.writeHead(301, {
-    Location: articlePath,
+    Location: nextPath,
   });
   res.end();
 };


### PR DESCRIPTION
This PR addresses 2 issues:

* Issue #109  - adds a template for the about page along with lookup functions for any static page (by slug) and a specific one for about page data
* Issue #103  - adds a preview route that's maybe 50% done for any static page, but definitely works for the about page; I can't make a general preview route without a general static page route/template

I think we'll probably need a general static page route & template, but until that's an actual use case, I tried to generalise as much as I could reasonably while making a solution for this particular `/about` page.