### PR TITLE
List, add, and edit authors using new API

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -3,7 +3,6 @@ import { GraphQLClient } from 'graphql-request';
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
-const LOCALE_ID = '5efce70db7dd5900074c4b73'; //TODO add to .env
 
 const LIST_ARTICLES = `
   {
@@ -161,10 +160,18 @@ const LIST_SLUGS = `
 
 const LIST_SECTIONS = `
 {
-  listCategories {
-  	data {
-      title
-      slug
+  categories {
+    listCategories {
+      data {
+        id
+        slug
+        title {
+          values {
+            value
+            locale
+          }
+        }
+      }
     }
   }
 }
@@ -230,14 +237,17 @@ export async function listAllSectionTitles() {
   });
 
   const sectionsData = await webinyHeadlessCms.request(LIST_SECTIONS);
+  console.log(sectionsData);
 
-  const sections = sectionsData.listCategories.data.map((section) => {
-    return {
-      params: {
-        category: section.slug,
-      },
-    };
-  });
+  const sections = sectionsData.categories.listCategories.data.map(
+    (section) => {
+      return {
+        params: {
+          category: section.slug,
+        },
+      };
+    }
+  );
   return sections;
 }
 

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -62,9 +62,9 @@ const UPDATE_AUTHOR = `mutation UpdateAuthor($id: ID!, $data: AuthorInput!) {
   }
 }`;
 
-const GET_AUTHOR = `{
+const GET_AUTHOR = `query GetAuthor($id: ID!) {
   authors {
-    getAuthor(id: "5f7cf853a0357c0008a6a0e8") {
+    getAuthor(id: $id) {
       data {
         id
         name
@@ -78,11 +78,11 @@ const GET_AUTHOR = `{
                   value
                 }
         }
+        staff
         photoUrl
         twitter
         slug
         published
