### PR TITLE
Fixes bug that caused blank homepage data to be saved

### DIFF
--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -15,7 +15,7 @@ export default function BigFeaturedStory(props) {
       <div className="featured-article">
         <div className="columns">
           <div className="column is-two-thirds">
-            {props.editable && props.featuredArticle && (
+            {props.editable && (
               <>
                 <ModalArticleSearch
                   apiUrl={props.apiUrl}

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -603,23 +603,40 @@ export async function getArticleBySlug(slug, apiUrl) {
   return articlesData.getBasicArticle.data;
 }
 
-export async function getHomepageArticles(hpArticleData) {
+export async function getHomepageArticles(hpData) {
   let hpArticles = {};
-  Object.entries(hpArticleData).map(([key, values]) => {
-    if (typeof values === 'string') {
-      let foundArticle;
-      (async () => {
-        foundArticle = await getArticleBySlug(values);
-        hpArticles[key] = foundArticle;
-      })();
-    } else {
-      let foundArticles;
-      (async () => {
-        foundArticles = await listArticlesBySlug(values);
-        hpArticles[key] = foundArticles;
-      })();
-    }
-  });
+  let hpArticleData = hpData.articles;
+
+  // if for some reason the homepage layout data is blank, fall back to
+  // the layout schema which at least has the structure defined
+  // this is used in the tinynews homepage editor
+  if (hpArticleData === undefined || hpArticleData === null) {
+    let articleConfig = JSON.parse(hpData.layoutSchema.data);
+    Object.entries(articleConfig).map(([key, value]) => {
+      if (value === 'string') {
+        hpArticles[key] = null;
+      } else {
+        hpArticles[key] = [];
+      }
+    });
+  }
+  if (hpArticleData !== undefined && hpArticleData !== null) {
+    Object.entries(hpArticleData).map(([key, values]) => {
+      if (typeof values === 'string') {
+        let foundArticle;
+        (async () => {
+          foundArticle = await getArticleBySlug(values);
+          hpArticles[key] = foundArticle;
+        })();
+      } else {
+        let foundArticles;
+        (async () => {
+          foundArticles = await listArticlesBySlug(values);
+          hpArticles[key] = foundArticles;
+        })();
+      }
+    });
+  }
 
   return hpArticles;
 }

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -18,6 +18,7 @@ const LIST_HOMEPAGE_DATA = `
       layoutSchema {
           id
           name
+          data
 			}
       data
       createdOn

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,7 +79,7 @@ export async function getStaticProps() {
   //    get selected homepage layout / data
   const hpData = await getHomepageData();
   //    look up selected homepage articles
-  const hpArticles = await getHomepageArticles(hpData.articles);
+  const hpArticles = await getHomepageArticles(hpData);
 
   const streamArticles = await listMostRecentArticles();
 

--- a/pages/tinycms/homepage.js
+++ b/pages/tinycms/homepage.js
@@ -64,17 +64,15 @@ export default function HomePageEditor({
       'saving homepage...',
       selectedLayout,
       'featuredArticle:',
-      featuredArticle,
-      'subfeaturedLeft:',
-      subFeaturedLeftArticle
+      featuredArticle
     );
 
     let articlesData;
-    if (selectedLayout.name.value === 'Big Featured Story') {
+    if (selectedLayout.name === 'Big Featured Story') {
       articlesData = {
         featured: featuredArticle.slug,
       };
-    } else if (selectedLayout.name.value === 'Large Package Story lead') {
+    } else if (selectedLayout.name === 'Large Package Story lead') {
       articlesData = {
         featured: featuredArticle.slug,
         'subfeatured-left': subFeaturedLeftArticle.slug,
@@ -183,7 +181,7 @@ export async function getStaticProps() {
   const hpData = await getHomepageData();
 
   //    look up selected homepage articles
-  const hpArticles = await getHomepageArticles(hpData.articles);
+  const hpArticles = await getHomepageArticles(hpData);
 
   const tags = await listAllTags();
   const sections = await listAllSections();


### PR DESCRIPTION
Issue #131 

As I mentioned on Slack, this blank hp data issue was due to switching between the admin/manage and public/read-only APIs, which annoyingly have slightly different data structures. 

I was checking which layout was being used, `selectedLayout.name` vs `selectedLayout.name.value` was the issue. 

While fixing this, though, I've made it so that even if the homepage article data section is blank, the "change featured article" button will still show up, allowing you to edit the homepage.

_(honest to-do: make sure the buttons still appear on the large pkg story layout as well if this bug reappears)_