### PR TITLE
getArticleBySlug expects a locale, pass it from query string

### DIFF
--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -8,7 +8,7 @@ export default async (req, res) => {
   }
 
   // Fetch the headless CMS to check if the provided `slug` exists
-  const article = await getArticleBySlug(req.query.slug);
+  const article = await getArticleBySlug(req.query.locale, req.query.slug);
 
   // If the slug doesn't exist prevent preview mode from being enabled
   if (!article) {


### PR DESCRIPTION
Closes issue #254 

Turns out this was due to the locale being missing. We need to pass the locale as a query string parameter to the preview URL in order to look up the article correctly.

This will depend upon https://github.com/news-catalyst/google-app-scripts/issues/170 being completed in the add-on. For now, you can test by loading this URL:

http://localhost:3000/api/preview?secret=DUNGEONSDRAGONS&slug=kensingtons-last-minute-gift-guide&locale=en-US