### PR TITLE
Meta tags content on article pages

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -18,6 +18,7 @@ export default function Layout({ children, locale, meta, article, sections }) {
 
   const metaValues = {
     canonical: meta['siteUrl'],
+    siteName: meta['shortName'],
     searchTitle: meta['searchTitle'],
     searchDescription: meta['searchDescription'],
     facebookTitle: meta['facebookTitle'],
@@ -26,6 +27,25 @@ export default function Layout({ children, locale, meta, article, sections }) {
     twitterDescription: meta['twitterDescription'],
     coverImage: meta['coverImage'],
   };
+  if (article) {
+    metaValues.section = localiseText(locale, article.category.title);
+    metaValues.searchTitle = localiseText(locale, article.searchTitle);
+    metaValues.searchDescription = localiseText(
+      locale,
+      article.searchDescription
+    );
+    metaValues.twitterTitle = localiseText(locale, article.twitterTitle);
+    metaValues.twitterDescription = localiseText(
+      locale,
+      article.twitterDescription
+    );
+    metaValues.facebookTitle = localiseText(locale, article.facebookTitle);
+    metaValues.facebookDescription = localiseText(
+      locale,
+      article.facebookDescription
+    );
+  }
+
   if (article && article.firstPublishedOn) {
     metaValues['firstPublishedOn'] = article.firstPublishedOn;
   }
@@ -82,7 +102,7 @@ export default function Layout({ children, locale, meta, article, sections }) {
           property="og:description"
           content={metaValues.facebookDescription}
         />
-        <meta property="og:site_name" content="Site Name, i.e. Moz" />
+        <meta property="og:site_name" content={metaValues.siteName} />
         <meta
           property="article:published_time"
           content={metaValues.firstPublishedOn}
@@ -91,8 +111,15 @@ export default function Layout({ children, locale, meta, article, sections }) {
           property="article:modified_time"
           content={metaValues.lastPublishedOn}
         />
-        <meta property="article:section" content="Article Section" />
-        <meta property="article:tag" content="Article Tag" />
+        <meta property="article:section" content={metaValues.section} />
+
+        {article !== undefined &&
+          article.tags.map((tag) => (
+            <meta
+              property="article:tag"
+              content={localiseText(locale, tag.title)}
+            />
+          ))}
         <meta property="fb:admins" content="Facebook numeric ID" />
 
         {isAmp && (

--- a/pages/index.js
+++ b/pages/index.js
@@ -48,7 +48,9 @@ export default function Home({
 
   let featuredArticleIds = [];
   useEffect(() => {
+    console.log('hpArticles:', hpArticles);
     for (const [key, article] of Object.entries(hpArticles)) {
+      console.log(key, article);
       // replace any missing featured articles with the next top article from the stream
       if (article === null) {
         hpArticles[key] = streamArticles.shift();
@@ -56,9 +58,9 @@ export default function Home({
     }
 
     // build a quick list of homepage featured article ids to ensure they do not appear again in the stream
-    featuredArticleIds = Object.values(hpArticles)
-      .filter((article) => !article === null)
-      .map((article) => article.id);
+    featuredArticleIds = Object.values(hpArticles).map((article) => {
+      return article.id;
+    });
 
     // filter out any articles from the stream that are already featured using the list of IDs from right above
     setMostRecentArticles(
@@ -122,7 +124,6 @@ export async function getStaticProps({ locale }) {
 
   //    look up featured homepage articles
   const hpArticles = await getHomepageArticles(currentLocale, hpData);
-  console.log('hpArticles:', hpArticles);
 
   const streamArticles = await listMostRecentArticles(currentLocale);
 


### PR DESCRIPTION
Issue #243 

This PR fixes the meta tags on the article page to pull in the article-specific content:

* search title & description
* facebook title & description
* twitter title & description
* article:section (single)
* article:tag (multiple)

<img width="823" alt="Screen Shot 2020-12-23 at 11 55 45 am" src="https://user-images.githubusercontent.com/3397/102946856-f8755180-4515-11eb-8990-38a27357de21.png">
