### PR TITLE
Bootstrap data

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -1,0 +1,116 @@
+const CREATE_LAYOUT = `mutation CreateHomepageLayoutData($data: HomepageLayoutDataInput!) {
+  homepageLayoutDatas {
+      createHomepageLayoutData(data: $data) {
+        data {
+          id
+          data
+          layoutSchema {
+            id
+            name
+            data
+          }
+        }
+        error  {
+          code
+          message
+          data
+        }
+      }
+  }
+}`;
+
+const CREATE_LAYOUT_SCHEMA = `mutation CreateHomepageLayoutSchema($data: HomepageLayoutSchemaInput!) {
+  homepageLayoutSchemas {
+      createHomepageLayoutSchema(data: $data) {
+        data {
+          id
+          name
+          data
+        }
+        error  {
+          code
+          message
+          data
+        }
+      }
+  }
+}`;
+
+const UPDATE_LAYOUT = `mutation UpdateHomepageLayoutSchema($id: ID!, $data: HomepageLayoutSchemaInput!) {
+  homepageLayoutSchemas {
+    updateHomepageLayoutSchema(id: $id, data: $data) {
+      data {
+        id
+        name
+        data
+      }
+      error {
+        code
+        data
+        message
+      }
+    }
+  }
+}`;
+
+const LIST_HOMEPAGE_DATA = `{
+  homepageLayoutDatas {
+    listHomepageLayoutDatas {
+      error{
+        code
+        message
+      }
+      data {
+        id
+        data
+        layoutSchema {
+          id
+          name
+          data
+        }
+      }
+    }
+  }
+}`;
+
+const LIST_LAYOUT_SCHEMAS = `{
+  homepageLayoutSchemas {
+    listHomepageLayoutSchemas {
+      error {
+        code
+        message
+      }
+      data {
+        id
+        name
+        data
+      }
+    }
+  }
+}`;
+
+const GET_LAYOUT = `query GetHomepageLayoutSchema($id: ID!) {
+  homepageLayoutSchemas {
+    getHomepageLayoutSchema(id: $id) {
+      data {
+        id
+        name
+        data
+      }
+      error {
+        code
+        data
+        message
+      }
+    }
+  }
+}`;
+
+module.exports = {
+  CREATE_LAYOUT,
+  CREATE_LAYOUT_SCHEMA,
+  UPDATE_LAYOUT,
+  LIST_HOMEPAGE_DATA,
+  LIST_LAYOUT_SCHEMAS,
+  GET_LAYOUT,
+};

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -171,6 +171,18 @@ const UPDATE_METADATA = `mutation UpdateSiteMetadata($id: ID!, $data: SiteMetada
   }
 }`;
 
+const LIST_LOCALES = `query ListI18nLocales {
+  i18n {
+    listI18NLocales {
+      data {
+        id
+        code
+        default
+      }
+    }
+  }
+}`;
+
 module.exports = {
   CREATE_LAYOUT,
   CREATE_LAYOUT_SCHEMA,
@@ -181,4 +193,5 @@ module.exports = {
   LIST_METADATA,
   CREATE_METADATA,
   UPDATE_METADATA,
+  LIST_LOCALES,
 };

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -106,6 +106,71 @@ const GET_LAYOUT = `query GetHomepageLayoutSchema($id: ID!) {
   }
 }`;
 
+const LIST_METADATA = `{
+  siteMetadatas {
+    listSiteMetadatas {
+      data {
+        id
+        data {
+          values {
+            locale
+            value
+          }
+        }
+        published
+      }
+    }
+  }
+}`;
+
+const CREATE_METADATA = `mutation CreateSiteMetadata($data: SiteMetadataInput!) {
+  siteMetadatas {
+      createSiteMetadata(data: $data) {
+        data {
+          id
+          data {
+            values { 
+              locale
+              value
+            }
+          }
+          published
+          firstPublishedOn
+          lastPublishedOn
+        }
+        error  {
+          code
+          message
+          data
+        }
+      }
+  }
+}`;
+
+const UPDATE_METADATA = `mutation UpdateSiteMetadata($id: ID!, $data: SiteMetadataInput!) {
+  siteMetadatas {
+    updateSiteMetadata(id: $id, data: $data) {
+      data {
+        id
+        data {
+          values {
+            locale
+            value
+          }
+        }
+        published
+        firstPublishedOn
+        lastPublishedOn
+      }
+      error {
+        code
+        data
+        message
+      }
+    }
+  }
+}`;
+
 module.exports = {
   CREATE_LAYOUT,
   CREATE_LAYOUT_SCHEMA,
@@ -113,4 +178,7 @@ module.exports = {
   LIST_HOMEPAGE_DATA,
   LIST_LAYOUT_SCHEMAS,
   GET_LAYOUT,
+  LIST_METADATA,
+  CREATE_METADATA,
+  UPDATE_METADATA,
 };

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -1,29 +1,11 @@
 import { GraphQLClient } from 'graphql-request';
 import _ from 'lodash';
 
+const gql = require('./graphql/queries');
+
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
-
-const LIST_HOMEPAGE_DATA = `{
-  homepageLayoutDatas {
-    listHomepageLayoutDatas {
-      error{
-        code
-        message
-      }
-      data {
-        id
-        data
-        layoutSchema {
-          id
-          name
-          data
-        }
-      }
-    }
-  }
-}`;
 
 export async function getHomepageData() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
@@ -32,7 +14,7 @@ export async function getHomepageData() {
     },
   });
 
