### PR TITLE
Simplify homepage components, most recent articles auto list

### DIFF
--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -5,8 +5,6 @@ import { renderDate, renderAuthors } from '../../lib/utils.js';
 export default function ArticleLink({ article, isAmp }) {
   let mainImage = null;
 
-  console.log(article);
-
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'
   );

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -1,84 +1,34 @@
-import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
-import { useAmp } from 'next/amp';
-import { siteMetadata } from '../../lib/siteMetadata.js';
-import Layout from '../Layout.js';
 import FeaturedArticleLink from './FeaturedArticleLink.js';
-import ArticleLink from './ArticleLink.js';
-import GlobalNav from '../nav/GlobalNav.js';
-import GlobalFooter from '../nav/GlobalFooter.js';
 import FeaturedSidebar from './FeaturedSidebar.js';
 
 export default function BigFeaturedStory(props) {
   const [featuredArticle, setFeaturedArticle] = useState(
     props.articles['featured']
   );
-  const [streamArticles, setStreamArticles] = useState(
-    props.articles['stream']
-  );
 
-  const isAmp = useAmp();
-
-  // I noticed that `streamArticles` were null or undefined on occasional page loads
-  // using this hook seems to fix the load order issue; the useState calls could probably
-  // default to `useState(null)` but I figured I'd leave them as-is.
   useEffect(() => {
     setFeaturedArticle(props.articles['featured']);
-    setStreamArticles(props.articles['stream']);
   }, [props.articles]);
 
-  const tagLinks = props.tags.map((tag) => (
-    <Link key={tag.title} href={`/tags/${tag.slug}`}>
-      <a className="panel-block is-active">{tag.title}</a>
-    </Link>
-  ));
-
   return (
-    <div className="homepage">
-      <Layout meta={siteMetadata}>
-        <GlobalNav
-          metadata={siteMetadata}
-          tags={props.tags}
-          sections={props.sections}
-        />
-        <div className="featured-article">
-          <div className="columns">
-            <div className="column is-two-thirds">
-              {featuredArticle && (
-                <FeaturedArticleLink
-                  key={featuredArticle.id}
-                  article={featuredArticle}
-                  amp={isAmp}
-                />
-              )}
-            </div>
-            <div className="column is-one-third">
-              <FeaturedSidebar />
-            </div>
+    <>
+      <div className="featured-article">
+        <div className="columns">
+          <div className="column is-two-thirds">
+            {featuredArticle && (
+              <FeaturedArticleLink
+                key={featuredArticle.id}
+                article={featuredArticle}
+                amp={props.isAmp}
+              />
+            )}
+          </div>
+          <div className="column is-one-third">
+            <FeaturedSidebar />
           </div>
         </div>
-        <section className="section">
-          <div className="columns">
-            <div className="column is-three-quarters">
-              {streamArticles &&
-                streamArticles.map((streamArticle) => (
-                  <ArticleLink
-                    key={streamArticle.id}
-                    article={streamArticle}
-                    amp={isAmp}
-                  />
-                ))}
-            </div>
-            <div className="column">
-              <nav className="panel">
-                <p className="panel-heading">{siteMetadata.labels.topics}</p>
-                {tagLinks}
-              </nav>
-            </div>
-          </div>
-        </section>
-      </Layout>
-      <GlobalFooter post_type="home" />
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -1,13 +1,8 @@
 import _ from 'lodash';
-import Link from 'next/link';
 import React, { useState } from 'react';
 import { useAmp } from 'next/amp';
-import { siteMetadata } from '../../lib/siteMetadata.js';
-import Layout from '../Layout.js';
-import GlobalNav from '../nav/GlobalNav.js';
 import FeaturedArticleLink from './FeaturedArticleLink.js';
 import ArticleCard from './ArticleCard.js';
-import GlobalFooter from '../nav/GlobalFooter.js';
 
 export const config = { amp: 'hybrid' };
 
@@ -28,65 +23,48 @@ export default function LargePackageStoryLead(props) {
     props.articles['subfeatured-right']
   );
 
-  const tagLinks = props.tags.map((tag) => (
-    <Link key={tag.title} href={`/tags/${tag.title}`}>
-      <a className="panel-block is-active">{_.startCase(tag.title)}</a>
-    </Link>
-  ));
   return (
-    <div className="homepage">
-      <GlobalNav sections={props.sections} />
-      <Layout meta={siteMetadata}>
-        <section className="hero is-dark is-bold">
-          <div className="hero-body">
-            <div className="container">
-              <h1 className="title">{siteMetadata.homepageTitle}</h1>
-              <h2 className="subtitle">{siteMetadata.homepageSubtitle}</h2>
-            </div>
+    <>
+      <div className="featured-article">
+        {featuredArticle && (
+          <FeaturedArticleLink
+            key={featuredArticle.id}
+            article={featuredArticle}
+            amp={isAmp}
+          />
+        )}
+      </div>
+      <section className="section">
+        <div className="columns">
+          <div className="column is-one-third">
+            {subfeaturedLeftArticle && (
+              <ArticleCard
+                key={subfeaturedLeftArticle.id}
+                article={subfeaturedLeftArticle}
+                amp={isAmp}
+              />
+            )}
           </div>
-        </section>
-        <div className="featured-article">
-          {featuredArticle && (
-            <FeaturedArticleLink
-              key={featuredArticle.id}
-              article={featuredArticle}
-              amp={isAmp}
-            />
-          )}
+          <div className="column is-one-third">
+            {subfeaturedMiddleArticle && (
+              <ArticleCard
+                key={subfeaturedMiddleArticle.id}
+                article={subfeaturedMiddleArticle}
+                amp={isAmp}
+              />
+            )}
+          </div>
+          <div className="column is-one-third">
+            {subfeaturedRightArticle && (
+              <ArticleCard
+                key={subfeaturedRightArticle.id}
+                article={subfeaturedRightArticle}
+                amp={isAmp}
+              />
+            )}
+          </div>
         </div>
-        <section className="section">
-          <div className="columns">
-            <div className="column is-one-third">
-              {subfeaturedLeftArticle && (
-                <ArticleCard
-                  key={subfeaturedLeftArticle.id}
-                  article={subfeaturedLeftArticle}
-                  amp={isAmp}
-                />
-              )}
-            </div>
-            <div className="column is-one-third">
-              {subfeaturedMiddleArticle && (
-                <ArticleCard
-                  key={subfeaturedMiddleArticle.id}
-                  article={subfeaturedMiddleArticle}
-                  amp={isAmp}
-                />
-              )}
-            </div>
-            <div className="column is-one-third">
-              {subfeaturedRightArticle && (
-                <ArticleCard
-                  key={subfeaturedRightArticle.id}
-                  article={subfeaturedRightArticle}
-                  amp={isAmp}
-                />
-              )}
-            </div>
-          </div>
-        </section>
-      </Layout>
-      <GlobalFooter post_type="home" />
-    </div>
+      </section>
+    </>
   );
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -34,6 +34,40 @@ const LIST_ARTICLES = `
   }
 `;
 
+const LIST_ARTICLES_REVERSE_CHRON = `
+  query listBasicArticles {
+    content: listBasicArticles(sort: lastPublishedOn_DESC) {
+      data {
+        id
+        headline 
+        byline
+        slug
+        authorSlugs
+        authors {
+          id
+          name
+          slug
+        }
+        content
+        tags {
+          title
+        }
+        category {
+          slug
+          title
+        }
+        firstPublishedOn
+        lastPublishedOn
+        searchTitle
+        searchDescription
+        facebookTitle
+        facebookDescription
+        twitterTitle
+        twitterDescription
+      } 
+    }
+  }`;
+
 const LIST_ARTICLES_BY_SLUG = `
   query listBasicArticles($where: BasicArticleListWhereInput) {
     content: listBasicArticles(where: $where) {
@@ -302,6 +336,22 @@ export async function listAllArticles() {
   return articlesData.listBasicArticles.data;
 }
 
+export async function listMostRecentArticles() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES_REVERSE_CHRON
+  );
+  articlesData.content.data.map((article) => {
+    article.content = JSON.parse(article.content);
+  });
+  return articlesData.content.data;
+}
+
 export async function listArticlesBySlug(slugs) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -553,20 +603,14 @@ export async function getArticleBySlug(slug, apiUrl) {
 
 export async function getHomepageArticles(hpArticleData) {
   let hpArticles = {};
-  console.log('hpArticleData keys:', Object.keys(hpArticleData));
-  console.log('hpArticleData:', hpArticleData);
   Object.entries(hpArticleData).map(([key, values]) => {
-    // console.log(" looking for article in section:", key);
     if (typeof values === 'string') {
-      console.log('looking up one article:', values);
       let foundArticle;
       (async () => {
         foundArticle = await getArticleBySlug(values);
-        console.log('foundArticle: ', foundArticle);
         hpArticles[key] = foundArticle;
       })();
     } else {
-      // console.log('looking up multiple articles:', values);
       let foundArticles;
       (async () => {
         foundArticles = await listArticlesBySlug(values);
@@ -574,6 +618,7 @@ export async function getHomepageArticles(hpArticleData) {
       })();
     }
   });
+
   return hpArticles;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,10 @@ export const renderAuthors = (article) => {
     return article.byline;
   }
 
+  if (!article.authors) {
+    return;
+  }
+
   const authors = article.authors.map(renderAuthor);
 
   var output = [];
@@ -48,11 +52,19 @@ export const renderAuthors = (article) => {
 
 export const renderDate = (isoDate, renderTime = true) => {
   const parsed = new Date(isoDate);
-  if (renderTime) {
-    return `${apdate(parsed)} at ${aptime(parsed)}`;
-  } else {
-    return apdate(parsed);
+
+  let renderedDate;
+
+  try {
+    if (renderTime) {
+      renderedDate = `${apdate(parsed)} at ${aptime(parsed)}`;
+    } else {
+      renderedDate = `${apdate(parsed)}`;
+    }
+  } catch (e) {
+    console.log(e);
   }
+  return renderedDate;
 };
 
 export const renderBody = (article, isAmp) => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,18 @@
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { getHomepageData } from '../lib/homepage.js';
+import { useAmp } from 'next/amp';
 import {
   listAllTags,
   listAllSections,
+  listMostRecentArticles,
   getHomepageArticles,
 } from '../lib/articles.js';
+import Layout from '../components/Layout';
+import { siteMetadata } from '../lib/siteMetadata.js';
+import GlobalNav from '../components/nav/GlobalNav';
+import GlobalFooter from '../components/nav/GlobalFooter';
+import ArticleLink from '../components/homepage/ArticleLink';
 
 const BigFeaturedStory = dynamic(() =>
   import(`../components/homepage/BigFeaturedStory`)
@@ -13,24 +21,65 @@ const LargePackageStoryLead = dynamic(() =>
   import(`../components/homepage/LargePackageStoryLead`)
 );
 
-export default function Home({ hpData, hpArticles, tags, sections }) {
+export default function Home({
+  hpData,
+  hpArticles,
+  streamArticles,
+  tags,
+  sections,
+}) {
+  const isAmp = useAmp();
+  const tagLinks = tags.map((tag) => (
+    <Link key={tag.title} href={`/tags/${tag.slug}`}>
+      <a className="panel-block is-active">{tag.title}</a>
+    </Link>
+  ));
+
+  console.log('streamArticles:', streamArticles);
+
   return (
-    <>
-      {hpData.layoutComponent === 'BigFeaturedStory' && (
-        <BigFeaturedStory
-          articles={hpArticles}
-          tags={tags}
-          sections={sections}
-        />
-      )}
-      {hpData.layoutComponent === 'LargePackageStoryLead' && (
-        <LargePackageStoryLead
-          articles={hpArticles}
-          tags={tags}
-          sections={sections}
-        />
-      )}
-    </>
+    <div className="homepage">
+      <Layout meta={siteMetadata}>
+        <GlobalNav metadata={siteMetadata} tags={tags} sections={sections} />
+        {hpData.layoutComponent === 'BigFeaturedStory' && (
+          <BigFeaturedStory
+            articles={hpArticles}
+            tags={tags}
+            sections={sections}
+            isAmp={isAmp}
+          />
+        )}
+        {hpData.layoutComponent === 'LargePackageStoryLead' && (
+          <LargePackageStoryLead
+            articles={hpArticles}
+            tags={tags}
+            sections={sections}
+            isAmp={isAmp}
+          />
+        )}
+        <section className="section">
+          <div className="columns">
+            <div className="column is-three-quarters">
+              {streamArticles &&
+                streamArticles.map((streamArticle) => (
+                  <ArticleLink
+                    key={streamArticle.id}
+                    article={streamArticle}
+                    amp={isAmp}
+                  />
+                ))}
+            </div>
+            <div className="column">
+              <nav className="panel">
+                <p className="panel-heading">{siteMetadata.labels.topics}</p>
+                {tagLinks}
+              </nav>
+            </div>
+          </div>
+        </section>
+        <GlobalFooter post_type="home" />
+      </Layout>
+    </div>
   );
 }
 
@@ -39,7 +88,8 @@ export async function getStaticProps() {
   const hpData = await getHomepageData();
   //    look up selected homepage articles
   const hpArticles = await getHomepageArticles(hpData.articles);
-  console.log('found hpArticles keys:', Object.keys(hpArticles));
+
+  const streamArticles = await listMostRecentArticles();
 
   const tags = await listAllTags();
   const sections = await listAllSections();
@@ -48,6 +98,7 @@ export async function getStaticProps() {
     props: {
       hpData,
       hpArticles,
+      streamArticles,
       tags,
       sections,
     },

--- a/pages/index.js
+++ b/pages/index.js
@@ -35,7 +35,14 @@ export default function Home({
     </Link>
   ));
 
-  console.log('streamArticles:', streamArticles);
+  const featuredArticleIds = Object.values(hpArticles).map(
+    (article) => article.id
+  );
+  console.log(featuredArticleIds);
+  const mostRecentArticles = streamArticles.filter(
+    (streamArticle) => !featuredArticleIds.includes(streamArticle.id)
+  );
+  console.log('streamArticles:', mostRecentArticles);
 
   return (
     <div className="homepage">
@@ -60,8 +67,8 @@ export default function Home({
         <section className="section">
           <div className="columns">
             <div className="column is-three-quarters">
-              {streamArticles &&
-                streamArticles.map((streamArticle) => (
+              {mostRecentArticles &&
+                mostRecentArticles.map((streamArticle) => (
                   <ArticleLink
                     key={streamArticle.id}
                     article={streamArticle}


### PR DESCRIPTION
Issue #108 

_Ready for review:_

- [x] gql list articles sorted by last published time descending
- [x] remove common elements from homepage layout components (global nav/footer, layout, etc)
- [x] request most recent articles from homepage getStaticProps
- [x] display most recent articles in layout below custom featured areas
- [x] ensure most recent articles do not include featured articles
