### PR TITLE
Small change: redirect to authors index after create/update

### DIFF
--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -29,6 +29,8 @@ export default function EditAuthor({
   const [authorId, setAuthorId] = useState(null);
   const [staffYesNo, setStaffYesNo] = useState('no');
 
+  const router = useRouter();
+
   useEffect(() => {
     if (author) {
       setI18nTitleValues(author.title.values);
@@ -59,7 +61,6 @@ export default function EditAuthor({
       }
     }
   }, []);
-  const router = useRouter();
 
   const handleChange = (ev) => {
     if (ev.target.value === 'yes') {
@@ -124,6 +125,7 @@ export default function EditAuthor({
       setNotificationMessage('Successfully saved and published the author!');
       setNotificationType('success');
       setShowNotification(true);
+      router.push('/tinycms/authors?action=edit');
     }
   }
 

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
@@ -17,6 +18,8 @@ export default function AddAuthor({ apiUrl, apiToken, currentLocale }) {
   const [slug, setSlug] = useState('');
   const [staff, setStaff] = useState('no');
   const [bio, setBio] = useState('');
+
+  const router = useRouter();
 
   const handleChange = (ev) => setStaff(ev.target.value);
 
@@ -44,6 +47,8 @@ export default function AddAuthor({ apiUrl, apiToken, currentLocale }) {
       setNotificationMessage('Successfully saved and published the author!');
       setNotificationType('success');
       setShowNotification(true);
+
+      router.push('/tinycms/authors?action=create');
     }
   }
 

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -3,23 +3,31 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
+import Notification from '../../../components/tinycms/Notification';
 import { listAllLocales } from '../../../lib/articles.js';
 import { listAllAuthors } from '../../../lib/authors.js';
 import { localiseText } from '../../../lib/utils.js';
 import { cachedContents } from '../../../lib/cached';
 
 export default function Authors({ authors, currentLocale }) {
-  const [message, setMessage] = useState(null);
+  // const [message, setMessage] = useState(null);
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [notificationType, setNotificationType] = useState('');
+  const [showNotification, setShowNotification] = useState(false);
 
   const router = useRouter();
   const { action } = router.query;
 
   useEffect(() => {
     if (action && action === 'edit') {
-      setMessage('Successfully updated author.');
+      setNotificationMessage('Successfully updated author.');
+      setNotificationType('success');
+      setShowNotification(true);
     }
     if (action && action === 'create') {
-      setMessage('Successfully created author.');
+      setNotificationMessage('Successfully created author.');
+      setNotificationType('success');
+      setShowNotification(true);
     }
   }, []);
 
@@ -39,12 +47,19 @@ export default function Authors({ authors, currentLocale }) {
 
   return (
     <AdminLayout>
-      <AdminNav />
+      <AdminNav homePageEditor={false} />
+      {showNotification && (
+        <Notification
+          message={notificationMessage}
+          setShowNotification={setShowNotification}
+          notificationType={notificationType}
+        />
+      )}
       <div id="page">
         <h1 className="title">Authors</h1>
         <Link href="/tinycms/authors/add">Add Author</Link>
 
-        {message && <div className="success">{message}</div>}
+        {/* {message && <div className="success">{message}</div>} */}
         <ul>{listItems}</ul>
       </div>
     </AdminLayout>


### PR DESCRIPTION
Issue #213 

This is a tiny change that means adding or editing an author redirects you back to the index page (/tinycms/authors). I'm using a query string to display the success notification - I wasn't sure how else to do this without the store, but I'm happy to update to some better way if you know of it. 

I didn't think any of the toast libraries that work well with react would work in this situation (do an api call, redirect, display a message) but I could very well be wrong.