### PR TITLE
removed useEffect from article header

### DIFF
--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -7,12 +7,10 @@ export default function ArticleHeader({ article, locale }) {
   let categoryTitle;
   let headline;
 
-  useEffect(() => {
-    if (article && article.category) {
-      categoryTitle = localiseText(locale, article.category.title);
-      headline = localiseText(locale, article.headline);
-    }
-  }, [article]);
+  if (article && article.category) {
+    categoryTitle = localiseText(locale, article.category.title);
+    headline = localiseText(locale, article.headline);
+  }
 
   if (!article) {
     return null;

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -338,6 +338,47 @@ const LIST_TAGS = `{
   }
 }`;
 
+const UPDATE_TAG = `mutation UpdateTag($id: ID!, $data: TagInput!) {
+  tags {
+    updateTag(id: $id, data: $data) {
+      data {
+        id
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        published
+        slug
+      }
+      error {
+        code
+        data
+        message
+      }
+    }
+  }
+}`;
+
+const GET_TAG_BY_ID = `query GetTag($id: ID!) {
+  tags {
+		getTag(id: $id) {
+      data {
+        id
+        published
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+    }
+  }
+}`;
+
 const GET_AUTHOR_BY_SLUG = `query Author($slug: String) {
   authors {
     listAuthors(where: {slug: $slug}) {
@@ -502,6 +543,7 @@ export async function listAllTags() {
 
   const slugs = tagsData.tags.listTags.data.map((tag) => {
     return {
+      id: tag.id,
       title: tag.title,
       slug: tag.slug,
     };
@@ -1094,6 +1136,21 @@ query Tag($slug: String) {
   }
 }`;
 
+export async function getTag(id) {
+  const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+    },
+  });
+
+  const tagsData = await webinyHeadlessCms.request(GET_TAG_BY_ID, {
+    id: id,
+  });
+  let tag = tagsData.tags.getTag.data;
+  console.log('TAG:', tag);
+  return tag;
+}
+
 export async function getTagBySlug(slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;
@@ -1108,6 +1165,50 @@ export async function getTagBySlug(slug, apiUrl) {
     slug,
   });
   return tagsData.tags.listTags.data[0];
