### PR TITLE
Cache sections and tags to streamline build process

### DIFF
--- a/components/homepage/ArticleCard.js
+++ b/components/homepage/ArticleCard.js
@@ -3,8 +3,6 @@ import Link from 'next/link';
 import { renderAuthors, renderDate } from '../../lib/utils.js';
 
 export default function ArticleCard({ article, isAmp }) {
-  console.log('ArticleCard article:', article);
-
   let mainImage = null;
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -17,11 +17,7 @@ export default function LargePackageStoryLead(props) {
     props.setSubFeaturedLeftArticle(props.articles['subfeatured-left']);
     props.setSubFeaturedRightArticle(props.articles['subfeatured-right']);
     props.setSubFeaturedMiddleArticle(props.articles['subfeatured-middle']);
-
-    console.log('useEffect props:', props);
   }, [props.articles]);
-
-  console.log('LPSL props:', props);
 
   return (
     <>

--- a/components/nodes/EmbedNode.js
+++ b/components/nodes/EmbedNode.js
@@ -21,7 +21,6 @@ export default function EmbedNode({ node, amp }) {
       break;
     case 'youtube.com':
       const videoId = url.searchParams.get('v');
-      console.log(url.searchParams.get('v'));
       el = amp ? (
         <amp-youtube
           layout="responsive"

--- a/components/tinycms/ModalArticleSearch.js
+++ b/components/tinycms/ModalArticleSearch.js
@@ -6,8 +6,6 @@ export default function ModalArticleSearch(props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
 
-  console.log('ModalArticleSearch props:', props);
-
   function selectArticle(article) {
     console.log(
       'changing featured article from:',
@@ -23,13 +21,11 @@ export default function ModalArticleSearch(props) {
     event.preventDefault();
     setLoading(true);
 
-    console.log('handling search...', event);
     const results = await searchArticles(
       props.apiUrl,
       props.apiToken,
       searchTerm
     );
-    console.log('results: ', results);
     setLoading(false);
     setSearchResults(results);
   }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -210,6 +210,7 @@ const GET_AUTHOR_BY_SLUG = `query getAuthor($slug: String) {
 }`;
 
 export async function listAllSections() {
+  console.log('listing all sections from API...');
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
@@ -791,7 +792,6 @@ export async function searchArticles(url, token, term) {
     article.slug = rawData.slug.value;
     article.authorSlugs = rawData.authorSlugs.value;
     article.content = JSON.parse(rawData.content.value);
-    console.log(article);
     articles.push(article);
   });
 

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -125,10 +125,7 @@ export async function createAuthor(
   bio,
   staff
 ) {
-  console.log('apiUrl:', apiUrl);
-
   let staffBool = false;
-  console.log('staff: ', staff);
   if (staff === 'yes') {
     staffBool = true;
   }
@@ -177,7 +174,6 @@ export async function createAuthor(
     },
   };
 
-  console.log('variables:', JSON.stringify(variables));
   const webinyHeadlessCms = new GraphQLClient(apiUrl, {
     headers: {
       authorization: apiToken,
@@ -260,7 +256,6 @@ export async function updateAuthor(
     },
   };
 
-  console.log('variables:', JSON.stringify(variables));
   const webinyHeadlessCms = new GraphQLClient(apiUrl, {
     headers: {
       authorization: apiToken,

--- a/lib/cached.js
+++ b/lib/cached.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+export async function cachedContents(name, cb) {
+  const cachedFile = path.join(process.cwd(), 'cached', `${name}.json`);
+  console.log('cachedContents file:', cachedFile);
+  let data;
+  try {
+    const fileContents = fs.readFileSync(cachedFile, 'utf8');
+    data = JSON.parse(fileContents);
+    console.log('cachedContents READ sections from file:', data);
+  } catch (e) {
+    console.log('cachedContents ERROR:', e);
+    data = await cb();
+    fs.writeFile(cachedFile, JSON.stringify(data), (err) => {
+      if (err) throw err;
+      console.log('cachedContents The file has been saved!');
+    });
+  }
+  return data;
+}

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -43,16 +43,13 @@ export async function getHomepageData() {
   });
   // let articlesBySection = [];
   let currentHomepageData = homepageData.listHomepageLayoutData.data[0];
-  console.log('currentHomepageData:', currentHomepageData);
   let layoutComponentName = _.upperFirst(
     _.camelCase(currentHomepageData.layoutSchema.name)
   );
   let layoutSchemaId = currentHomepageData.layoutSchema.id;
-  console.log('layoutSchemaId:', layoutSchemaId);
 
   // parse JSON data
   let articleConfig = JSON.parse(currentHomepageData.data);
-  console.log('articleConfig:', articleConfig);
 
   let homepageSetup = {
     layoutSchemaId: layoutSchemaId, // TODO get rid of this
@@ -139,7 +136,6 @@ export async function createHomepageLayout(url, token, layoutId, data) {
     CREATE_LAYOUT,
     variables
   );
-  console.log('responseData: ', responseData);
 
   return responseData;
 }

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import Layout from '../components/Layout.js';
 import ArticleLink from '../components/homepage/ArticleLink.js';
+import { cachedContents } from '../lib/cached';
 import {
   listAllArticlesBySection,
   listAllSectionTitles,
@@ -43,8 +44,8 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const articles = await listAllArticlesBySection(params.category);
-  const sections = await listAllSections();
-  const tags = await listAllTags();
+  const sections = await cachedContents('sections', listAllSections);
+  const tags = await cachedContents('tags', listAllTags);
   let title;
 
   for (var i = 0; i < sections.length; i++) {

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,5 +1,6 @@
 import { useAmp } from 'next/amp';
 import { getAboutPage, listAuthors, listAllSections } from '../lib/articles.js';
+import { cachedContents } from '../lib/cached';
 import Layout from '../components/Layout';
 import GlobalNav from '../components/nav/GlobalNav';
 import GlobalFooter from '../components/nav/GlobalFooter';
@@ -40,8 +41,7 @@ export async function getStaticProps() {
   //    get about page contents
   const data = await getAboutPage();
   const authors = await listAuthors();
-  const sections = await listAllSections();
-
+  const sections = await cachedContents('sections', listAllSections);
   return {
     props: {
       data,

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -4,6 +4,7 @@ import {
   listAllSections,
   listAllTags,
 } from '../../../lib/articles.js';
+import { cachedContents } from '../../../lib/cached';
 import { useRouter } from 'next/router';
 import Article from '../../../components/Article.js';
 
@@ -32,8 +33,8 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const article = await getArticleBySlug(params.slug);
-  const sections = await listAllSections();
-  const tags = await listAllTags();
+  const tags = await cachedContents('tags', listAllTags);
+  const sections = await cachedContents('sections', listAllSections);
 
   return {
     props: {

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -6,6 +6,7 @@ import {
   listAllAuthorPaths,
   getAuthorBySlug,
 } from '../../lib/articles.js';
+import { cachedContents } from '../../lib/cached';
 import { siteMetadata } from '../../lib/siteMetadata.js';
 import GlobalNav from '../../components/nav/GlobalNav.js';
 import GlobalFooter from '../../components/nav/GlobalFooter.js';
@@ -41,7 +42,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const articles = await listAllArticlesByAuthor(params.slug);
-  const sections = await listAllSections();
+  const sections = await cachedContents('sections', listAllSections);
   const author = await getAuthorBySlug(params.slug);
   return {
     props: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { getHomepageData } from '../lib/homepage.js';
 import { useAmp } from 'next/amp';
+import { cachedContents } from '../lib/cached';
 import {
   listAllTags,
   listAllSections,
@@ -40,11 +41,9 @@ export default function Home({
   const featuredArticleIds = Object.values(hpArticles).map(
     (article) => article.id
   );
-  console.log(featuredArticleIds);
   const mostRecentArticles = streamArticles.filter(
     (streamArticle) => !featuredArticleIds.includes(streamArticle.id)
   );
-  console.log('streamArticles:', mostRecentArticles);
 
   return (
     <div className="homepage">
@@ -102,8 +101,8 @@ export async function getStaticProps() {
 
   const streamArticles = await listMostRecentArticles();
 
-  const tags = await listAllTags();
-  const sections = await listAllSections();
+  const tags = await cachedContents('tags', listAllTags);
+  const sections = await cachedContents('sections', listAllSections);
 
   return {
     props: {

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -4,6 +4,7 @@ import {
   listAllSections,
   listAllTags,
 } from '../../../lib/articles.js';
+import { cachedContents } from '../../../lib/cached';
 import Article from '../../../components/Article.js';
 
 export default function PreviewArticle(props) {
@@ -23,8 +24,8 @@ export async function getStaticProps({ params }) {
     params.slug,
     process.env.PREVIEW_API_URL
   );
-  const sections = await listAllSections();
-  const tags = await listAllTags();
+  const sections = await cachedContents('sections', listAllSections);
+  const tags = await cachedContents('tags', listAllTags);
   return {
     props: {
       article,

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -6,6 +6,7 @@ import {
   listAllTagPaths,
   getTagBySlug,
 } from '../../lib/articles.js';
+import { cachedContents } from '../../lib/cached';
 import { siteMetadata } from '../../lib/siteMetadata.js';
 import GlobalNav from '../../components/nav/GlobalNav.js';
 import GlobalFooter from '../../components/nav/GlobalFooter.js';
@@ -41,7 +42,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   const articles = await listAllArticlesByTag(params.slug);
-  const sections = await listAllSections();
+  const sections = await cachedContents('sections', listAllSections);
   const tag = await getTagBySlug(params.slug);
   return {
     props: {


### PR DESCRIPTION
Issue #124 

I did a bunch of reading on how to speed up the nextjs build process and came up with a solution that seems to cut quite a bit of time.

For sections and tags:

* try to load a JSON file from `cached/`
* if it doesn't exist, make the API call and write the contents as JSON to the file path
* if it does exist, use the data from the file

The build went from taking over 250 seconds for me to around 120 seconds. I've left the regular API implementation of tags & sections on the `tinycms/homepage` editor. 

Unfortunately I don't see what other data we could cache this way - but if you think of any, I'm happy to extend this and save more time!