### PR TITLE
Site metadata now supports translations of data

### DIFF
--- a/components/tinycms/CreateSiteMetadata.js
+++ b/components/tinycms/CreateSiteMetadata.js
@@ -23,6 +23,7 @@ export default function AddMetadata(props) {
     const response = await createSiteMetadata(
       props.apiUrl,
       props.apiToken,
+      props.currentLocale,
       data
     );
 

--- a/components/tinycms/UpdateSiteMetadata.js
+++ b/components/tinycms/UpdateSiteMetadata.js
@@ -22,10 +22,19 @@ export default function UpdateMetadata(props) {
 
   useEffect(() => {
     if (props.metadata) {
-      let parsed = props.metadata.data;
-      if (typeof props.metadata.data === 'string') {
-        parsed = JSON.parse(props.metadata.data);
+      let localisedData = props.metadata.data.values.find(
+        (item) => item.locale === props.currentLocale.id
+      );
+
+      let parsed = {};
+      if (
+        localisedData &&
+        localisedData.value &&
+        typeof localisedData.value === 'string'
+      ) {
+        parsed = JSON.parse(localisedData.value);
       }
+
       Object.keys(parsed).map((key) => {
         if (typeof parsed[key] !== 'string') {
           parsed[key] = JSON.stringify(parsed[key]);
@@ -45,11 +54,28 @@ export default function UpdateMetadata(props) {
   async function handleSubmit(ev) {
     ev.preventDefault();
 
+    console.log('data:', data);
+    console.log('parsedData:', parsedData);
+
+    let parsed = parsedData;
+    if (data && Object.keys(parsedData).length === 0) {
+      console.log('Populating new locale site metadata');
+      parsed = JSON.parse(data);
+      Object.keys(parsed).map((key) => {
+        if (typeof parsed[key] !== 'string') {
+          parsed[key] = JSON.stringify(parsed[key]);
+        }
+      });
+      setParsedData(parsed);
+      console.log('parsed:', parsedData);
+    }
+    // return;
     const response = await updateSiteMetadata(
       props.apiUrl,
       props.apiToken,
-      props.metadata.id,
-      parsedData
+      props.metadata,
+      props.currentLocale,
+      parsed
     );
 
     if (response.siteMetadatas.updateSiteMetadata.error !== null) {
@@ -81,6 +107,21 @@ export default function UpdateMetadata(props) {
           <pre>{data}</pre>
         </div>
       </div>
+      {Object.keys(parsedData).length === 0 && (
+        <div className="field">
+          <label className="label" htmlFor="name">
+            Data: enter as JSON
+          </label>
+          <div className="control">
+            <textarea
+              className="textarea"
+              name="data"
+              value={data}
+              onChange={(ev) => setData(ev.target.value)}
+            />
+          </div>
+        </div>
+      )}
       {Object.keys(parsedData).map((key) => (
         <div className="field" key={key}>
           <label className="label" htmlFor={key}>

--- a/lib/site_metadata.js
+++ b/lib/site_metadata.js
@@ -10,7 +10,12 @@ const LIST_METADATA = `{
     listSiteMetadatas {
       data {
         id
-        data
+        data {
+          values {
+            locale
+            value
+          }
+        }
         published
         firstPublishedOn
         lastPublishedOn
@@ -21,7 +26,7 @@ const LIST_METADATA = `{
 
 // this always lists the metadata and grabs the most recent one
 // NOTE: there should only be one record
-export async function getSiteMetadata(apiUrl, apiToken) {
+export async function getSiteMetadata(apiUrl, apiToken, locale) {
   const webinyHeadlessCms = new GraphQLClient(apiUrl, {
     headers: {
       authorization: apiToken,
@@ -32,15 +37,25 @@ export async function getSiteMetadata(apiUrl, apiToken) {
 
   const metadataRecords = response.siteMetadatas.listSiteMetadatas.data;
   let metadata = metadataRecords[0];
-  if (metadata && metadata.data !== null && metadata.data !== undefined) {
-    metadata.data = JSON.parse(metadata.data);
-    return metadata;
-  } else if (metadata) {
+  if (metadata && (metadata.data === null || metadata.data === undefined)) {
     metadata.data = {};
-    return metadata;
-  } else {
-    return null;
+    // } else {
+    //   console.log("metadata from getSiteMetadata:", metadata);
   }
+  return metadata;
+  // if (metadata && metadata.data !== null && metadata.data !== undefined && metadata.data.values) {
+  //   let localisedData = metadata.data.values.find(
+  //     (item) => item.locale === locale.id
+  //   );
+  //   console.log("localised metadata:", localisedData);
+  //   metadata.data = JSON.parse(localisedData.value);
+  //   return metadata;
+  // } else if (metadata) {
+  //   metadata.data = {};
+  //   return metadata;
+  // } else {
+  //   return null;
+  // }
 }
 
 const CREATE_METADATA = `mutation CreateSiteMetadata($data: SiteMetadataInput!) {
@@ -48,7 +63,12 @@ const CREATE_METADATA = `mutation CreateSiteMetadata($data: SiteMetadataInput!) 
       createSiteMetadata(data: $data) {
         data {
           id
-          data
+          data {
+            values { 
+              locale
+              value
+            }
+          }
           published
           firstPublishedOn
           lastPublishedOn
@@ -62,7 +82,7 @@ const CREATE_METADATA = `mutation CreateSiteMetadata($data: SiteMetadataInput!) 
   }
 }`;
 
-export async function createSiteMetadata(url, token, data) {
+export async function createSiteMetadata(url, token, locale, data) {
   const webinyHeadlessCms = new GraphQLClient(url, {
     headers: {
       authorization: token,
@@ -71,7 +91,14 @@ export async function createSiteMetadata(url, token, data) {
 
   const variables = {
     data: {
-      data: JSON.stringify(data),
+      data: {
+        values: [
+          {
+            value: data,
+            locale: locale.id,
+          },
+        ],
+      },
       published: true,
     },
   };
@@ -88,7 +115,12 @@ const UPDATE_METADATA = `mutation UpdateSiteMetadata($id: ID!, $data: SiteMetada
     updateSiteMetadata(id: $id, data: $data) {
       data {
         id
-        data
+        data {
+          values {
+            locale
+            value
+          }
+        }
         published
         firstPublishedOn
         lastPublishedOn
@@ -102,7 +134,35 @@ const UPDATE_METADATA = `mutation UpdateSiteMetadata($id: ID!, $data: SiteMetada
   }
 }`;
 
-export async function updateSiteMetadata(url, token, id, data) {
+export async function updateSiteMetadata(
+  url,
+  token,
+  previousMetadata,
+  locale,
+  data
+) {
+  let id = previousMetadata.id;
+  console.log('previousMetadata:', previousMetadata, 'new data:', data);
+  // let dataValues = [];
+  let foundIt = false;
+  // look for content in the specified locale; if it exists, update the data
+  previousMetadata.data.values.map((item) => {
+    if (item.locale === locale.id) {
+      foundIt = true;
+      console.log('found previous entry for this locale:', item);
+      item.value = JSON.stringify(data);
+      console.log('updated entry:', item);
+    }
+  });
+
+  // if we didn't find data for the specified locale, we should add it to the array
+  if (!foundIt) {
+    previousMetadata.data.values.push({
+      value: JSON.stringify(data),
+      locale: locale.id,
+    });
+  }
+
   const webinyHeadlessCms = new GraphQLClient(url, {
     headers: {
       authorization: token,
@@ -112,7 +172,9 @@ export async function updateSiteMetadata(url, token, id, data) {
   const variables = {
     id: id,
     data: {
-      data: JSON.stringify(data),
+      data: {
+        values: previousMetadata.data.values,
+      },
       published: true,
     },
   };


### PR DESCRIPTION
Issue #212 

This PR adds i18n support to the site metadata in the tinycms (http://localhost:3000/tinycms/config/metadata & http://localhost:3000/es/tinycms/config/metadata for example).

So now the logic goes:

* if no site metadata exists, display a textarea for the blob of json & create a new record with content stored in the current locale on submit
* if a site metadata record exists & there is content in the current locale, parse the data and display multiple form fields; update the content in the current locale on submit
* if a site metadata record exists & there is NO content in the current locale, display a textarea & update the existing record with content stored in the current locale, while preserving existing content in other locales. Then parse the data and show the separate form fields instead of the textarea.

Note: I need to do some basic UI / UX updates on the "tinycms" - it's kind of, um, lacking at the moment, especially the navigation. This will include a locale switcher. Right now the only way to access the translations for any given content - authors, categories, metadata - is by adding a locale `es` to the URL.

Also, this required a schema change in the API which has already been deployed to the current prod API at https://d19u1w7eqbvlum.cloudfront.net/graphql