+}
+
+export async function updateTag(url, token, tagId, titleValues, slug) {
+  // let id = previousTag.id;
+  // console.log('previousTag:', previousTag, 'new title:', title);
+  // // let dataValues = [];
+  // let foundIt = false;
+  // // look for content in the specified locale; if it exists, update the data
+  // previousTag.title.values.map((item) => {
+  //   if (item.locale === locale.id) {
+  //     foundIt = true;
+  //     console.log('found previous entry for this locale:', item);
+  //     item.value = JSON.stringify(title);
+  //     console.log('updated entry:', item);
+  //   }
+  // });
+
+  // // if we didn't find data for the specified locale, we should add it to the array
+  // if (!foundIt) {
+  //   previousTag.title.values.push({
+  //     value: JSON.stringify(data),
+  //     locale: locale.id,
+  //   });
+  // }
+
+  const webinyHeadlessCms = new GraphQLClient(url, {
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const variables = {
+    id: tagId,
+    data: {
+      title: {
+        values: titleValues,
+      },
+      slug: slug,
+      published: true,
+    },
+  };
+
+  const responseData = await webinyHeadlessCms.request(UPDATE_TAG, variables);
+  return responseData;
 }
 
 export async function getAuthorBySlug(slug, apiUrl) {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1136,6 +1136,21 @@ query Tag($slug: String) {
   }
 }`;
 
+const CREATE_TAG = `mutation CreateTag($data: TagInput!) {
+  tags {
+   createTag(data: $data) {
+     data {
+       id
+       slug
+     }
+     error {
+       code
+       message
+     }
+   }
+  } 
+ }`;
+
 export async function getTag(id) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -1147,7 +1162,6 @@ export async function getTag(id) {
     id: id,
   });
   let tag = tagsData.tags.getTag.data;
-  console.log('TAG:', tag);
   return tag;
 }
 
@@ -1167,29 +1181,28 @@ export async function getTagBySlug(slug, apiUrl) {
   return tagsData.tags.listTags.data[0];
 }
 
+export async function createTag(url, token, titleValues, slug) {
+  const webinyHeadlessCms = new GraphQLClient(url, {
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const variables = {
+    data: {
+      title: {
+        values: titleValues,
+      },
+      slug: slug,
+      published: true,
+    },
+  };
+
+  const responseData = await webinyHeadlessCms.request(CREATE_TAG, variables);
+  return responseData;
+}
+
 export async function updateTag(url, token, tagId, titleValues, slug) {
-  // let id = previousTag.id;
-  // console.log('previousTag:', previousTag, 'new title:', title);
-  // // let dataValues = [];
-  // let foundIt = false;
-  // // look for content in the specified locale; if it exists, update the data
-  // previousTag.title.values.map((item) => {
-  //   if (item.locale === locale.id) {
-  //     foundIt = true;
-  //     console.log('found previous entry for this locale:', item);
-  //     item.value = JSON.stringify(title);
-  //     console.log('updated entry:', item);
-  //   }
-  // });
-
-  // // if we didn't find data for the specified locale, we should add it to the array
-  // if (!foundIt) {
-  //   previousTag.title.values.push({
-  //     value: JSON.stringify(data),
-  //     locale: locale.id,
-  //   });
-  // }
-
   const webinyHeadlessCms = new GraphQLClient(url, {
     headers: {
       authorization: token,

--- a/pages/tinycms/tags/[id].js
+++ b/pages/tinycms/tags/[id].js
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import AdminLayout from '../../../components/AdminLayout';
+import AdminNav from '../../../components/nav/AdminNav';
+import Notification from '../../../components/tinycms/Notification';
+import { getTag, updateTag, listAllLocales } from '../../../lib/articles.js';
+import { localiseText } from '../../../lib/utils.js';
+import { cachedContents } from '../../../lib/cached';
+
+export default function EditTag({ apiUrl, apiToken, tag, currentLocale }) {
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [notificationType, setNotificationType] = useState('');
+  const [showNotification, setShowNotification] = useState(false);
+
+  const [tagId, setTagId] = useState('');
+  const [title, setTitle] = useState('');
+  const [i18nTitleValues, setI18nTitleValues] = useState([]);
+  const [slug, setSlug] = useState('');
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (tag) {
+      setTagId(tag.id);
+      setI18nTitleValues(tag.title.values);
+
+      if (tag.title && tag.title.values) {
+        let title = localiseText(currentLocale, tag.title);
+        setTitle(title);
+      }
+      if (tag.slug) {
+        setSlug(tag.slug);
+      }
+    }
+  }, []);
+
+  async function handleCancel(ev) {
+    ev.preventDefault();
+    router.push('/tinycms/tags');
+  }
+
+  async function handleSubmit(ev) {
+    ev.preventDefault();
+
+    let foundTitle = false;
+    i18nTitleValues.map((localValue) => {
+      if (localValue.locale === currentLocale.id) {
+        foundTitle = true;
+        localValue.value = title;
+      }
+    });
+    if (!foundTitle) {
+      i18nTitleValues.push({ value: title, locale: currentLocale.id });
+      setI18nTitleValues(i18nTitleValues);
+    }
+
+    const response = await updateTag(
+      apiUrl,
+      apiToken,
+      tagId,
+      i18nTitleValues,
+      slug
+    );
+
+    if (response.tags.updateTag.error !== null) {
+      setNotificationMessage(response.tags.updateTag.error);
+      setNotificationType('error');
+      setShowNotification(true);
+    } else {
+      setTagId(response.tags.updateTag.data.id);
+      // display success message
+      setNotificationMessage('Successfully saved and published the tag!');
+      setNotificationType('success');
+      setShowNotification(true);
+      router.push('/tinycms/tags?action=edit');
+    }
+  }
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+
+      {showNotification && (
+        <Notification
+          message={notificationMessage}
+          setShowNotification={setShowNotification}
+          notificationType={notificationType}
+        />
+      )}
+
+      <div id="page">
+        <h1 className="title">Edit Tag ({currentLocale.code})</h1>
+
+        <form onSubmit={handleSubmit}>
+          <div className="field">
+            <label className="label" htmlFor="slug">
+              Slug
+            </label>
+            <div className="control">
+              <input
+                className="input"
+                type="text"
+                value={slug}
+                name="slug"
+                onChange={(ev) => setSlug(ev.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label className="label" htmlFor="title">
+              Title
+            </label>
+            <div className="control">
+              <input
+                className="input"
+                type="text"
+                value={title}
+                name="title"
+                onChange={(ev) => setTitle(ev.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="field is-grouped">
+            <div className="control">
+              <input
+                className="button is-link"
+                name="submit"
+                type="submit"
+                value="Submit"
+              />
+            </div>
+            <div className="control">
+              <button
+                className="button is-link is-light"
+                name="cancel"
+                onClick={handleCancel}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </AdminLayout>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === context.locale
+  );
+
+  const apiUrl = process.env.CONTENT_DELIVERY_API_URL;
+  const apiToken = process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+  let tag = await getTag(context.params.id);
+  return {
+    props: {
+      apiUrl: apiUrl,
+      apiToken: apiToken,
+      tag: tag,
+      currentLocale: currentLocale,
+    },
+  };
+}

--- a/pages/tinycms/tags/add.js
+++ b/pages/tinycms/tags/add.js
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import AdminLayout from '../../../components/AdminLayout';
+import AdminNav from '../../../components/nav/AdminNav';
+import Notification from '../../../components/tinycms/Notification';
+import { cachedContents } from '../../../lib/cached';
+import { createTag, listAllLocales } from '../../../lib/articles.js';
+
+export default function AddTag({ apiUrl, apiToken, currentLocale }) {
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [notificationType, setNotificationType] = useState('');
+  const [showNotification, setShowNotification] = useState(false);
+
+  // const [tagId, setTagId] = useState('');
+  const [title, setTitle] = useState('');
+  const [i18nTitleValues, setI18nTitleValues] = useState([]);
+  const [slug, setSlug] = useState('');
+
+  const router = useRouter();
+
+  async function handleCancel(ev) {
+    ev.preventDefault();
+    router.push('/tinycms/tags');
+  }
+
+  async function handleSubmit(ev) {
+    ev.preventDefault();
+
+    let foundTitle = false;
+    i18nTitleValues.map((localValue) => {
+      if (localValue.locale === currentLocale.id) {
+        foundTitle = true;
+        localValue.value = title;
+      }
+    });
+    if (!foundTitle) {
+      i18nTitleValues.push({ value: title, locale: currentLocale.id });
+      setI18nTitleValues(i18nTitleValues);
+    }
+
+    const response = await createTag(apiUrl, apiToken, i18nTitleValues, slug);
+
+    if (response.tags.createTag.error !== null) {
+      setNotificationMessage(response.tags.createTag.error);
+      setNotificationType('error');
+      setShowNotification(true);
+    } else {
+      // display success message
+      setNotificationMessage('Successfully saved and published the tag!');
+      setNotificationType('success');
+      setShowNotification(true);
+
+      router.push('/tinycms/tags?action=create');
+    }
+  }
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+
+      {showNotification && (
+        <Notification
+          message={notificationMessage}
+          setShowNotification={setShowNotification}
+          notificationType={notificationType}
+        />
+      )}
+      <div id="page">
+        <h1 className="title">Add a tag</h1>
+
+        <form onSubmit={handleSubmit}>
+          <div className="field">
+            <label className="label" htmlFor="slug">
+              Slug
+            </label>
+            <div className="control">
+              <input
+                className="input"
+                type="text"
+                value={slug}
+                name="slug"
+                onChange={(ev) => setSlug(ev.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="field">
+            <label className="label" htmlFor="title">
+              Title
+            </label>
+            <div className="control">
+              <input
+                className="input"
+                type="text"
+                value={title}
+                name="title"
+                onChange={(ev) => setTitle(ev.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="field is-grouped">
+            <div className="control">
+              <input type="submit" className="button is-link" value="Submit" />
+            </div>
+            <div className="control">
+              <button
+                className="button is-link is-light"
+                onClick={handleCancel}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </AdminLayout>
+  );
+}
+export async function getServerSideProps(context) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === context.locale
+  );
+
+  const apiUrl = process.env.CONTENT_DELIVERY_API_URL;
+  const apiToken = process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+  return {
+    props: {
+      apiUrl: apiUrl,
+      apiToken: apiToken,
+      currentLocale: currentLocale,
+    },
+  };
+}

--- a/pages/tinycms/tags/index.js
+++ b/pages/tinycms/tags/index.js
@@ -9,7 +9,6 @@ import { localiseText } from '../../../lib/utils.js';
 import { cachedContents } from '../../../lib/cached';
 
 export default function Tags({ tags, currentLocale }) {
-  // const [message, setMessage] = useState(null);
   const [notificationMessage, setNotificationMessage] = useState('');
   const [notificationType, setNotificationType] = useState('');
   const [showNotification, setShowNotification] = useState(false);
@@ -37,7 +36,8 @@ export default function Tags({ tags, currentLocale }) {
       <li key={tag.id}>
         <Link key={`${tag.id}-link`} href={`/tinycms/tags/${tag.id}`}>
           <a>{title}</a>
-        </Link>
+        </Link>{' '}
+        ({tag.slug})
       </li>
     );
   });

--- a/pages/tinycms/tags/index.js
+++ b/pages/tinycms/tags/index.js
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import AdminLayout from '../../../components/AdminLayout.js';
+import AdminNav from '../../../components/nav/AdminNav';
+import Notification from '../../../components/tinycms/Notification';
+import { listAllLocales, listAllTags } from '../../../lib/articles.js';
+import { localiseText } from '../../../lib/utils.js';
+import { cachedContents } from '../../../lib/cached';
+
+export default function Tags({ tags, currentLocale }) {
+  // const [message, setMessage] = useState(null);
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [notificationType, setNotificationType] = useState('');
+  const [showNotification, setShowNotification] = useState(false);
+
+  const router = useRouter();
+  const { action } = router.query;
+
+  useEffect(() => {
+    if (action && action === 'edit') {
+      setNotificationMessage('Successfully updated tag.');
+      setNotificationType('success');
+      setShowNotification(true);
+    }
+    if (action && action === 'create') {
+      setNotificationMessage('Successfully created tag.');
+      setNotificationType('success');
+      setShowNotification(true);
+    }
+  }, []);
+
+  const listItems = tags.map((tag) => {
+    let title = localiseText(currentLocale, tag.title);
+
+    return (
+      <li key={tag.id}>
+        <Link key={`${tag.id}-link`} href={`/tinycms/tags/${tag.id}`}>
+          <a>{title}</a>
+        </Link>
+      </li>
+    );
+  });
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+      {showNotification && (
+        <Notification
+          message={notificationMessage}
+          setShowNotification={setShowNotification}
+          notificationType={notificationType}
+        />
+      )}
+      <div id="page">
+        <h1 className="title">Tags</h1>
+        <Link href="/tinycms/tags/add">Add Tag</Link>
+
+        <ul>{listItems}</ul>
+      </div>
+    </AdminLayout>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const localeMappings = await cachedContents('locales', listAllLocales);
+
+  const currentLocale = localeMappings.find(
+    (localeMap) => localeMap.code === context.locale
+  );
+
+  let tags = await listAllTags();
+  return {
+    props: {
+      tags: tags,
+      currentLocale: currentLocale,
+    },
+  };
+}


### PR DESCRIPTION
Issue #220 

I could have sworn that I added the useEffect as a result of an issue building the site (`yarn build`), as it's definitely not my inclination to throw that function into the mix... but removing it caused no issues for me via `yarn dev` or `yarn build` locally.

I should add a caveat that running dev or build _with_ the `useEffect` call also caused no issues for, which is kinda strange. Anyway, this PR removes it from the `ArticleHeader` component. 

I'm moving onto the homepage now, and I'll submit whatever changes that requires as a separate PR.