-  const homepageData = await webinyHeadlessCms.request(LIST_HOMEPAGE_DATA);
+  const homepageData = await webinyHeadlessCms.request(gql.LIST_HOMEPAGE_DATA);
 
   if (
     homepageData &&
@@ -74,22 +56,6 @@ export async function getHomepageData() {
   }
 }
 
-const LIST_LAYOUT_SCHEMAS = `{
-  homepageLayoutSchemas {
-    listHomepageLayoutSchemas {
-      error {
-        code
-        message
-      }
-      data {
-        id
-        name
-        data
-      }
-    }
-  }
-}`;
-
 export async function listLayoutSchemas() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -97,7 +63,7 @@ export async function listLayoutSchemas() {
     },
   });
 
-  const schemaData = await webinyHeadlessCms.request(LIST_LAYOUT_SCHEMAS);
+  const schemaData = await webinyHeadlessCms.request(gql.LIST_LAYOUT_SCHEMAS);
 
   return schemaData.homepageLayoutSchemas.listHomepageLayoutSchemas.data;
 }
@@ -109,7 +75,7 @@ export async function listLayoutSchemaIds() {
     },
   });
 
-  const schemaData = await webinyHeadlessCms.request(LIST_LAYOUT_SCHEMAS);
+  const schemaData = await webinyHeadlessCms.request(gql.LIST_LAYOUT_SCHEMAS);
 
   const layoutIds = schemaData.homepageLayoutSchemas.listHomepageLayoutSchemas.data.map(
     (layout) => {
@@ -122,61 +88,6 @@ export async function listLayoutSchemaIds() {
   );
   return layoutIds;
 }
-const CREATE_LAYOUT = `mutation CreateHomepageLayoutData($data: HomepageLayoutDataInput!) {
-  homepageLayoutDatas {
-      createHomepageLayoutData(data: $data) {
-        data {
-          id
-          data
-          layoutSchema {
-            id
-            name
-            data
-          }
-        }
-        error  {
-          code
-          message
-          data
-        }
-      }
-  }
-}`;
-
-const CREATE_LAYOUT_SCHEMA = `mutation CreateHomepageLayoutSchema($data: HomepageLayoutSchemaInput!) {
-  homepageLayoutSchemas {
-      createHomepageLayoutSchema(data: $data) {
-        data {
-          id
-          name
-          data
-        }
-        error  {
-          code
-          message
-          data
-        }
-      }
-  }
-}`;
-
-const UPDATE_LAYOUT = `mutation UpdateHomepageLayoutSchema($id: ID!, $data: HomepageLayoutSchemaInput!) {
-  homepageLayoutSchemas {
-    updateHomepageLayoutSchema(id: $id, data: $data) {
-      data {
-        id
-        name
-        data
-      }
-      error {
-        code
-        data
-        message
-      }
-    }
-  }
-}`;
-
 export async function createHomepageLayoutSchema(url, token, name, data) {
   const webinyHeadlessCms = new GraphQLClient(url, {
     headers: {
@@ -192,7 +103,7 @@ export async function createHomepageLayoutSchema(url, token, name, data) {
   };
 
   const responseData = await webinyHeadlessCms.request(
-    CREATE_LAYOUT_SCHEMA,
+    gql.CREATE_LAYOUT_SCHEMA,
     variables
   );
 
@@ -214,29 +125,12 @@ export async function createHomepageLayout(url, token, layoutId, data) {
   };
 
   const responseData = await webinyHeadlessCms.request(
-    CREATE_LAYOUT,
+    gql.CREATE_LAYOUT,
     variables
   );
 
   return responseData;
 }
-
-const GET_LAYOUT = `query GetHomepageLayoutSchema($id: ID!) {
-  homepageLayoutSchemas {
-    getHomepageLayoutSchema(id: $id) {
-      data {
-        id
-        name
-        data
-      }
-      error {
-        code
-        data
-        message
-      }
-    }
-  }
-}`;
 
 export async function getHomepageLayout(id) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
@@ -249,7 +143,10 @@ export async function getHomepageLayout(id) {
     id: id,
   };
 
-  const responseData = await webinyHeadlessCms.request(GET_LAYOUT, variables);
+  const responseData = await webinyHeadlessCms.request(
+    gql.GET_LAYOUT,
+    variables
+  );
 
   return responseData.homepageLayoutSchemas.getHomepageLayoutSchema.data;
 }
@@ -270,39 +167,9 @@ export async function updateHomepageLayout(url, token, layoutId, name, data) {
   };
 
   const responseData = await webinyHeadlessCms.request(
-    UPDATE_LAYOUT,
+    gql.UPDATE_LAYOUT,
     variables
   );
 
-  return responseData;
-}
-
-const PUBLISH_LAYOUT = `mutation PublishHomepageLayoutData($revision: ID!) {
-  content: publishHomepageLayoutData(revision: $revision) {
-    data {
-      id
-    }
-    error {
-      message
-      code
-      data
-    }
-  }
-}
-`;
-export async function publishLayout(url, token, layoutId) {
-  const webinyHeadlessCms = new GraphQLClient(url, {
-    headers: {
-      authorization: token,
-    },
-  });
-
-  const variables = {
-    revision: layoutId,
-  };
-  const responseData = await webinyHeadlessCms.request(
-    PUBLISH_LAYOUT,
-    variables
-  );
   return responseData;
 }

--- a/lib/site_metadata.js
+++ b/lib/site_metadata.js
@@ -1,22 +1,7 @@
 import { GraphQLClient } from 'graphql-request';
 import _ from 'lodash';
 
-const LIST_METADATA = `{
-  siteMetadatas {
-    listSiteMetadatas {
-      data {
-        id
-        data {
-          values {
-            locale
-            value
-          }
-        }
-        published
-      }
-    }
-  }
-}`;
+const gql = require('./graphql/queries');
 
 // this always lists the metadata and grabs the most recent one
 // NOTE: there should only be one record
@@ -33,7 +18,7 @@ export async function getSiteMetadata(apiUrl, apiToken) {
     },
   });
 
