### PR TITLE
Fresh client start homepage fix

### DIFF
--- a/components/homepage/Placeholder.js
+++ b/components/homepage/Placeholder.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Placeholder() {
+  return (
+    <>
+      <h1>Coming soon.</h1>
+    </>
+  );
+}

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -47,6 +47,11 @@ export async function getHomepageData() {
     // let articlesBySection = [];
     let currentHomepageData =
       homepageData.homepageLayoutDatas.listHomepageLayoutDatas.data[0];
+
+    if (!currentHomepageData) {
+      return null;
+    }
+
     let layoutComponentName = _.upperFirst(
       _.camelCase(currentHomepageData.layoutSchema.name)
     );

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,7 @@ import { siteMetadata } from '../lib/siteMetadata.js';
 import GlobalNav from '../components/nav/GlobalNav';
 import GlobalFooter from '../components/nav/GlobalFooter';
 import ArticleLink from '../components/homepage/ArticleLink';
+import Placeholder from '../components/homepage/Placeholder';
 
 const BigFeaturedStory = dynamic(() =>
   import(`../components/homepage/BigFeaturedStory`)
@@ -71,7 +72,8 @@ export default function Home({
       <Layout meta={siteMetadata} locale={currentLocale}>
         <GlobalNav metadata={siteMetadata} sections={sections} />
         <div className="container">
-          {hpData.layoutComponent === 'BigFeaturedStory' && (
+          {!hpData && <Placeholder />}
+          {hpData && hpData.layoutComponent === 'BigFeaturedStory' && (
             <BigFeaturedStory
               locale={currentLocale}
               articles={hpArticles}
@@ -81,7 +83,7 @@ export default function Home({
               isAmp={isAmp}
             />
           )}
-          {hpData.layoutComponent === 'LargePackageStoryLead' && (
+          {hpData && hpData.layoutComponent === 'LargePackageStoryLead' && (
             <LargePackageStoryLead
               locale={currentLocale}
               articles={hpArticles}


### PR DESCRIPTION
The homepage wasn't rendering on a fresh install of this front-end site. This PR fixes that by replacing the dynamic content with a static Placeholder component that we can customize in the future.