### PR TITLE
i18n category index page

### DIFF
--- a/components/homepage/ArticleCard.js
+++ b/components/homepage/ArticleCard.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderAuthors, renderDate } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function ArticleCard({ article, isAmp }) {
+export default function ArticleCard({ article, locale, isAmp }) {
   let mainImage = null;
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'
@@ -11,6 +11,8 @@ export default function ArticleCard({ article, isAmp }) {
   if (mainImageNode) {
     mainImage = mainImageNode.children[0];
   }
+
+  let headline = localiseText(locale, article.headline);
   return (
     <div className="card">
       {mainImage && (
@@ -43,7 +45,7 @@ export default function ArticleCard({ article, isAmp }) {
               href="/articles/[category]/[slug]"
               as={`/articles/${article.category.slug}/${article.slug}`}
             >
-              <a>{article.headline.values[0].value}</a>
+              <a>{headline}</a>
             </Link>
           </h1>
           <p>{renderAuthors(article)}</p>

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -9,6 +9,7 @@ export default function ArticleLink({ locale, article, isAmp }) {
 
   let headline = localiseText(locale, article.headline);
   let searchDescription = localiseText(locale, article.searchDescription);
+  console.log(locale, 'article.category.title:', article.category.title);
   let categoryTitle = localiseText(locale, article.category.title);
 
   if (article.content !== null && article.content !== undefined) {

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderDate, renderAuthors } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function ArticleLink({ article, isAmp }) {
+export default function ArticleLink({ locale, article, isAmp }) {
   let mainImage = null;
   let mainImageNode;
+
+  let headline = localiseText(locale, article.headline);
+  let searchDescription = localiseText(locale, article.searchDescription);
+  let categoryTitle = localiseText(locale, article.category.title);
 
   if (article.content !== null && article.content !== undefined) {
     try {
@@ -50,11 +54,8 @@ export default function ArticleLink({ article, isAmp }) {
             <h6 className="is-6">
               {article.category && (
                 <span className="category">
-                  <Link
-                    key={article.category.title.values[0].value}
-                    href={`/${article.category.slug}`}
-                  >
-                    <a>{article.category.title.values[0].value}</a>
+                  <Link key={categoryTitle} href={`/${article.category.slug}`}>
+                    <a>{categoryTitle}</a>
                   </Link>
                 </span>
               )}
@@ -69,15 +70,15 @@ export default function ArticleLink({ article, isAmp }) {
                   href="/articles/[category]/[slug]"
                   as={`/articles/${article.category.slug}/${article.slug}`}
                 >
-                  <a>{article.headline.values[0].value}</a>
+                  <a>{headline}</a>
                 </Link>
               )}
-              {!article.category && article.headline.values[0].value}
+              {!article.category && headline}
             </h2>
             <p>
               <span>By</span>&nbsp;{renderAuthors(article)}
             </p>
-            <p>{article.searchDescription}</p>
+            <p>{searchDescription}</p>
           </div>
         </div>
       </article>

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -6,11 +6,8 @@ import ModalArticleSearch from '../tinycms/ModalArticleSearch';
 export default function BigFeaturedStory(props) {
   const [isModalActive, setModal] = useState(false);
 
-  console.log('BigFeaturedStory locale:', props.locale);
   useEffect(() => {
-    //   console.log("setting featured article to", props.articles['featured'])
-    //   props.setFeaturedArticle(props.articles['featured']);
-    console.log('featuredArticle is now', props.featuredArticle);
+    props.setFeaturedArticle(props.articles['featured']);
   }, [props.articles, props.featuredArticle]);
 
   return (

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -6,6 +6,7 @@ import ModalArticleSearch from '../tinycms/ModalArticleSearch';
 export default function BigFeaturedStory(props) {
   const [isModalActive, setModal] = useState(false);
 
+  console.log('BigFeaturedStory locale:', props.locale);
   useEffect(() => {
     //   console.log("setting featured article to", props.articles['featured'])
     //   props.setFeaturedArticle(props.articles['featured']);
@@ -38,6 +39,7 @@ export default function BigFeaturedStory(props) {
                   {props.featuredArticle && (
                     <FeaturedArticleLink
                       key={props.articles['featured'].id}
+                      locale={props.locale}
                       article={props.featuredArticle}
                       amp={props.isAmp}
                     />
@@ -48,6 +50,7 @@ export default function BigFeaturedStory(props) {
             {!props.editable && props.articles['featured'] && (
               <FeaturedArticleLink
                 key={props.articles['featured'].id}
+                locale={props.locale}
                 article={props.articles['featured']}
                 amp={props.isAmp}
               />

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -1,20 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderDate, renderAuthors } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function FeaturedArticleLink({ article, isAmp }) {
+export default function FeaturedArticleLink({ locale, article, isAmp }) {
   let mainImage = null;
   let mainImageNode = null;
 
-  let headline =
-    article.headline && article.headline.values
-      ? article.headline.values[0].value
-      : article.headline;
-  let searchDescription =
-    article.searchDescription && article.searchDescription.values
-      ? article.searchDescription.values[0].value
-      : article.searchDescription;
+  let headline = localiseText(locale, article.headline);
+  let searchDescription = localiseText(locale, article.searchDescription);
+  let categoryTitle = localiseText(locale, article.category.title);
 
   if (article && article.content) {
     mainImageNode = article.content.find((node) => node.type === 'mainImage');
@@ -55,7 +50,7 @@ export default function FeaturedArticleLink({ article, isAmp }) {
             {article.category && (
               <span className="category">
                 <Link href="/[slug]" as={article.category.slug}>
-                  <a>{article.category.title.values[0].value}</a>
+                  <a>{categoryTitle}</a>
                 </Link>
               </span>
             )}

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -41,6 +41,7 @@ export default function LargePackageStoryLead(props) {
         )}
         {props.featuredArticle && (
           <FeaturedArticleLink
+            locale={props.locale}
             key={props.featuredArticle.id}
             article={props.featuredArticle}
             amp={props.isAmp}
@@ -73,6 +74,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedLeftArticle && (
               <ArticleCard
                 key={props.subFeaturedLeftArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedLeftArticle}
                 amp={props.isAmp}
               />
@@ -102,6 +104,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedMiddleArticle && (
               <ArticleCard
                 key={props.subFeaturedMiddleArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedMiddleArticle}
                 amp={props.isAmp}
               />
@@ -130,6 +133,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedRightArticle && (
               <ArticleCard
                 key={props.subFeaturedRightArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedRightArticle}
                 amp={props.isAmp}
               />

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -11,17 +11,20 @@ const LIST_ARTICLES = `
   listArticles {
     data {
       id
+      availableLocales
       headlineSearch
       firstPublishedOn
-        lastPublishedOn
+      lastPublishedOn
       slug
       headline {
         values {
+          locale
           value
         }
       }
       content {
         values {
+          locale
           value
         }
       }
@@ -29,6 +32,7 @@ const LIST_ARTICLES = `
         id
         title {
           values {
+            locale
             value
           }
         }
@@ -36,8 +40,9 @@ const LIST_ARTICLES = `
       }
       tags {
         id
-        title{
+        title {
           values {
+            locale
             value
           }
         }
@@ -355,18 +360,37 @@ export async function listAllSectionTitles() {
   return sections;
 }
 
-export async function listAllArticlesBySection(section) {
+export async function listAllArticlesBySection(locale, section) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
+  const variables = {
+    where: {
+      availableLocales_contains: locale.code,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES,
+    variables
+  );
   let articlesBySection = [];
   articlesData.articles.listArticles.data.map((article) => {
     if (article.category.slug == section) {
-      article.content = JSON.parse(article.content.values[0].value);
+      let articleContent;
+      if (article.content && article.content.values) {
+        articleContent = localiseText(locale, article.content);
+      }
+      try {
+        article.content = JSON.parse(articleContent);
+      } catch (e) {
+        console.log('setting content to null from:', articleContent);
+        console.log(e);
+        article.content = null;
+      }
+      // article.content = JSON.parse(article.content.values[0].value);
       articlesBySection.push(article);
     }
   });

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -291,6 +291,31 @@ const GET_AUTHOR_BY_SLUG = `query Author($slug: String) {
   }
 }`;
 
+const LIST_LOCALES = `
+  query ListI18nLocales {
+    i18n {
+      listI18NLocales {
+        data {
+          id
+          code
+          default
+        }
+      }
+    }
+  }`;
+
+export async function listAllLocales() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const response = await webinyHeadlessCms.request(LIST_LOCALES);
+
+  return response.data.i18n.listI18NLocales.data;
+}
+
 export async function listAllSections() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -686,35 +711,43 @@ query SearchArticles($where: ArticleListWhere) {
       data {
         id
         headlineSearch
+        published
+        availableLocales
         firstPublishedOn
         lastPublishedOn
         twitterTitle {
           values {
+            locale
             value
           }
         }
         twitterDescription {
           values {
+            locale
             value
           }
         }
         facebookTitle {
           values {
+            locale
             value
           }
         }
         facebookDescription {
           values {
+            locale
             value
           }
         }
         searchTitle {
           values {
+            locale
             value
           }
         }
         searchDescription {
           values {
+            locale
             value
           }
         }
@@ -722,11 +755,13 @@ query SearchArticles($where: ArticleListWhere) {
         slug
         headline {
           values {
+            locale
             value
           }
         }
         content {
           values {
+            locale
             value
           }
         }
@@ -734,6 +769,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -743,6 +779,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -774,7 +811,7 @@ export async function getArticle(id) {
   return articlesData.getBasicArticle.data;
 }
 
-export async function getArticleBySlug(slug, apiUrl) {
+export async function getArticleBySlug(locale, slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;
   }
@@ -790,15 +827,22 @@ export async function getArticleBySlug(slug, apiUrl) {
     },
   });
   let articleData = articlesData.articles.listArticles.data[0];
+  console.log('looking for', locale, 'in articleData', articleData.content);
+  let localisedContent = articleData.content.values.find(
+    (item) => item.locale === locale.id
+  );
+  console.log('localised content:', localisedContent);
+
   try {
-    articleData.content = JSON.parse(articleData.content.values[0].value);
+    articleData.content = JSON.parse(localisedContent.value);
   } catch (e) {
     console.log(slug, 'failed parsing json:', e);
+    articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
   }
   return articleData;
 }
 
-export async function getHomepageArticles(hpData) {
+export async function getHomepageArticles(locale, hpData) {
   if (hpData === null) {
     return [];
   }
@@ -823,7 +867,7 @@ export async function getHomepageArticles(hpData) {
       if (typeof values === 'string') {
         let foundArticle;
         (async () => {
-          foundArticle = await getArticleBySlug(values);
+          foundArticle = await getArticleBySlug(locale, values);
           hpArticles[key] = foundArticle;
         })();
       } else {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -808,6 +808,42 @@ export async function getArticle(id) {
   return articlesData.getBasicArticle.data;
 }
 
+export async function getMostRecentArticle(locale, slug, apiUrl) {
+  if (apiUrl === undefined) {
+    apiUrl = CONTENT_DELIVERY_API_URL;
+  }
+  const webinyHeadlessCms = new GraphQLClient(apiUrl, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(SEARCH_ARTICLES, {
+    where: {
+      availableLocales_contains: locale.code,
+    },
+  });
+  let articleData;
+  try {
+    articleData = articlesData.articles.listArticles.data[0];
+  } catch (e) {
+    console.log('error grabbing first article:', e);
+    return null;
+  }
+  let localisedContent;
+  localisedContent = articleData.content.values.find(
+    (item) => item.locale === locale.id
+  );
+
+  try {
+    articleData.content = JSON.parse(localisedContent.value);
+  } catch (e) {
+    console.log(slug, 'failed parsing json:', e);
+    articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
+  }
+  return articleData;
+}
+
 export async function getArticleBySlug(locale, slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;
@@ -820,18 +856,30 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
 
   const articlesData = await webinyHeadlessCms.request(GET_ARTICLE_BY_SLUG, {
     where: {
+      availableLocales_contains: locale.code,
       slug: slug,
     },
   });
-  let articleData = articlesData.articles.listArticles.data[0];
-  let localisedContent = articleData.content.values.find(
-    (item) => item.locale === locale.id
-  );
+  let articleData;
+  let localisedContent;
+  if (
+    articlesData &&
+    articlesData.articles &&
+    articlesData.listArticles &&
+    articlesData.articles.listArticles.data &&
+    articlesData.articles.listArticles.data[0]
+  ) {
+    articleData = articlesData.articles.listArticles.data[0];
+    localisedContent = articleData.content.values.find(
+      (item) => item.locale === locale.id
+    );
+  } else {
+    return null;
+  }
 
   try {
     articleData.content = JSON.parse(localisedContent.value);
   } catch (e) {
-    console.log(slug, 'failed parsing json:', e);
     articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
   }
   return articleData;
@@ -864,6 +912,7 @@ export async function getHomepageArticles(locale, hpData) {
         (async () => {
           foundArticle = await getArticleBySlug(locale, values);
           hpArticles[key] = foundArticle;
+          console.log('hpArticles[key]:', hpArticles[key]);
         })();
       } else {
         let foundArticles;
@@ -875,6 +924,9 @@ export async function getHomepageArticles(locale, hpData) {
     });
   }
 
+  Object.entries(hpArticles).map(([key, value]) => {
+    console.log('key:', key, 'value:', value);
+  });
   return hpArticles;
 }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -324,7 +324,7 @@ export async function listAllLocales() {
 
   const response = await webinyHeadlessCms.request(LIST_LOCALES);
 
-  return response.data.i18n.listI18NLocales.data;
+  return response.i18n.listI18NLocales.data;
 }
 
 export async function listAllSections() {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,4 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
+import { localiseText } from './utils';
 
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
@@ -59,17 +60,20 @@ const LIST_ARTICLES_REVERSE_CHRON = `
   listArticles(sort: {firstPublishedOn: -1}) {
     data {
       id
+      availableLocales
       headlineSearch
       firstPublishedOn
-        lastPublishedOn
+      lastPublishedOn
       slug
       headline {
         values {
+          locale
           value
         }
       }
       content {
         values {
+          locale
           value
         }
       }
@@ -77,6 +81,7 @@ const LIST_ARTICLES_REVERSE_CHRON = `
         id
         title {
           values {
+            locale
             value
           }
         }
@@ -86,6 +91,7 @@ const LIST_ARTICLES_REVERSE_CHRON = `
         id
         title{
           values {
+            locale
             value
           }
         }
@@ -446,25 +452,16 @@ export async function listAllArticles() {
   return articlesData.articles.listArticles.data;
 }
 
-export async function listMostRecentArticles() {
-  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-    },
-  });
-
-  const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES_REVERSE_CHRON
+export async function listMostRecentArticles(locale) {
+  const articlesData = await listArticlesInLocale(
+    CONTENT_DELIVERY_API_URL,
+    CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    locale.code
   );
-  articlesData.articles.listArticles.data.map((article) => {
+  articlesData.map((article) => {
     let articleContent;
-    if (
-      article.content &&
-      article.content.values &&
-      article.content.values[0] &&
-      article.content.values[0].value
-    ) {
-      articleContent = article.content.values[0].value;
+    if (article.content && article.content.values) {
+      articleContent = localiseText(locale, article.content);
     }
     try {
       article.content = JSON.parse(articleContent);
@@ -474,7 +471,7 @@ export async function listMostRecentArticles() {
       article.content = null;
     }
   });
-  return articlesData.articles.listArticles.data;
+  return articlesData;
 }
 
 export async function listArticlesBySlug(slugs) {
@@ -827,11 +824,9 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
     },
   });
   let articleData = articlesData.articles.listArticles.data[0];
-  console.log('looking for', locale, 'in articleData', articleData.content);
   let localisedContent = articleData.content.values.find(
     (item) => item.locale === locale.id
   );
-  console.log('localised content:', localisedContent);
 
   try {
     articleData.content = JSON.parse(localisedContent.value);
@@ -971,19 +966,22 @@ export async function listAuthors() {
 const SEARCH_ARTICLES = `
 query SearchArticles($where: ArticleListWhere) {
   articles {
-    listArticles(where: $where) {
+    listArticles(sort: {firstPublishedOn: -1}, where: $where) {
       data {
         id
+        availableLocales
         headlineSearch
         firstPublishedOn
         slug
         headline {
           values {
+            locale
             value
           }
         }
         content {
           values {
+            locale
             value
           }
         }
@@ -991,6 +989,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -998,8 +997,9 @@ query SearchArticles($where: ArticleListWhere) {
         }
         tags {
           id
-          title{
+          title {
             values {
+              locale
               value
             }
           }
@@ -1059,4 +1059,24 @@ export async function searchArticles(url, token, term) {
   });
 
   return articles;
+}
+
+export async function listArticlesInLocale(url, token, locale) {
+  const webinyHeadlessCms = new GraphQLClient(url, {
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const variables = {
+    where: {
+      availableLocales_contains: locale,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    SEARCH_ARTICLES,
+    variables
+  );
+
+  return articlesData.articles.listArticles.data;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,9 +21,6 @@ export const localiseText = (locale, field) => {
 };
 
 export const renderAuthor = (author, i) => {
-  if (author === undefined) {
-    return null;
-  }
   if (author.slug !== null && author.slug !== undefined) {
     return (
       <Link href={`/authors/${author.slug}`} key={`${author.slug}-${i}`}>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,9 @@ export const localiseText = (locale, field) => {
 };
 
 export const renderAuthor = (author, i) => {
+  if (author === undefined) {
+    return null;
+  }
   if (author.slug !== null && author.slug !== undefined) {
     return (
       <Link href={`/authors/${author.slug}`} key={`${author.slug}-${i}`}>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,20 @@ import ListNode from '../components/nodes/ListNode.js';
 import TextNode from '../components/nodes/TextNode.js';
 import ImageWithTextAd from '../components/ads/ImageWithTextAd.js';
 
+export const localiseText = (locale, field) => {
+  let localisedValue;
+  let text = 'NEEDS TRANSLATION'; // for now, default to this so it's obvious what's missing
+
+  if (field && field.values) {
+    localisedValue = field.values.find((item) => item.locale === locale.id);
+    if (localisedValue) {
+      text = localisedValue.value;
+    }
+  }
+
+  return text;
+};
+
 export const renderAuthor = (author, i) => {
   if (author.slug !== null && author.slug !== undefined) {
     return (

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -14,7 +14,13 @@ import GlobalNav from '../components/nav/GlobalNav.js';
 import GlobalFooter from '../components/nav/GlobalFooter.js';
 import { useAmp } from 'next/amp';
 
-export default function CategoryPage({ articles, title, sections, tags }) {
+export default function CategoryPage({
+  locale,
+  articles,
+  title,
+  sections,
+  tags,
+}) {
   const isAmp = useAmp();
   siteMetadata.tags = tags;
 
@@ -34,7 +40,12 @@ export default function CategoryPage({ articles, title, sections, tags }) {
           <div className="columns">
             <div className="column is-four-fifths">
               {articles.map((article) => (
-                <ArticleLink key={article.id} article={article} amp={isAmp} />
+                <ArticleLink
+                  key={article.id}
+                  locale={locale}
+                  article={article}
+                  amp={isAmp}
+                />
               ))}
             </div>
           </div>
@@ -53,7 +64,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ locale, params }) {
   const articles = await listAllArticlesBySection(params.category);
   const sections = await listAllSections();
   // const sections = await cachedContents('sections', listAllSections);
@@ -76,6 +87,7 @@ export async function getStaticProps({ params }) {
   }
   return {
     props: {
+      locale,
       articles,
       title,
       tags,

--- a/pages/index.js
+++ b/pages/index.js
@@ -124,7 +124,7 @@ export async function getStaticProps({ locale }) {
   const hpArticles = await getHomepageArticles(currentLocale, hpData);
   // const hpArticles = { "featured": ""}
 
-  const streamArticles = await listMostRecentArticles();
+  const streamArticles = await listMostRecentArticles(currentLocale);
 
   const sections = await cachedContents('sections', listAllSections);
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,6 +94,7 @@ export default function Home({
                   mostRecentArticles.map((streamArticle) => (
                     <ArticleLink
                       key={streamArticle.id}
+                      locale={currentLocale}
                       article={streamArticle}
                       amp={isAmp}
                     />

--- a/script/populate.js
+++ b/script/populate.js
@@ -16,6 +16,39 @@ function writeCache(name, data) {
   });
 }
 
+function listLocales() {
+  const query = `
+    query ListI18nLocales {
+      i18n {
+        listI18NLocales {
+          data {
+            id
+            code
+            default
+          }
+        }
+      }
+    }
+  `;
+
+  const url = CONTENT_DELIVERY_API_URL;
+  let opts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  };
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((responseParsed) => {
+      let locales = responseParsed.data.i18n.listI18NLocales.data;
+      writeCache('locales', locales);
+    })
+    .catch(console.error);
+}
+
 function listSections() {
   const query = `
     {
@@ -107,6 +140,7 @@ function getAds() {
 }
 
 async function main() {
+  listLocales();
   listSections();
   listTags();
   getAds();


### PR DESCRIPTION
Issue #180 

This localises the category index page:

* the category title of the page uses the current locale
* the list of articles only includes those available in the current locale
* each article's headline/category/desc use the current locale

Right now I see a fair amount of my fallback text "NEEDS TRANSLATION" but that's by design. This approach worked well on a few i18n projects in the past for me. 

The main "NEEDS TRANSLATION" on this page is the category title. I've logged an issue to update the tinycms to localise categories. 

A lot of the article headlines on my pages are also showing up as needing translating, so, as a test, I chose the top "business" article appearing on my Spanish "business" index page (http://localhost:3000/es/business). I opened the google doc (en-US), created it in `es` using the sidebar link, translated the headline via google, and published. When I refreshed my Spanish business page, the article headline appeared in Spanish. It was nice to see that work!