### PR TITLE
Basic i18n routing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 Clear out any old cache files, rebuild the cache and run the development server:
 
 ```bash
-yarn clear && yarn populate && yarn start
+yarn clear && yarn populate && yarn dev
+```
+
+To build the site and serve from the static files:
+
+```bash
+yarn clear && yarn populate && yarn build && yarn start
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser.

--- a/next.config.js
+++ b/next.config.js
@@ -5,4 +5,8 @@ module.exports = {
       'wherebyspace.nyc3.digitaloceanspaces.com',
     ],
   },
+  i18n: {
+    locales: ['en-US', 'es'],
+    defaultLocale: 'en-US'
+  }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { getHomepageData } from '../lib/homepage.js';
 import { useAmp } from 'next/amp';
+import { useRouter } from 'next/router';
 import { cachedContents } from '../lib/cached';
 import {
   listAllSections,
@@ -42,6 +43,13 @@ export default function Home({ hpData, hpArticles, streamArticles, sections }) {
   const mostRecentArticles = streamArticles.filter(
     (streamArticle) => !featuredArticleIds.includes(streamArticle.id)
   );
+
+  const router = useRouter();
+  const { locale, locales, defaultLocale } = router;
+
+  console.log('current locale:', locale);
+  console.log('default locale:', defaultLocale);
+  console.log('locales:', JSON.stringify(locales));
 
   return (
     <div className="homepage">


### PR DESCRIPTION
This is a small PR - remember those?!

I've setup this front-end demo to use 2 locales: en-us as the default, es as the second. 

I've added some console logging to the homepage to confirm it's working. You can see that by loading http://localhost:3000 and http://localhost:3000/es.

I'd like to break up this work into easily digestible chunks so we're not having to review and merge huge code changes, if possible, so if that's alright with you, there will be more i18n PRs in the future :) 