### PR TITLE
Link to authors in lists; fixed section link in lists

### DIFF
--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -43,7 +43,10 @@ export default function ArticleLink({ article, isAmp }) {
             <h6 className="is-6">
               {article.category && (
                 <span className="category">
-                  <Link href="/[slug]" as={article.category.slug}>
+                  <Link
+                    key={article.category.title.values[0].value}
+                    href={`/${article.category.slug}`}
+                  >
                     <a>{article.category.title.values[0].value}</a>
                   </Link>
                 </span>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -45,6 +45,7 @@ const LIST_ARTICLES = `
       authors {
         id
         name
+        slug
       }
       authorSlugs
     }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -94,6 +94,7 @@ const LIST_ARTICLES_REVERSE_CHRON = `
       authors {
         id
         name
+        slug
       }
       authorSlugs
     }


### PR DESCRIPTION
Issue #144 

* authors are now linked on tag and section list pages (not on author pages; seemed redundant)
* bugfix on section links on those list pages (was: `/tag/health` or `/authors/health`)