-        staff
       }
       error  {
         			code

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -1,118 +1,124 @@
 import { GraphQLClient } from 'graphql-request';
 
-const CONTENT_DELIVERY_API_URL = process.env.ADMIN_CONTENT_DELIVERY_API_URL;
+const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
-  process.env.NEXT_PUBLIC_ADMIN_CONTENT_DELIVERY_API_ACCESS_TOKEN;
+  process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
 const LOCALE_ID = '5efce70db7dd5900074c4b73'; //TODO add to .env
 
 const LIST_AUTHORS = `
-  {
+{
+  authors {
     listAuthors {
       data {
         id
-        name {
-          value
-        }
-        title {
-          value
-        }
+        name
         bio {
-          value
+          values {
+            value
+          }
         }
-        twitter {
-          value
+        twitter
+        photoUrl
+        title {
+          values {
+            value
+          }
         }
-        photoUrl {
-          value
-        }
-        staff {
-          value
-        }
+        staff
       }
     }
   }
+}
 `;
 
-const UPDATE_AUTHOR = `mutation CreateAuthorFrom($revision: ID!, $data: AuthorInput) {
-  content: createAuthorFrom(revision: $revision, data: $data) {
-    data {
-      id
-      savedOn
-      meta {
-        published
-        version
-        locked
-        parent
-        status
+const UPDATE_AUTHOR = `mutation UpdateAuthor($id: ID!, $data: AuthorInput!) {
+  authors {
+      updateAuthor(id: $id, data: $data) {
+          data {
+            id
+            name
+            bio {
+              values {
+                value
+              }
+            }
+            title {
+              values {
+                value
+              }
+            }
+            photoUrl
+            twitter
+            slug
+            published
+            staff
+          }
+          error  {
+            code
+            message
+            data
+          }
       }
-    }
-    error {
-      message
-      code
-      data
-    }
   }
 }`;
 
-const GET_AUTHOR = `query Author($id: ID!) {
-  getAuthor(where: {id: $id}) {
-    data {
-      id
-      name {
-        value
+const GET_AUTHOR = `{
+  authors {
+    getAuthor(id: "5f7cf853a0357c0008a6a0e8") {
+      data {
+        id
+        name
+        bio {
+                values {
+                  value
+                }
+        }
+        title {
+                values {
+                  value
+                }
+        }
+        photoUrl
+        twitter
+        slug
+        published
+        staff
       }
-      title {
-        value
-      }
-      twitter {
-        value
-      }
-      bio {
-        value
-      }
-      staff {
-        value
-      }
-    }
-  }
+      error  {
+        			code
+        			message
+        			data
+    	}
+   }
+ }
 }`;
 
 const CREATE_AUTHOR = `mutation CreateAuthor($data: AuthorInput!) {
-      content: createAuthor(data: $data) {
-        data {
-          id
-          savedOn
-          meta {
-            published
-            version
-            locked
-            parent
-            status
+  authors {
+      createAuthor(data: $data) {
+          data {
+            id
+            name
+            bio {
+              values {
+                value
+              }
+            }
+            title {
+              values {
+                value
+              }
+            }
+            photoUrl
+            twitter
+            slug
           }
-        }
-        error {
-          message
-          code
-          data
-        }
+          error  {
+            code
+            message
+            data
+          }
       }
-    }`;
-
-const PUBLISH_AUTHOR = `mutation PublishAuthor($revision: ID!) {
-  content: publishAuthor(revision: $revision) {
-    data {
-      id
-      meta {
-        publishedOn
-      	published
-    	}
-    }
-
-    error {
-      message
-      code
-      data
-    }
   }
 }`;
 
@@ -131,14 +137,7 @@ export async function createAuthor(
   }
   const variables = {
     data: {
-      name: {
-        values: [
-          {
-            locale: LOCALE_ID,
-            value: name,
-          },
-        ],
-      },
+      name: name,
       title: {
         values: [
           {
@@ -155,22 +154,8 @@ export async function createAuthor(
           },
         ],
       },
-      twitter: {
-        values: [
-          {
-            locale: LOCALE_ID,
-            value: twitter,
-          },
-        ],
-      },
-      staff: {
-        values: [
-          {
-            locale: LOCALE_ID,
-            value: staffBool,
-          },
-        ],
-      },
+      twitter: twitter,
+      staff: staffBool,
     },
   };
 
@@ -193,7 +178,8 @@ export async function getAuthor(id) {
   });
 
   const authorData = await webinyHeadlessCms.request(GET_AUTHOR, { id });
-  return authorData.getAuthor.data;
+  console.log(authorData.authors.getAuthor.data);
+  return authorData.authors.getAuthor.data;
 }
 
 export async function updateAuthor(
@@ -211,16 +197,9 @@ export async function updateAuthor(
     staffBool = true;
   }
   const variables = {
-    revision: authorId,
+    id: authorId,
     data: {
-      name: {
-        values: [
-          {
-            value: name,
-            locale: LOCALE_ID,
-          },
-        ],
-      },
+      name: name,
       title: {
         values: [
           {
@@ -237,22 +216,9 @@ export async function updateAuthor(
           },
         ],
       },
-      twitter: {
-        values: [
-          {
-            value: twitter,
-            locale: LOCALE_ID,
-          },
-        ],
-      },
-      staff: {
-        values: [
-          {
-            locale: LOCALE_ID,
-            value: staffBool,
-          },
-        ],
-      },
+      twitter: twitter,
+      staff: staffBool,
+      published: true,
     },
   };
 
@@ -276,7 +242,7 @@ export async function listAllAuthors() {
 
   const data = await webinyHeadlessCms.request(LIST_AUTHORS);
 
-  return data.listAuthors.data;
+  return data.authors.listAuthors.data;
 }
 
 export async function listAllAuthorIds() {
@@ -287,7 +253,7 @@ export async function listAllAuthorIds() {
   });
 
   const data = await webinyHeadlessCms.request(LIST_AUTHORS);
-  const authorIds = data.listAuthors.data.map((author) => {
+  const authorIds = data.authors.listAuthors.data.map((author) => {
     return {
       params: {
         id: author.id,
@@ -295,21 +261,4 @@ export async function listAllAuthorIds() {
     };
   });
   return authorIds;
-}
-
-export async function publishAuthor(url, token, authorId) {
-  const webinyHeadlessCms = new GraphQLClient(url, {
-    headers: {
-      authorization: token,
-    },
-  });
-
-  const variables = {
-    revision: authorId,
-  };
-  const responseData = await webinyHeadlessCms.request(
-    PUBLISH_AUTHOR,
-    variables
-  );
-  return responseData;
 }

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -5,7 +5,6 @@ import {
   getAuthor,
   listAllAuthorIds,
   updateAuthor,
-  publishAuthor,
 } from '../../../lib/authors';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
@@ -25,17 +24,18 @@ export default function EditAuthor({ apiUrl, apiToken, author }) {
 
   useEffect(() => {
     if (author) {
-      setName(author.name.value);
-      setTitle(author.title.value);
-      setTwitter(author.twitter.value);
-      setBio(author.bio.value);
+      setName(author.name);
+      setTitle(author.title.values[0].value);
+      setTwitter(author.twitter);
+      setBio(author.bio.values[0].value);
       setAuthorId(author.id);
-      if (author.staff.value) {
+      if (author.staff) {
         setStaffYesNo('yes');
+        setStaff(true);
       } else {
         setStaffYesNo('no');
+        setStaff(false);
       }
-      setStaff(author.staff.value);
     }
   }, []);
   const router = useRouter();
@@ -68,19 +68,12 @@ export default function EditAuthor({ apiUrl, apiToken, author }) {
       staff
     );
 
-    if (response.content.error !== null) {
-      setNotificationMessage(response.content.error);
+    if (response.authors.updateAuthor.error !== null) {
+      setNotificationMessage(response.authors.updateAuthor.error);
       setNotificationType('error');
       setShowNotification(true);
     } else {
-      setAuthorId(response.content.data.id);
-      // publish author
-      const publishResponse = await publishAuthor(
-        apiUrl,
-        apiToken,
-        response.content.data.id
-      );
-
+      setAuthorId(response.authors.updateAuthor.data.id);
       // display success message
       setNotificationMessage('Successfully saved and published the author!');
       setNotificationType('success');

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
-import { createAuthor, publishAuthor } from '../../../lib/authors';
+import { createAuthor } from '../../../lib/authors';
 
 export default function AddAuthor({ apiUrl, apiToken }) {
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -29,18 +29,12 @@ export default function AddAuthor({ apiUrl, apiToken }) {
       bio,
       staff
     );
-    if (response.content.error !== null) {
-      setNotificationMessage(response.content.error);
+
+    if (response.authors.createAuthor.error !== null) {
+      setNotificationMessage(response.authors.createAuthor.error);
       setNotificationType('error');
       setShowNotification(true);
     } else {
-      // publish author
-      const publishResponse = await publishAuthor(
-        apiUrl,
-        apiToken,
-        response.content.data.id
-      );
-
       // display success message
       setNotificationMessage('Successfully saved and published the author!');
       setNotificationType('success');
@@ -150,7 +144,7 @@ export default function AddAuthor({ apiUrl, apiToken }) {
 
           <div className="field is-grouped">
             <div className="control">
-              <button className="button is-link">Submit</button>
+              <input type="submit" className="button is-link" value="Submit" />
             </div>
             <div className="control">
               <button className="button is-link is-light">Cancel</button>
@@ -162,8 +156,8 @@ export default function AddAuthor({ apiUrl, apiToken }) {
   );
 }
 export async function getStaticProps() {
-  const apiUrl = process.env.ADMIN_CONTENT_DELIVERY_API_URL;
-  const apiToken = process.env.ADMIN_CONTENT_DELIVERY_API_ACCESS_TOKEN;
+  const apiUrl = process.env.CONTENT_DELIVERY_API_URL;
+  const apiToken = process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
   return {
     props: {
       apiUrl: apiUrl,

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -25,7 +25,7 @@ export default function Authors({ authors }) {
       <li key={author.id}>
         <Link key={`${author.id}-link`} href={`/tinycms/authors/${author.id}`}>
           <a>
-            {author.name.value}, {author.title.value}
+            {author.name}, {author.title.values[0].value}
           </a>
         </Link>
       </li>


### PR DESCRIPTION
This updates the authors bit of the tinycms to use the new scripted API.

The only major change is that we no longer need a separate "publish" step - authors are either created or updated with the `published` flag set to true.

Previously, the extra call to publish happened automatically - you hit submit, the create or update request happened, then another request immediately to publish - so I didn't see this as a feature change. @TylerFisher we may want to discuss if we want changes made to authors in the tinycms to go live immediately or not.