### PR TITLE
Author names now link to author pages from article page

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -10,9 +10,6 @@ import Layout from './Layout.js';
 
 export default function Article({ article, sections, tags }) {
   const isAmp = useAmp();
-  console.log('all tags: ', tags);
-  console.log('article tags: ', article.tags);
-  console.log('article: ', article);
 
   return (
     <Layout meta={article}>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -751,6 +751,7 @@ query SearchArticles($where: ArticleListWhere) {
         authors {
           id
           name
+          slug
         }
         authorSlugs
       }


### PR DESCRIPTION
issue #141  - I had accidentally omitted the author `slug` in the `GET_ARTICLE_BY_SLUG` query. The name is now linked from the article page, wherever `renderAuthors` is called.