### PR TITLE
i18n article and tag pages

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -17,9 +17,8 @@ export default function Article({
 }) {
   const isAmp = useAmp();
 
-  console.log('article:', article);
   return (
-    <Layout meta={article}>
+    <Layout meta={article} locale={currentLocale}>
       <GlobalNav sections={sections} />
       <article className="container">
         <ArticleHeader article={article} locale={currentLocale} />

--- a/components/Article.js
+++ b/components/Article.js
@@ -8,18 +8,30 @@ import GlobalFooter from './nav/GlobalFooter.js';
 import { useAmp } from 'next/amp';
 import Layout from './Layout.js';
 
-export default function Article({ article, sections, tags, ads }) {
+export default function Article({
+  article,
+  currentLocale,
+  sections,
+  tags,
+  ads,
+}) {
   const isAmp = useAmp();
 
+  console.log('article:', article);
   return (
     <Layout meta={article}>
       <GlobalNav sections={sections} />
       <article className="container">
-        <ArticleHeader article={article} />
+        <ArticleHeader article={article} locale={currentLocale} />
         <MainImage article={article} isAmp={isAmp} />
-        <ArticleBody article={article} isAmp={isAmp} ads={ads} />
-        <Tags article={article} />
-        <ArticleFooter article={article} isAmp={isAmp} />
+        <ArticleBody
+          article={article}
+          locale={currentLocale}
+          isAmp={isAmp}
+          ads={ads}
+        />
+        <Tags article={article} locale={currentLocale} />
+        <ArticleFooter article={article} locale={currentLocale} isAmp={isAmp} />
       </article>
       <GlobalFooter />
     </Layout>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -113,6 +113,9 @@ export default function Layout({ children, locale, meta }) {
             key="amp-analytics"
           />
         )}
+        <style jsx global>
+          {globalStyles}
+        </style>
       </Head>
       <main>
         {isAmp && (
@@ -137,9 +140,6 @@ export default function Layout({ children, locale, meta }) {
         )}
         {children}
       </main>
-      <style jsx global>
-        {globalStyles}
-      </style>
     </>
   );
 }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,34 +3,37 @@ import { siteMetadata } from '../lib/siteMetadata.js';
 import globalStyles from '../styles/global.js';
 import { useAmp } from 'next/amp';
 import AmpAnalytics from './amp/AmpAnalytics.js';
+import { localiseText } from '../lib/utils.js';
 
-export default function Layout({ children, meta }) {
+export default function Layout({ children, locale, meta }) {
+  if (meta === null || meta === undefined) {
+    console.log('Layout meta is missing');
+    meta = {};
+  }
+  if (locale === null || locale === undefined) {
+    console.log('Layout locale is missing');
+    meta = {};
+  }
   const metaValues = {
     canonical: meta.canonical || siteMetadata.siteUrl,
-    searchTitle:
-      meta.searchTitle && meta.searchTitle.values
-        ? meta.searchTitle.values[0].value
-        : siteMetadata.searchTitle,
-    searchDescription:
-      meta.searchDescription && meta.searchDescription.values
-        ? meta.searchDescription.values[0].value
-        : siteMetadata.searchDescription,
-    facebookTitle:
-      meta.facebookTitle && meta.facebookTitle.values
-        ? meta.facebookTitle.values[0].value
-        : siteMetadata.facebookTitle,
-    facebookDescription:
-      meta.facebookDescription && meta.facebookDescription.values
-        ? meta.facebookDescription.values[0].value
-        : siteMetadata.facebookDescription,
-    twitterTitle:
-      meta.twitterTitle && meta.twitterTitle.values
-        ? meta.twitterTitle.values[0].value
-        : siteMetadata.twitterTitle,
-    twitterDescription:
-      meta.twitterDescription && meta.twitterDescription.values
-        ? meta.twitterDescription.values[0].value
-        : siteMetadata.twitterDescription,
+    searchTitle: meta.searchTitle
+      ? localiseText(locale, meta.searchTitle)
+      : siteMetadata.searchTitle,
+    searchDescription: meta.searchDescription
+      ? localiseText(locale, meta.searchDescription)
+      : siteMetadata.searchDescription,
+    facebookTitle: meta.facebookTitle
+      ? localiseText(locale, meta.facebookTitle)
+      : siteMetadata.facebookTitle,
+    facebookDescription: meta.facebookDescription
+      ? localiseText(locale, meta.facebookDescription)
+      : siteMetadata.facebookDescription,
+    twitterTitle: meta.twitterTitle
+      ? localiseText(locale, meta.twitterTitle)
+      : siteMetadata.twitterTitle,
+    twitterDescription: meta.twitterDescription
+      ? localiseText(locale, meta.twitterDescription)
+      : siteMetadata.twitterDescription,
     firstPublishedOn: meta.firstPublishedOn || siteMetadata.firstPublishedOn,
     lastPublishedOn: meta.lastPublishedOn || siteMetadata.lastPublishedOn,
     tags: meta.tags || siteMetadata.tags,
@@ -51,17 +54,10 @@ export default function Layout({ children, meta }) {
   const trackingId = process.env.GA_TRACKING_ID;
 
   let title;
-  if (
-    meta &&
-    meta.searchTitle &&
-    meta.searchTitle.values &&
-    meta.searchTitle.values[0]
-  ) {
-    title = meta.searchTitle.values[0].value;
-  } else if (meta && meta.searchTitle) {
-    title = meta.searchTitle;
+  if (meta && meta.searchTitle) {
+    title = localiseText(locale, meta.searchTitle);
   } else if (metaValues.searchTitle) {
-    title = metaValues.searchTitle.values[0].value;
+    title = localiseText(locale, metaValues.searchTitle);
   }
 
   return (

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -113,9 +113,6 @@ export default function Layout({ children, locale, meta }) {
             key="amp-analytics"
           />
         )}
-        <style jsx global>
-          {globalStyles}
-        </style>
       </Head>
       <main>
         {isAmp && (
@@ -140,6 +137,9 @@ export default function Layout({ children, locale, meta }) {
         )}
         {children}
       </main>
+      <style jsx global>
+        {globalStyles}
+      </style>
     </>
   );
 }

--- a/components/articles/ArticleBody.js
+++ b/components/articles/ArticleBody.js
@@ -62,7 +62,7 @@ export default function ArticleBody({ article, locale, ads, isAmp }) {
 
   return (
     <section className="section" key="body" ref={ref}>
-      <div id="articleText" className="content">
+      <div id="articleText" className="content" key="bodyContent">
         {body}
       </div>
     </section>

--- a/components/articles/ArticleBody.js
+++ b/components/articles/ArticleBody.js
@@ -3,7 +3,7 @@ import { useScrollPercentage } from 'react-scroll-percentage';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
 import { renderBody } from '../../lib/utils.js';
 
-export default function ArticleBody({ article, ads, isAmp }) {
+export default function ArticleBody({ article, locale, ads, isAmp }) {
   const body = renderBody(article, ads, isAmp);
 
   const { trackEvent } = useAnalytics();

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -1,25 +1,10 @@
 import Link from 'next/link';
 import PublishDate from './PublishDate.js';
+import { localiseText } from '../../lib/utils.js';
 
-export default function ArticleHeader({ article }) {
-  let categoryTitle, headline;
-  if (
-    article.category &&
-    article.category.title &&
-    article.category.title.values &&
-    article.category.title.values[0] &&
-    article.category.title.values[0].value
-  ) {
-    categoryTitle = article.category.title.values[0].value;
-  }
-  if (
-    article.headline &&
-    article.headline.values &&
-    article.headline.values[0] &&
-    article.headline.values[0].value
-  ) {
-    headline = article.headline.values[0].value;
-  }
+export default function ArticleHeader({ article, locale }) {
+  let categoryTitle = localiseText(locale, article.category.title);
+  let headline = localiseText(locale, article.headline);
 
   return (
     <section key="title">

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -1,21 +1,35 @@
 import Link from 'next/link';
+import React, { useEffect } from 'react';
 import PublishDate from './PublishDate.js';
 import { localiseText } from '../../lib/utils.js';
 
 export default function ArticleHeader({ article, locale }) {
-  let categoryTitle = localiseText(locale, article.category.title);
-  let headline = localiseText(locale, article.headline);
+  let categoryTitle;
+  let headline;
+
+  useEffect(() => {
+    if (article && article.category) {
+      categoryTitle = localiseText(locale, article.category.title);
+      headline = localiseText(locale, article.headline);
+    }
+  }, [article]);
+
+  if (!article) {
+    return null;
+  }
 
   return (
     <section key="title">
       <div className="hero-body">
         <div className={article.cover ? 'container head-margin' : 'container'}>
           <h2 className="subtitle">
-            <Link key={categoryTitle} href={`/${article.category.slug}`}>
-              {categoryTitle}
-            </Link>
+            {categoryTitle && (
+              <Link key={categoryTitle} href={`/${article.category.slug}`}>
+                {categoryTitle}
+              </Link>
+            )}
           </h2>
-          <h1 className="title is-size-1">{headline}</h1>
+          {headline && <h1 className="title is-size-1">{headline}</h1>}
           <PublishDate article={article} />
         </div>
       </div>

--- a/components/articles/Tags.js
+++ b/components/articles/Tags.js
@@ -1,11 +1,13 @@
 import Link from 'next/link';
+import { localiseText } from '../../lib/utils.js';
 
-export default function Tags({ article }) {
+export default function Tags({ article, locale }) {
   let tagLinks;
+  console.log('locale:', locale, 'article.tags', article.tags);
   if (article.tags) {
     tagLinks = article.tags.map((tag, index) => (
       <Link href={`/tags/${tag.slug}`} key={`${tag.slug}-${index}`}>
-        <a className="is-link tag">{tag.title.values[0].value}</a>
+        <a className="is-link tag">{localiseText(locale, tag.title)}</a>
       </Link>
     ));
   }

--- a/components/articles/Tags.js
+++ b/components/articles/Tags.js
@@ -3,7 +3,6 @@ import { localiseText } from '../../lib/utils.js';
 
 export default function Tags({ article, locale }) {
   let tagLinks;
-  console.log('locale:', locale, 'article.tags', article.tags);
   if (article.tags) {
     tagLinks = article.tags.map((tag, index) => (
       <Link href={`/tags/${tag.slug}`} key={`${tag.slug}-${index}`}>

--- a/components/homepage/ArticleCard.js
+++ b/components/homepage/ArticleCard.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderAuthors, renderDate } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function ArticleCard({ article, isAmp }) {
+export default function ArticleCard({ article, locale, isAmp }) {
   let mainImage = null;
   const mainImageNode = article.content.find(
     (node) => node.type === 'mainImage'
@@ -11,6 +11,8 @@ export default function ArticleCard({ article, isAmp }) {
   if (mainImageNode) {
     mainImage = mainImageNode.children[0];
   }
+
+  let headline = localiseText(locale, article.headline);
   return (
     <div className="card">
       {mainImage && (
@@ -43,7 +45,7 @@ export default function ArticleCard({ article, isAmp }) {
               href="/articles/[category]/[slug]"
               as={`/articles/${article.category.slug}/${article.slug}`}
             >
-              <a>{article.headline.values[0].value}</a>
+              <a>{headline}</a>
             </Link>
           </h1>
           <p>{renderAuthors(article)}</p>

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -10,6 +10,16 @@ export default function ArticleLink({ locale, article, isAmp }) {
   let headline = localiseText(locale, article.headline);
   let searchDescription = localiseText(locale, article.searchDescription);
   let categoryTitle = localiseText(locale, article.category.title);
+  if (typeof categoryTitle !== 'string') {
+    console.log(
+      'category title is not a string:',
+      categoryTitle,
+      typeof categoryTitle
+    );
+  }
+  if (typeof headline !== 'string') {
+    console.log('headline is not a string:', headline, typeof headline);
+  }
 
   if (article.content !== null && article.content !== undefined) {
     try {
@@ -52,7 +62,7 @@ export default function ArticleLink({ locale, article, isAmp }) {
         <div className="media-content small-margin-left article-tease">
           <div className="content">
             <h6 className="is-6">
-              {article.category && (
+              {article.category && categoryTitle && (
                 <span className="category">
                   <Link key={categoryTitle} href={`/${article.category.slug}`}>
                     <a>{categoryTitle}</a>
@@ -65,7 +75,7 @@ export default function ArticleLink({ locale, article, isAmp }) {
               </span>
             </h6>
             <h2 className="is-2 article-title">
-              {article.category && (
+              {article.category && headline && (
                 <Link
                   href="/articles/[category]/[slug]"
                   as={`/articles/${article.category.slug}/${article.slug}`}

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -9,6 +9,7 @@ export default function ArticleLink({ locale, article, isAmp }) {
 
   let headline = localiseText(locale, article.headline);
   let searchDescription = localiseText(locale, article.searchDescription);
+  console.log(locale, 'article.category.title:', article.category.title);
   let categoryTitle = localiseText(locale, article.category.title);
 
   if (article.content !== null && article.content !== undefined) {

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderDate, renderAuthors } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function ArticleLink({ article, isAmp }) {
+export default function ArticleLink({ locale, article, isAmp }) {
   let mainImage = null;
   let mainImageNode;
+
+  let headline = localiseText(locale, article.headline);
+  let searchDescription = localiseText(locale, article.searchDescription);
+  let categoryTitle = localiseText(locale, article.category.title);
 
   if (article.content !== null && article.content !== undefined) {
     try {
@@ -50,11 +54,8 @@ export default function ArticleLink({ article, isAmp }) {
             <h6 className="is-6">
               {article.category && (
                 <span className="category">
-                  <Link
-                    key={article.category.title.values[0].value}
-                    href={`/${article.category.slug}`}
-                  >
-                    <a>{article.category.title.values[0].value}</a>
+                  <Link key={categoryTitle} href={`/${article.category.slug}`}>
+                    <a>{categoryTitle}</a>
                   </Link>
                 </span>
               )}
@@ -69,15 +70,15 @@ export default function ArticleLink({ article, isAmp }) {
                   href="/articles/[category]/[slug]"
                   as={`/articles/${article.category.slug}/${article.slug}`}
                 >
-                  <a>{article.headline.values[0].value}</a>
+                  <a>{headline}</a>
                 </Link>
               )}
-              {!article.category && article.headline.values[0].value}
+              {!article.category && headline}
             </h2>
             <p>
               <span>By</span>&nbsp;{renderAuthors(article)}
             </p>
-            <p>{article.searchDescription}</p>
+            <p>{searchDescription}</p>
           </div>
         </div>
       </article>

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -9,7 +9,6 @@ export default function ArticleLink({ locale, article, isAmp }) {
 
   let headline = localiseText(locale, article.headline);
   let searchDescription = localiseText(locale, article.searchDescription);
-  console.log(locale, 'article.category.title:', article.category.title);
   let categoryTitle = localiseText(locale, article.category.title);
 
   if (article.content !== null && article.content !== undefined) {

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -6,11 +6,8 @@ import ModalArticleSearch from '../tinycms/ModalArticleSearch';
 export default function BigFeaturedStory(props) {
   const [isModalActive, setModal] = useState(false);
 
-  console.log('BigFeaturedStory locale:', props.locale);
   useEffect(() => {
-    //   console.log("setting featured article to", props.articles['featured'])
-    //   props.setFeaturedArticle(props.articles['featured']);
-    console.log('featuredArticle is now', props.featuredArticle);
+    props.setFeaturedArticle(props.articles['featured']);
   }, [props.articles, props.featuredArticle]);
 
   return (

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -6,6 +6,7 @@ import ModalArticleSearch from '../tinycms/ModalArticleSearch';
 export default function BigFeaturedStory(props) {
   const [isModalActive, setModal] = useState(false);
 
+  console.log('BigFeaturedStory locale:', props.locale);
   useEffect(() => {
     //   console.log("setting featured article to", props.articles['featured'])
     //   props.setFeaturedArticle(props.articles['featured']);
@@ -38,6 +39,7 @@ export default function BigFeaturedStory(props) {
                   {props.featuredArticle && (
                     <FeaturedArticleLink
                       key={props.articles['featured'].id}
+                      locale={props.locale}
                       article={props.featuredArticle}
                       amp={props.isAmp}
                     />
@@ -48,6 +50,7 @@ export default function BigFeaturedStory(props) {
             {!props.editable && props.articles['featured'] && (
               <FeaturedArticleLink
                 key={props.articles['featured'].id}
+                locale={props.locale}
                 article={props.articles['featured']}
                 amp={props.isAmp}
               />

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -1,20 +1,15 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { renderDate, renderAuthors } from '../../lib/utils.js';
+import { localiseText, renderDate, renderAuthors } from '../../lib/utils.js';
 
-export default function FeaturedArticleLink({ article, isAmp }) {
+export default function FeaturedArticleLink({ locale, article, isAmp }) {
   let mainImage = null;
   let mainImageNode = null;
 
-  let headline =
-    article.headline && article.headline.values
-      ? article.headline.values[0].value
-      : article.headline;
-  let searchDescription =
-    article.searchDescription && article.searchDescription.values
-      ? article.searchDescription.values[0].value
-      : article.searchDescription;
+  let headline = localiseText(locale, article.headline);
+  let searchDescription = localiseText(locale, article.searchDescription);
+  let categoryTitle = localiseText(locale, article.category.title);
 
   if (article && article.content) {
     mainImageNode = article.content.find((node) => node.type === 'mainImage');
@@ -55,7 +50,7 @@ export default function FeaturedArticleLink({ article, isAmp }) {
             {article.category && (
               <span className="category">
                 <Link href="/[slug]" as={article.category.slug}>
-                  <a>{article.category.title.values[0].value}</a>
+                  <a>{categoryTitle}</a>
                 </Link>
               </span>
             )}

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -41,6 +41,7 @@ export default function LargePackageStoryLead(props) {
         )}
         {props.featuredArticle && (
           <FeaturedArticleLink
+            locale={props.locale}
             key={props.featuredArticle.id}
             article={props.featuredArticle}
             amp={props.isAmp}
@@ -73,6 +74,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedLeftArticle && (
               <ArticleCard
                 key={props.subFeaturedLeftArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedLeftArticle}
                 amp={props.isAmp}
               />
@@ -102,6 +104,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedMiddleArticle && (
               <ArticleCard
                 key={props.subFeaturedMiddleArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedMiddleArticle}
                 amp={props.isAmp}
               />
@@ -130,6 +133,7 @@ export default function LargePackageStoryLead(props) {
             {props.subFeaturedRightArticle && (
               <ArticleCard
                 key={props.subFeaturedRightArticle.id}
+                locale={props.locale}
                 article={props.subFeaturedRightArticle}
                 amp={props.isAmp}
               />

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -11,17 +11,20 @@ const LIST_ARTICLES = `
   listArticles {
     data {
       id
+      availableLocales
       headlineSearch
       firstPublishedOn
-        lastPublishedOn
+      lastPublishedOn
       slug
       headline {
         values {
+          locale
           value
         }
       }
       content {
         values {
+          locale
           value
         }
       }
@@ -29,6 +32,7 @@ const LIST_ARTICLES = `
         id
         title {
           values {
+            locale
             value
           }
         }
@@ -36,8 +40,9 @@ const LIST_ARTICLES = `
       }
       tags {
         id
-        title{
+        title {
           values {
+            locale
             value
           }
         }
@@ -355,18 +360,37 @@ export async function listAllSectionTitles() {
   return sections;
 }
 
-export async function listAllArticlesBySection(section) {
+export async function listAllArticlesBySection(locale, section) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
+  const variables = {
+    where: {
+      availableLocales_contains: locale.code,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES,
+    variables
+  );
   let articlesBySection = [];
   articlesData.articles.listArticles.data.map((article) => {
     if (article.category.slug == section) {
-      article.content = JSON.parse(article.content.values[0].value);
+      let articleContent;
+      if (article.content && article.content.values) {
+        articleContent = localiseText(locale, article.content);
+      }
+      try {
+        article.content = JSON.parse(articleContent);
+      } catch (e) {
+        console.log('setting content to null from:', articleContent);
+        console.log(e);
+        article.content = null;
+      }
+      // article.content = JSON.parse(article.content.values[0].value);
       articlesBySection.push(article);
     }
   });

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -291,6 +291,31 @@ const GET_AUTHOR_BY_SLUG = `query Author($slug: String) {
   }
 }`;
 
+const LIST_LOCALES = `
+  query ListI18nLocales {
+    i18n {
+      listI18NLocales {
+        data {
+          id
+          code
+          default
+        }
+      }
+    }
+  }`;
+
+export async function listAllLocales() {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const response = await webinyHeadlessCms.request(LIST_LOCALES);
+
+  return response.data.i18n.listI18NLocales.data;
+}
+
 export async function listAllSections() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -686,35 +711,43 @@ query SearchArticles($where: ArticleListWhere) {
       data {
         id
         headlineSearch
+        published
+        availableLocales
         firstPublishedOn
         lastPublishedOn
         twitterTitle {
           values {
+            locale
             value
           }
         }
         twitterDescription {
           values {
+            locale
             value
           }
         }
         facebookTitle {
           values {
+            locale
             value
           }
         }
         facebookDescription {
           values {
+            locale
             value
           }
         }
         searchTitle {
           values {
+            locale
             value
           }
         }
         searchDescription {
           values {
+            locale
             value
           }
         }
@@ -722,11 +755,13 @@ query SearchArticles($where: ArticleListWhere) {
         slug
         headline {
           values {
+            locale
             value
           }
         }
         content {
           values {
+            locale
             value
           }
         }
@@ -734,6 +769,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -743,6 +779,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -774,7 +811,7 @@ export async function getArticle(id) {
   return articlesData.getBasicArticle.data;
 }
 
-export async function getArticleBySlug(slug, apiUrl) {
+export async function getArticleBySlug(locale, slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;
   }
@@ -790,15 +827,22 @@ export async function getArticleBySlug(slug, apiUrl) {
     },
   });
   let articleData = articlesData.articles.listArticles.data[0];
+  console.log('looking for', locale, 'in articleData', articleData.content);
+  let localisedContent = articleData.content.values.find(
+    (item) => item.locale === locale.id
+  );
+  console.log('localised content:', localisedContent);
+
   try {
-    articleData.content = JSON.parse(articleData.content.values[0].value);
+    articleData.content = JSON.parse(localisedContent.value);
   } catch (e) {
     console.log(slug, 'failed parsing json:', e);
+    articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
   }
   return articleData;
 }
 
-export async function getHomepageArticles(hpData) {
+export async function getHomepageArticles(locale, hpData) {
   if (hpData === null) {
     return [];
   }
@@ -823,7 +867,7 @@ export async function getHomepageArticles(hpData) {
       if (typeof values === 'string') {
         let foundArticle;
         (async () => {
-          foundArticle = await getArticleBySlug(values);
+          foundArticle = await getArticleBySlug(locale, values);
           hpArticles[key] = foundArticle;
         })();
       } else {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -386,7 +386,6 @@ export async function listAllArticlesBySection(locale, section) {
       try {
         article.content = JSON.parse(articleContent);
       } catch (e) {
-        console.log('setting content to null from:', articleContent);
         console.log(e);
         article.content = null;
       }
@@ -397,7 +396,7 @@ export async function listAllArticlesBySection(locale, section) {
   return articlesBySection;
 }
 
-export async function listAllAuthorPaths() {
+export async function listAllAuthorPaths(locales) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
@@ -406,13 +405,17 @@ export async function listAllAuthorPaths() {
 
   const authorData = await webinyHeadlessCms.request(LIST_AUTHORS);
 
-  const slugs = authorData.authors.listAuthors.data.map((author) => {
-    return {
-      params: {
-        slug: author.slug,
-      },
-    };
-  });
+  let slugs = [];
+  for (const locale of locales) {
+    authorData.authors.listAuthors.data.map((author) => {
+      slugs.push({
+        params: {
+          slug: author.slug,
+        },
+        locale,
+      });
+    });
+  }
   return slugs;
 }
 
@@ -494,7 +497,6 @@ export async function listMostRecentArticles(locale) {
     try {
       article.content = JSON.parse(articleContent);
     } catch (e) {
-      console.log('setting content to null from:', articleContent);
       console.log(e);
       article.content = null;
     }
@@ -568,7 +570,6 @@ export async function listAllArticlesByTag(locale, tag) {
     try {
       article.content = JSON.parse(articleContent);
     } catch (e) {
-      console.log('error parsing json article content:', articleContent);
       console.log(e);
       article.content = null;
     }
@@ -577,7 +578,7 @@ export async function listAllArticlesByTag(locale, tag) {
   return articlesByTag;
 }
 
-export async function listAllArticlesByAuthor(authorSlug) {
+export async function listAllArticlesByAuthor(locale, authorSlug) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
@@ -587,6 +588,7 @@ export async function listAllArticlesByAuthor(authorSlug) {
   const variables = {
     where: {
       authorSlugs_contains: authorSlug,
+      availableLocales_contains: locale.code,
     },
   };
   const articlesData = await webinyHeadlessCms.request(
@@ -595,8 +597,12 @@ export async function listAllArticlesByAuthor(authorSlug) {
   );
 
   articlesData.articles.listArticles.data.map((article) => {
+    let articleContent;
+    if (article.content && article.content.values) {
+      articleContent = localiseText(locale, article.content);
+    }
     try {
-      article.content = JSON.parse(article.content.values[0].value);
+      article.content = JSON.parse(articleContent);
     } catch (e) {
       console.log('error parsing json:', e);
     }
@@ -623,7 +629,7 @@ export async function listAllArticleIds() {
   return ids;
 }
 
-export async function listAllArticleSlugs() {
+export async function listAllArticleSlugs(locales) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
@@ -631,14 +637,18 @@ export async function listAllArticleSlugs() {
   });
 
   const articlesData = await webinyHeadlessCms.request(LIST_SLUGS);
-  const slugs = articlesData.articles.listArticles.data.map((article) => {
-    return {
-      params: {
-        category: article.category ? article.category.slug : null,
-        slug: article.slug,
-      },
-    };
-  });
+  let slugs = [];
+  for (const locale of locales) {
+    articlesData.articles.listArticles.data.map((article) => {
+      slugs.push({
+        params: {
+          category: article.category ? article.category.slug : null,
+          slug: article.slug,
+        },
+        locale,
+      });
+    });
+  }
   return slugs;
 }
 
@@ -956,7 +966,6 @@ export async function getHomepageArticles(locale, hpData) {
         (async () => {
           foundArticle = await getArticleBySlug(locale, values);
           hpArticles[key] = foundArticle;
-          console.log('hpArticles[key]:', hpArticles[key]);
         })();
       } else {
         let foundArticles;
@@ -968,9 +977,6 @@ export async function getHomepageArticles(locale, hpData) {
     });
   }
 
-  Object.entries(hpArticles).map(([key, value]) => {
-    console.log('key:', key, 'value:', value);
-  });
   return hpArticles;
 }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -808,6 +808,42 @@ export async function getArticle(id) {
   return articlesData.getBasicArticle.data;
 }
 
+export async function getMostRecentArticle(locale, slug, apiUrl) {
+  if (apiUrl === undefined) {
+    apiUrl = CONTENT_DELIVERY_API_URL;
+  }
+  const webinyHeadlessCms = new GraphQLClient(apiUrl, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(SEARCH_ARTICLES, {
+    where: {
+      availableLocales_contains: locale.code,
+    },
+  });
+  let articleData;
+  try {
+    articleData = articlesData.articles.listArticles.data[0];
+  } catch (e) {
+    console.log('error grabbing first article:', e);
+    return null;
+  }
+  let localisedContent;
+  localisedContent = articleData.content.values.find(
+    (item) => item.locale === locale.id
+  );
+
+  try {
+    articleData.content = JSON.parse(localisedContent.value);
+  } catch (e) {
+    console.log(slug, 'failed parsing json:', e);
+    articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
+  }
+  return articleData;
+}
+
 export async function getArticleBySlug(locale, slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;
@@ -820,18 +856,30 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
 
   const articlesData = await webinyHeadlessCms.request(GET_ARTICLE_BY_SLUG, {
     where: {
+      availableLocales_contains: locale.code,
       slug: slug,
     },
   });
-  let articleData = articlesData.articles.listArticles.data[0];
-  let localisedContent = articleData.content.values.find(
-    (item) => item.locale === locale.id
-  );
+  let articleData;
+  let localisedContent;
+  if (
+    articlesData &&
+    articlesData.articles &&
+    articlesData.listArticles &&
+    articlesData.articles.listArticles.data &&
+    articlesData.articles.listArticles.data[0]
+  ) {
+    articleData = articlesData.articles.listArticles.data[0];
+    localisedContent = articleData.content.values.find(
+      (item) => item.locale === locale.id
+    );
+  } else {
+    return null;
+  }
 
   try {
     articleData.content = JSON.parse(localisedContent.value);
   } catch (e) {
-    console.log(slug, 'failed parsing json:', e);
     articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
   }
   return articleData;
@@ -864,6 +912,7 @@ export async function getHomepageArticles(locale, hpData) {
         (async () => {
           foundArticle = await getArticleBySlug(locale, values);
           hpArticles[key] = foundArticle;
+          console.log('hpArticles[key]:', hpArticles[key]);
         })();
       } else {
         let foundArticles;
@@ -875,6 +924,9 @@ export async function getHomepageArticles(locale, hpData) {
     });
   }
 
+  Object.entries(hpArticles).map(([key, value]) => {
+    console.log('key:', key, 'value:', value);
+  });
   return hpArticles;
 }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -324,7 +324,7 @@ export async function listAllLocales() {
 
   const response = await webinyHeadlessCms.request(LIST_LOCALES);
 
-  return response.data.i18n.listI18NLocales.data;
+  return response.i18n.listI18NLocales.data;
 }
 
 export async function listAllSections() {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,4 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
+import { localiseText } from './utils';
 
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
@@ -59,17 +60,20 @@ const LIST_ARTICLES_REVERSE_CHRON = `
   listArticles(sort: {firstPublishedOn: -1}) {
     data {
       id
+      availableLocales
       headlineSearch
       firstPublishedOn
-        lastPublishedOn
+      lastPublishedOn
       slug
       headline {
         values {
+          locale
           value
         }
       }
       content {
         values {
+          locale
           value
         }
       }
@@ -77,6 +81,7 @@ const LIST_ARTICLES_REVERSE_CHRON = `
         id
         title {
           values {
+            locale
             value
           }
         }
@@ -86,6 +91,7 @@ const LIST_ARTICLES_REVERSE_CHRON = `
         id
         title{
           values {
+            locale
             value
           }
         }
@@ -446,25 +452,16 @@ export async function listAllArticles() {
   return articlesData.articles.listArticles.data;
 }
 
-export async function listMostRecentArticles() {
-  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-    },
-  });
-
-  const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES_REVERSE_CHRON
+export async function listMostRecentArticles(locale) {
+  const articlesData = await listArticlesInLocale(
+    CONTENT_DELIVERY_API_URL,
+    CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    locale.code
   );
-  articlesData.articles.listArticles.data.map((article) => {
+  articlesData.map((article) => {
     let articleContent;
-    if (
-      article.content &&
-      article.content.values &&
-      article.content.values[0] &&
-      article.content.values[0].value
-    ) {
-      articleContent = article.content.values[0].value;
+    if (article.content && article.content.values) {
+      articleContent = localiseText(locale, article.content);
     }
     try {
       article.content = JSON.parse(articleContent);
@@ -474,7 +471,7 @@ export async function listMostRecentArticles() {
       article.content = null;
     }
   });
-  return articlesData.articles.listArticles.data;
+  return articlesData;
 }
 
 export async function listArticlesBySlug(slugs) {
@@ -827,11 +824,9 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
     },
   });
   let articleData = articlesData.articles.listArticles.data[0];
-  console.log('looking for', locale, 'in articleData', articleData.content);
   let localisedContent = articleData.content.values.find(
     (item) => item.locale === locale.id
   );
-  console.log('localised content:', localisedContent);
 
   try {
     articleData.content = JSON.parse(localisedContent.value);
@@ -971,19 +966,22 @@ export async function listAuthors() {
 const SEARCH_ARTICLES = `
 query SearchArticles($where: ArticleListWhere) {
   articles {
-    listArticles(where: $where) {
+    listArticles(sort: {firstPublishedOn: -1}, where: $where) {
       data {
         id
+        availableLocales
         headlineSearch
         firstPublishedOn
         slug
         headline {
           values {
+            locale
             value
           }
         }
         content {
           values {
+            locale
             value
           }
         }
@@ -991,6 +989,7 @@ query SearchArticles($where: ArticleListWhere) {
           id
           title {
             values {
+              locale
               value
             }
           }
@@ -998,8 +997,9 @@ query SearchArticles($where: ArticleListWhere) {
         }
         tags {
           id
-          title{
+          title {
             values {
+              locale
               value
             }
           }
@@ -1059,4 +1059,24 @@ export async function searchArticles(url, token, term) {
   });
 
   return articles;
+}
+
+export async function listArticlesInLocale(url, token, locale) {
+  const webinyHeadlessCms = new GraphQLClient(url, {
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const variables = {
+    where: {
+      availableLocales_contains: locale,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    SEARCH_ARTICLES,
+    variables
+  );
+
+  return articlesData.articles.listArticles.data;
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -524,14 +524,22 @@ export async function listArticlesBySlug(slugs) {
   return articlesData.articles.listArticles.data;
 }
 
-export async function listAllArticlesByTag(tag) {
+export async function listAllArticlesByTag(locale, tag) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
+  const variables = {
+    where: {
+      availableLocales_contains: locale.code,
+    },
+  };
+  const articlesData = await webinyHeadlessCms.request(
+    LIST_ARTICLES,
+    variables
+  );
   let articlesByTag = [];
   articlesData.articles.listArticles.data.map((article) => {
     if (article.tags !== null && article.tags !== undefined) {
@@ -549,10 +557,16 @@ export async function listAllArticlesByTag(tag) {
   });
 
   articlesByTag.map((article) => {
+    let articleContent;
+    if (article.content && article.content.values) {
+      articleContent = localiseText(locale, article.content);
+    }
     try {
-      article.content = JSON.parse(article.content.values[0].value);
+      article.content = JSON.parse(articleContent);
     } catch (e) {
-      console.log('error parsing json:', e);
+      console.log('error parsing json article content:', articleContent);
+      console.log(e);
+      article.content = null;
     }
   });
 
@@ -884,12 +898,13 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
       slug: slug,
     },
   });
+  // console.log("articlesData:", articlesData.articles.listArticles.data[0].content.values);
   let articleData;
   let localisedContent;
   if (
     articlesData &&
     articlesData.articles &&
-    articlesData.listArticles &&
+    articlesData.articles.listArticles &&
     articlesData.articles.listArticles.data &&
     articlesData.articles.listArticles.data[0]
   ) {
@@ -906,6 +921,7 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
   } catch (e) {
     articleData.content = JSON.parse(articleData.content.values[0].value); // for now fallback to the default locale; TODO revisit this
   }
+
   return articleData;
 }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -416,7 +416,7 @@ export async function listAllAuthorPaths() {
   return slugs;
 }
 
-export async function listAllTagPaths() {
+export async function listAllTagPaths(locales) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
       authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
@@ -425,13 +425,17 @@ export async function listAllTagPaths() {
 
   const tagsData = await webinyHeadlessCms.request(LIST_TAGS);
 
-  const slugs = tagsData.tags.listTags.data.map((tag) => {
-    return {
-      params: {
-        slug: tag.slug,
-      },
-    };
-  });
+  let slugs = [];
+  for (const locale of locales) {
+    tagsData.tags.listTags.data.map((tag) => {
+      slugs.push({
+        params: {
+          slug: tag.slug,
+        },
+        locale,
+      });
+    });
+  }
   return slugs;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,9 +21,6 @@ export const localiseText = (locale, field) => {
 };
 
 export const renderAuthor = (author, i) => {
-  if (author === undefined) {
-    return null;
-  }
   if (author.slug !== null && author.slug !== undefined) {
     return (
       <Link href={`/authors/${author.slug}`} key={`${author.slug}-${i}`}>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,9 @@ export const localiseText = (locale, field) => {
 };
 
 export const renderAuthor = (author, i) => {
+  if (author === undefined) {
+    return null;
+  }
   if (author.slug !== null && author.slug !== undefined) {
     return (
       <Link href={`/authors/${author.slug}`} key={`${author.slug}-${i}`}>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,20 @@ import ListNode from '../components/nodes/ListNode.js';
 import TextNode from '../components/nodes/TextNode.js';
 import ImageWithTextAd from '../components/ads/ImageWithTextAd.js';
 
+export const localiseText = (locale, field) => {
+  let localisedValue;
+  let text = 'NEEDS TRANSLATION'; // for now, default to this so it's obvious what's missing
+
+  if (field && field.values) {
+    localisedValue = field.values.find((item) => item.locale === locale.id);
+    if (localisedValue) {
+      text = localisedValue.value;
+    }
+  }
+
+  return text;
+};
+
 export const renderAuthor = (author, i) => {
   if (author.slug !== null && author.slug !== undefined) {
     return (

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,3 @@
+export default function Custom404() {
+  return <h1>404 - Page Not Found (TODO: customise this)</h1>;
+}

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -14,7 +14,13 @@ import GlobalNav from '../components/nav/GlobalNav.js';
 import GlobalFooter from '../components/nav/GlobalFooter.js';
 import { useAmp } from 'next/amp';
 
-export default function CategoryPage({ articles, title, sections, tags }) {
+export default function CategoryPage({
+  locale,
+  articles,
+  title,
+  sections,
+  tags,
+}) {
   const isAmp = useAmp();
   siteMetadata.tags = tags;
 
@@ -34,7 +40,12 @@ export default function CategoryPage({ articles, title, sections, tags }) {
           <div className="columns">
             <div className="column is-four-fifths">
               {articles.map((article) => (
-                <ArticleLink key={article.id} article={article} amp={isAmp} />
+                <ArticleLink
+                  key={article.id}
+                  locale={locale}
+                  article={article}
+                  amp={isAmp}
+                />
               ))}
             </div>
           </div>
@@ -53,7 +64,7 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params }) {
+export async function getStaticProps({ locale, params }) {
   const articles = await listAllArticlesBySection(params.category);
   const sections = await listAllSections();
   // const sections = await cachedContents('sections', listAllSections);
@@ -76,6 +87,7 @@ export async function getStaticProps({ params }) {
   }
   return {
     props: {
+      locale,
       articles,
       title,
       tags,

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -17,11 +17,11 @@ import GlobalFooter from '../components/nav/GlobalFooter.js';
 import { useAmp } from 'next/amp';
 
 export default function CategoryPage({
-  currentLocale,
   articles,
-  title,
+  currentLocale,
   sections,
   tags,
+  title,
 }) {
   const isAmp = useAmp();
   siteMetadata.tags = tags;
@@ -34,7 +34,7 @@ export default function CategoryPage({
   }
 
   return (
-    <Layout meta={siteMetadata}>
+    <Layout meta={siteMetadata} locale={currentLocale}>
       <GlobalNav sections={sections} />
       <div className="container">
         <section className="section">
@@ -93,10 +93,10 @@ export async function getStaticProps({ locale, params }) {
   }
   return {
     props: {
-      currentLocale,
       articles,
-      title,
+      currentLocale,
       tags,
+      title,
       sections,
     },
   };

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,16 +1,21 @@
 import { useAmp } from 'next/amp';
-import { getAboutPage, listAuthors, listAllSections } from '../lib/articles.js';
+import {
+  listAllLocales,
+  getAboutPage,
+  listAuthors,
+  listAllSections,
+} from '../lib/articles.js';
 import { cachedContents } from '../lib/cached';
 import Layout from '../components/Layout';
 import GlobalNav from '../components/nav/GlobalNav';
 import GlobalFooter from '../components/nav/GlobalFooter';
 import { renderBody } from '../lib/utils.js';
 
-export default function About({ data, authors, sections }) {
+export default function About({ data, authors, currentLocale, sections }) {
   const isAmp = useAmp();
   const body = renderBody(data, isAmp);
   return (
-    <Layout meta={data}>
+    <Layout meta={data} locale={currentLocale}>
       <GlobalNav sections={sections} />
       <article className="container">
         <section className="section" key="body">
@@ -50,7 +55,13 @@ export default function About({ data, authors, sections }) {
   );
 }
 
-export async function getStaticProps() {
+export async function getStaticProps({ locale }) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === locale
+  );
+
   //    get about page contents
   const data = await getAboutPage();
   const authors = await listAuthors();
@@ -59,6 +70,7 @@ export async function getStaticProps() {
     props: {
       data,
       authors,
+      currentLocale,
       sections,
     },
   };

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -32,7 +32,7 @@ export default function ArticlePage(props) {
 
   // trying to fix build errors...
   if (!props.article) {
-    console.log('ArticlePage no article prop found:', props);
+    console.log('ArticlePage no article prop found:', router.pathname);
     return (
       <>
         <h1>404 Page Not Found</h1>

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import DefaultErrorPage from 'next/error';
+import React, { useEffect } from 'react';
 import {
   listAllLocales,
   getArticleBySlug,
@@ -20,17 +20,25 @@ export default function ArticlePage(props) {
   // initially until getStaticProps() finishes running
   // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
   if (router.isFallback) {
+    console.log('router is fallback', router.pathname);
     return <div>Loading...</div>;
   }
 
+  useEffect(() => {
+    if (!props.article) {
+      router.push('/404');
+    }
+  }, [props.article]);
+
+  // trying to fix build errors...
   if (!props.article) {
+    console.log('ArticlePage no article prop found:', props);
     return (
-      <div>
-        <DefaultErrorPage statusCode={404} />
-      </div>
+      <>
+        <h1>404 Page Not Found</h1>
+      </>
     );
   }
-
   return <Article {...props} />;
 }
 

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -1,4 +1,5 @@
 import {
+  listAllLocales,
   getArticleBySlug,
   listAllArticleSlugs,
   listAllSections,
@@ -32,8 +33,17 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params }) {
-  const article = await getArticleBySlug(params.slug);
+export async function getStaticProps({ locale, params }) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === locale
+  );
+  // console.log("article page currentLocale:", currentLocale);
+
+  const article = await getArticleBySlug(currentLocale, params.slug);
+  // console.log("article page article:", article);
+
   const tags = await cachedContents('tags', listAllTags);
   const sections = await cachedContents('sections', listAllSections);
   const allAds = await cachedContents('ads', getArticleAds);
@@ -41,6 +51,7 @@ export async function getStaticProps({ params }) {
 
   return {
     props: {
+      currentLocale,
       article,
       sections,
       tags,

--- a/pages/index.js
+++ b/pages/index.js
@@ -124,7 +124,7 @@ export async function getStaticProps({ locale }) {
   const hpArticles = await getHomepageArticles(currentLocale, hpData);
   // const hpArticles = { "featured": ""}
 
-  const streamArticles = await listMostRecentArticles();
+  const streamArticles = await listMostRecentArticles(currentLocale);
 
   const sections = await cachedContents('sections', listAllSections);
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,6 +94,7 @@ export default function Home({
                   mostRecentArticles.map((streamArticle) => (
                     <ArticleLink
                       key={streamArticle.id}
+                      locale={currentLocale}
                       article={streamArticle}
                       amp={isAmp}
                     />

--- a/pages/index.js
+++ b/pages/index.js
@@ -68,7 +68,7 @@ export default function Home({
 
   return (
     <div className="homepage">
-      <Layout meta={siteMetadata}>
+      <Layout meta={siteMetadata} locale={currentLocale}>
         <GlobalNav metadata={siteMetadata} sections={sections} />
         <div className="container">
           {hpData.layoutComponent === 'BigFeaturedStory' && (

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -18,7 +18,7 @@ export default function TagPage(props) {
   const isAmp = useAmp();
   let tagTitle = localiseText(props.currentLocale, props.tag.title);
   return (
-    <Layout meta={siteMetadata}>
+    <Layout meta={siteMetadata} locale={props.currentLocale}>
       <GlobalNav sections={props.sections} />
       <div className="container">
         <section className="section">

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -14,7 +14,7 @@ import { useAmp } from 'next/amp';
 
 export default function TagPage(props) {
   const isAmp = useAmp();
-  let tagTitle = props.tag.title.values[0].value;
+  let tagTitle = localiseText(props.currentLocale, props.tag.title);
   return (
     <Layout meta={siteMetadata}>
       <GlobalNav sections={props.sections} />
@@ -24,7 +24,12 @@ export default function TagPage(props) {
           <div className="columns">
             <div className="column is-four-fifths">
               {props.articles.map((article) => (
-                <ArticleLink key={article.id} article={article} amp={isAmp} />
+                <ArticleLink
+                  key={article.id}
+                  locale={props.currentLocale}
+                  article={article}
+                  amp={isAmp}
+                />
               ))}
             </div>
           </div>
@@ -43,12 +48,19 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params }) {
-  const articles = await listAllArticlesByTag(params.slug);
+export async function getStaticProps({ locale, params }) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === locale
+  );
+
+  const articles = await listAllArticlesByTag(currentLocale, params.slug);
   const sections = await cachedContents('sections', listAllSections);
   const tag = await getTagBySlug(params.slug);
   return {
     props: {
+      currentLocale,
       articles,
       tag,
       sections,

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -1,12 +1,14 @@
 import Layout from '../../components/Layout.js';
 import ArticleLink from '../../components/homepage/ArticleLink.js';
 import {
+  listAllLocales,
   listAllArticlesByTag,
   listAllSections,
   listAllTagPaths,
   getTagBySlug,
 } from '../../lib/articles.js';
 import { cachedContents } from '../../lib/cached';
+import { localiseText } from '../../lib/utils.js';
 import { siteMetadata } from '../../lib/siteMetadata.js';
 import GlobalNav from '../../components/nav/GlobalNav.js';
 import GlobalFooter from '../../components/nav/GlobalFooter.js';
@@ -49,12 +51,14 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ locale, params }) {
+  console.log('getStaticProps tag page');
   const localeMappings = await cachedContents('locales', listAllLocales);
 
   const currentLocale = localeMappings.find(
     (localeMap) => localeMap.code === locale
   );
 
+  console.log('currentLocale:', currentLocale);
   const articles = await listAllArticlesByTag(currentLocale, params.slug);
   const sections = await cachedContents('sections', listAllSections);
   const tag = await getTagBySlug(params.slug);

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -42,8 +42,8 @@ export default function TagPage(props) {
   );
 }
 
-export async function getStaticPaths() {
-  const paths = await listAllTagPaths();
+export async function getStaticPaths({ locales }) {
+  const paths = await listAllTagPaths(locales);
   return {
     paths,
     fallback: false,
@@ -51,14 +51,12 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ locale, params }) {
-  console.log('getStaticProps tag page');
   const localeMappings = await cachedContents('locales', listAllLocales);
 
   const currentLocale = localeMappings.find(
     (localeMap) => localeMap.code === locale
   );
 
-  console.log('currentLocale:', currentLocale);
   const articles = await listAllArticlesByTag(currentLocale, params.slug);
   const sections = await cachedContents('sections', listAllSections);
   const tag = await getTagBySlug(params.slug);

--- a/script/populate.js
+++ b/script/populate.js
@@ -16,6 +16,39 @@ function writeCache(name, data) {
   });
 }
 
+function listLocales() {
+  const query = `
+    query ListI18nLocales {
+      i18n {
+        listI18NLocales {
+          data {
+            id
+            code
+            default
+          }
+        }
+      }
+    }
+  `;
+
+  const url = CONTENT_DELIVERY_API_URL;
+  let opts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query }),
+  };
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((responseParsed) => {
+      let locales = responseParsed.data.i18n.listI18NLocales.data;
+      writeCache('locales', locales);
+    })
+    .catch(console.error);
+}
+
 function listSections() {
   const query = `
     {
@@ -107,6 +140,7 @@ function getAds() {
 }
 
 async function main() {
+  listLocales();
   listSections();
   listTags();
   getAds();


### PR DESCRIPTION
This PR localises the article page and the author + tag index pages:

* [example article page in spanish](http://localhost:3000/es/articles/pandemic/a-culture-of-exploitation-emerges-after-onset-of-coronavirus)
* [example tag index page in spanish](http://localhost:3000/es/tags/pandemic)
* [example author page in spanish](http://localhost:3000/es/authors/jacqui-lough)

This PR also includes a lot of fixes to the build - some were related to i18n, like spots I missed passing the locale; others were related to AMP; and few more that I then caused trying to fix the previous issues. Fun times. Hopefully this all builds properly now AND runs well in dev mode.

I've logged an issue to sort out translating tags as well.