-  const response = await webinyHeadlessCms.request(LIST_METADATA);
+  const response = await webinyHeadlessCms.request(gql.LIST_METADATA);
 
   const metadataRecords = response.siteMetadatas.listSiteMetadatas.data;
   let metadata = metadataRecords[0];
@@ -53,7 +38,7 @@ export async function getSiteMetadataForLocale(locale) {
     }
   );
 
-  const response = await webinyHeadlessCms.request(LIST_METADATA);
+  const response = await webinyHeadlessCms.request(gql.LIST_METADATA);
 
   const metadataRecords = response.siteMetadatas.listSiteMetadatas.data;
 
@@ -71,30 +56,6 @@ export async function getSiteMetadataForLocale(locale) {
   }
   return parsedData;
 }
-
-const CREATE_METADATA = `mutation CreateSiteMetadata($data: SiteMetadataInput!) {
-  siteMetadatas {
-      createSiteMetadata(data: $data) {
-        data {
-          id
-          data {
-            values { 
-              locale
-              value
-            }
-          }
-          published
-          firstPublishedOn
-          lastPublishedOn
-        }
-        error  {
-          code
-          message
-          data
-        }
-      }
-  }
-}`;
 
 export async function createSiteMetadata(url, token, locale, data) {
   const webinyHeadlessCms = new GraphQLClient(url, {
@@ -118,35 +79,11 @@ export async function createSiteMetadata(url, token, locale, data) {
   };
 
   const responseData = await webinyHeadlessCms.request(
-    CREATE_METADATA,
+    gql.CREATE_METADATA,
     variables
   );
   return responseData;
 }
-
-const UPDATE_METADATA = `mutation UpdateSiteMetadata($id: ID!, $data: SiteMetadataInput!) {
-  siteMetadatas {
-    updateSiteMetadata(id: $id, data: $data) {
-      data {
-        id
-        data {
-          values {
-            locale
-            value
-          }
-        }
-        published
-        firstPublishedOn
-        lastPublishedOn
-      }
-      error {
-        code
-        data
-        message
-      }
-    }
-  }
-}`;
 
 export async function updateSiteMetadata(
   url,
@@ -156,7 +93,6 @@ export async function updateSiteMetadata(
   data
 ) {
   let id = previousMetadata.id;
-  console.log('previousMetadata:', previousMetadata, 'new data:', data);
   // let dataValues = [];
   let foundIt = false;
   // look for content in the specified locale; if it exists, update the data
@@ -194,7 +130,7 @@ export async function updateSiteMetadata(
   };
 
   const responseData = await webinyHeadlessCms.request(
-    UPDATE_METADATA,
+    gql.UPDATE_METADATA,
     variables
   );
   return responseData;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
+    "bootstrap": "node script/bootstrap.js",
     "build": "next build",
     "start": "next start",
     "export": "next build && next export",

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -1,0 +1,67 @@
+#! /usr/bin/env node
+
+require('dotenv').config({ path: '.env.local' })
+
+const fetch = require('node-fetch');
+
+const gql = require('../lib/graphql/queries');
+
+const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
+const CONTENT_DELIVERY_API_ACCESS_TOKEN =
+  process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+function createHomepageLayouts() {
+  const url = CONTENT_DELIVERY_API_URL;
+
+  const lpslVars = {
+    data: {
+      name: "Large Package Story Lead",
+      data: "{ \"subfeatured-left\":\"string\", \"subfeatured-middle\":\"string\", \"subfeatured-right\":\"string\", \"featured\":\"string\" }"
+    }
+  };
+
+  const bfsVars = {
+    data: {
+      name: "Big Featured Story",
+      data: "{ \"featured\":\"string\" }"
+    }
+  };
+  
+  let opts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+
+    body: JSON.stringify({ 
+      query: gql.CREATE_LAYOUT_SCHEMA,
+      variables: lpslVars
+    }),
+  };
+
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((data) => {
+      console.log(JSON.stringify(data));
+    })
+    .catch(console.error);
+
+  opts.body = JSON.stringify({
+      query: gql.CREATE_LAYOUT_SCHEMA,
+      variables: bfsVars
+  })
+
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((data) => {
+      console.log(JSON.stringify(data));
+    })
+    .catch(console.error);
+}
+
+async function main() {
+  createHomepageLayouts();
+}
+
+main().catch((error) => console.error(error));

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -43,7 +43,7 @@ function createHomepageLayouts() {
   fetch(url, opts)
     .then((res) => res.json())
     .then((data) => {
-      console.log(JSON.stringify(data));
+      console.log("- created homepage layout schema: large package story lead")
     })
     .catch(console.error);
 
@@ -55,13 +55,192 @@ function createHomepageLayouts() {
   fetch(url, opts)
     .then((res) => res.json())
     .then((data) => {
-      console.log(JSON.stringify(data));
+      console.log("- created homepage layout schema: big featured story")
     })
     .catch(console.error);
 }
 
+function createMetadata() {
+
+  const data = {
+    "shortName": "The New Oaklyn Observer",
+    "siteUrl": "https://tinynewsco.org/",
+    "homepageTitle": "The New Oaklyn Observer",
+    "homepageSubtitle": "a new local news initiative",
+    "subscribe": "{\"title\":\"Subscribe\",\"subtitle\":\"Get the latest news from Oaklyn in your inbox.\"}",
+    "footerTitle": "tinynewsco.org",
+    "footerBylineName": "News Catalyst",
+    "footerBylineLink": "https://newscatalyst.org",
+    "labels": "{\"latestNews\":\"Latest News\",\"search\":\"Search\",\"topics\":\"Topics\"}",
+    "nav": "{\"articles\":\"Articles\",\"topics\":\"All Topics\",\"cms\":\"tinycms\"}",
+    "searchTitle": "The Oaklyn Observer",
+    "searchDescription": "Page description",
+    "facebookTitle": "Facebook title",
+    "facebookDescription": "Facebook description",
+    "twitterTitle": "Twitter title",
+    "twitterDescription": "Twitter description",
+    "aboutHed": "Who We Are",
+    "aboutDek": "We’re journalists for Oaklyn. We amplify community voices, share information resources, and investigate systems, not just symptoms.",
+    "aboutCTA": "Learn more",
+    "supportHed": "Support our work",
+    "supportDek": "The Oaklyn Observer exists based on the support of our readers. Chip in today to help us continue serving Oaklyn with quality journalism.",
+    "supportCTA": "Donate"
+  };
+
+  const url = CONTENT_DELIVERY_API_URL;
+
+  let localeOpts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({query: gql.LIST_LOCALES}),
+  };
+
+  fetch(url, localeOpts)
+    .then((res) => res.json())
+    .then((responseParsed) => {
+      // console.log(responseParsed)
+      let locales = responseParsed.data.i18n.listI18NLocales.data;
+
+      let metadataRecords = null;
+      let metadataOpts = {
+        method: 'POST',
+        headers: {
+          authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({query: gql.LIST_METADATA}),
+      };
+
+      fetch(url, metadataOpts)
+        .then((res) => res.json())
+        .then((metadataParsed) => {
+          try {
+            metadataRecords = metadataParsed.data.siteMetadatas.listSiteMetadatas.data;
+          } catch(e) {
+            console.log("error finding records in response: ", e)
+          }
+
+          if (metadataRecords === null || metadataRecords === undefined || metadataRecords.length <= 0) {
+            console.log("- no metadata found, creating...")
+            let metadataVars = [];
+            locales.map((locale) => {
+              metadataVars.push({
+                locale: locale.id,
+                value: JSON.stringify(data)
+              })
+            });
+
+            let variables = {
+              data: {
+                data: {
+                  values: metadataVars
+                },
+                published: true,
+              },
+            };
+            
+            let opts = {
+              method: 'POST',
+              headers: {
+                authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ 
+                query: gql.CREATE_METADATA,
+                variables: variables
+              }),
+            };
+
+            fetch(url, opts)
+              .then((res) => res.json())
+              .then((data) => {
+                console.log("... done! created site metadata for all locales");
+              })
+              .catch(console.error);
+
+          } else {
+            console.log("- found metadata, checking for all locales...")
+
+            let updatedMetadataVars = [];
+            let metadataID = metadataRecords[0].id;
+
+            // this should only be true if a locale is missing site metadata, otherwise there's no point in updating it
+            let needsUpdate = false;
+            locales.map((locale) => {
+              let metadata = metadataRecords[0].data.values.find(
+                (value) => value.locale === locale.id
+              );
+
+              if (metadata !== null && metadata !== undefined) {
+                // don't do anything: metadata exists for this locale
+                console.log("- metadata exists for locale: " + locale.code);
+
+                updatedMetadataVars.push(metadata);
+              } else {
+                // update the metadata record to add in this locale
+                console.log("- creating metadata for locale: " + locale.code);
+                needsUpdate = true;
+
+                updatedMetadataVars.push({
+                  locale: locale.id,
+                  value: JSON.stringify(data)
+                })
+              }
+            })
+
+            if (updatedMetadataVars.length > 0 && needsUpdate) {
+              let variables = {
+                id: metadataID,
+                data: {
+                  data: {
+                    values: updatedMetadataVars
+                  },
+                  published: true,
+                },
+              };
+            
+              let opts = {
+                method: 'POST',
+                headers: {
+                  authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ 
+                  query: gql.UPDATE_METADATA,
+                  variables: variables
+                }),
+              };
+
+              fetch(url, opts)
+                .then((res) => res.json())
+                .then((data) => {
+                  console.log("... done! updated site metadata for all locales");
+                })
+                .catch(console.error);
+
+            }
+          }
+        })
+        .catch( (err) => {
+          // I think this is the "no metadata whatsoever exists, db is empty" situation?
+          // create metadata (one record) with values for all site locales here.
+          console.log("error listing metadata:");
+          console.error(err);
+        });
+    })
+    .catch( (err) => {
+      console.log("error listing locales:");
+      console.error(err);
+    });
+
+}
+
 async function main() {
   createHomepageLayouts();
+  createMetadata();
 }
 
 main().catch((error) => console.error(error));

--- a/script/populate.js
+++ b/script/populate.js
@@ -6,6 +6,9 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 
+const gql = require('../lib/graphql/queries');
+const { create } = require('domain');
+
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
@@ -142,9 +145,58 @@ function getAds() {
     .catch(console.error);
 }
 
+function createHomepageLayouts() {
+  const url = CONTENT_DELIVERY_API_URL;
+
+  const lpslVars = {
+    data: {
+      name: "Large Package Story Lead",
+      data: "{ \"subfeatured-left\":\"string\", \"subfeatured-middle\":\"string\", \"subfeatured-right\":\"string\", \"featured\":\"string\" }"
+    }
+  };
+
+  const bfsVars = {
+    data: {
+      name: "Big Featured Story",
+      data: "{ \"featured\":\"string\" }"
+    }
+  };
+  
+  let opts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+
+    body: JSON.stringify({ 
+      query: gql.CREATE_LAYOUT_SCHEMA,
+      variables: lpslVars
+    }),
+  };
+
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((data) => {
+      console.log(JSON.stringify(data));
+    })
+    .catch(console.error);
+
+  opts.body = JSON.stringify({
+      query: gql.CREATE_LAYOUT_SCHEMA,
+      variables: bfsVars
+  })
+
+  fetch(url, opts)
+    .then((res) => res.json())
+    .then((data) => {
+      console.log(JSON.stringify(data));
+    })
+    .catch(console.error);
+}
+
 async function main() {
-  console.log("LETTERHEAD:", process.env.LETTERHEAD_API_URL, process.env.LETTERHEAD_API_KEY);
-  console.log("WEBINY:", process.env.CONTENT_DELIVERY_API_URL, process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN);
+  createHomepageLayouts();
   listLocales();
   listSections();
   listTags();


### PR DESCRIPTION
Closes issue #257, relates to https://github.com/news-catalyst/reproducible-tinynews-content-api/issues/74

This PR adds a new command, `yarn bootstrap`, that sets up the following:

* the two homepage layouts we've been using
* site metadata for all configured locales

The site metadata is currently set to the following for all locales; any existing metadata remains as-is:

```

  "shortName": "The New Oaklyn Observer",
  "siteUrl": "https://tinynewsco.org/",
  "homepageTitle": "The New Oaklyn Observer",
  "homepageSubtitle": "a new local news initiative",
  "subscribe": "{\"title\":\"Subscribe\",\"subtitle\":\"Get the latest news from Oaklyn in your inbox.\"}",
  "footerTitle": "tinynewsco.org",
  "footerBylineName": "News Catalyst",
  "footerBylineLink": "https://newscatalyst.org",
  "labels": "{\"latestNews\":\"Latest News\",\"search\":\"Search\",\"topics\":\"Topics\"}",
  "nav": "{\"articles\":\"Articles\",\"topics\":\"All Topics\",\"cms\":\"tinycms\"}",
  "searchTitle": "The Oaklyn Observer",
  "searchDescription": "Page description",
  "facebookTitle": "Facebook title",
  "facebookDescription": "Facebook description",
  "twitterTitle": "Twitter title",
  "twitterDescription": "Twitter description",
  "aboutHed": "Who We Are",
  "aboutDek": "We’re journalists for Oaklyn. We amplify community voices, share information resources, and investigate systems, not just symptoms.",
  "aboutCTA": "Learn more",
  "supportHed": "Support our work",
  "supportDek": "The Oaklyn Observer exists based on the support of our readers. Chip in today to help us continue serving Oaklyn with quality journalism.",
  "supportCTA": "Donate"
}
```

We'll want to make this localised for each locale, of course.

👉 We can make this bootstrap command setup things like sections, tags and authors. Do we want to do that here, or have it done in the tinycms? I was thinking the tinycms, since aside from sections, lacking authors and tags won't prevent publishing.

👉 As for sections, we will need at least one (articles require this), but it shouldn't be a placeholder. I figure we should do that intentionally per tiny-news-org. 

I'm definitely open to thoughts on all of this. 

Also, I am hoping this command works well when you run it, always a bit of a gamble with this stuff! I tried running it with and without data on the "oaklyn" api (https://djomoky4uky4c.cloudfront.net/graphql)