### PR TITLE
Create a general news section when bootstrapping site

### DIFF
--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -9,11 +9,13 @@ export default function ArticleHeader({ article, locale, isAmp, metadata }) {
   let categoryTitle;
   let headline;
   let postUrl;
+  let searchDescription;
 
   if (article && article.category) {
     categoryTitle = localiseText(locale, article.category.title);
     headline = localiseText(locale, article.headline);
     postUrl = `${metadata.siteUrl}${article.category.slug}/${article.slug}`;
+    searchDescription = localiseText(locale, article.searchDescription);
   }
 
   if (!article) {
@@ -38,9 +40,7 @@ export default function ArticleHeader({ article, locale, isAmp, metadata }) {
           </Link>
         </div>
         <div className="post__title">{headline}</div>
-        <div className="post__dek">
-          {article.searchDescription.values[0].value}
-        </div>
+        <div className="post__dek">{searchDescription}</div>
         <PublishDate article={article} />
         <div className="section post__featured-media">
           <figure>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,407 +1,10 @@
 import { GraphQLClient } from 'graphql-request';
 import { localiseText } from './utils';
+const gql = require('./graphql/queries');
 
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
-
-const LIST_ARTICLES = `
-{
-  articles {
-  listArticles {
-    data {
-      id
-      availableLocales
-      headlineSearch
-      firstPublishedOn
-      lastPublishedOn
-      slug
-      headline {
-        values {
-          locale
-          value
-        }
-      }
-      content {
-        values {
-          locale
-          value
-        }
-      }
-      category {
-        id
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-      tags {
-        id
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-      authors {
-        id
-        name
-        slug
-      }
-      authorSlugs
-      twitterTitle {
-        values {
-          locale
-          value
-        }
-      }
-      twitterDescription {
-        values {
-          locale
-          value
-        }
-      }
-      facebookTitle {
-        values {
-          locale
-          value
-        }
-      }
-      facebookDescription {
-        values {
-          locale
-          value
-        }
-      }
-      searchTitle {
-        values {
-          locale
-          value
-        }
-      }
-      searchDescription {
-        values {
-          locale
-          value
-        }
-      }
-    }
-  }
-}
-}`;
-
-const LIST_ARTICLES_REVERSE_CHRON = `
-{
-  articles {
-  listArticles(sort: {firstPublishedOn: -1}) {
-    data {
-      id
-      availableLocales
-      headlineSearch
-      firstPublishedOn
-      lastPublishedOn
-      slug
-      headline {
-        values {
-          locale
-          value
-        }
-      }
-      content {
-        values {
-          locale
-          value
-        }
-      }
-      category {
-        id
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-      tags {
-        id
-        title{
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-      authors {
-        id
-        name
-        slug
-      }
-      authorSlugs
-    }
-  }
-}
-  }`;
-
-const LIST_ARTICLES_BY_SLUG = `
-query SearchArticles($where: ArticleListWhere) {
-  articles {
-    listArticles(where: $where) {
-      data {
-        id
-        headlineSearch
-        firstPublishedOn
-        lastPublishedOn
-        slug
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        category {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        tags {
-          id
-          title{
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        authors {
-          id
-          name
-        }
-        authorSlugs
-      }
-    }
-  }
-}`;
-
-const LIST_ARTICLES_BY_AUTHOR = `
-query SearchArticles($where: ArticleListWhere) {
-  articles {
-    listArticles(where: $where) {
-      data {
-        id
-        headlineSearch
-        firstPublishedOn
-        lastPublishedOn
-        slug
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        category {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        tags {
-          id
-          title{
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        authors {
-          id
-          name
-        }
-        authorSlugs
-      }
-    }
-  }
-}`;
-
-const LIST_IDS = `
-{
-  articles {
-    listArticles {
-      data {
-        id
-      }
-    }
-  }
-}`;
-
-const LIST_SLUGS = `
-{
-  articles {
-    listArticles {
-      data {
-        category {
-          slug
-        }
-        slug
-      }
-    }
-  }
-}`;
-
-const LIST_SECTIONS = `
-{
-  categories {
-    listCategories {
-      data {
-        id
-        slug
-        title {
-          values {
-            value
-            locale
-          }
-        }
-      }
-    }
-  }
-}
-`;
-
-const LIST_AUTHORS = `
-{
-  authors {
-    listAuthors {
-      data {
-        bio {
-          values {
-            locale
-            value
-          }
-        }
-        name
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-    }
-  }
-}`;
-
-const LIST_TAGS = `{
-  tags {
-    listTags {
-      data {
-        id
-        slug
-        title {
-          values {
-            locale
-            value
-          }
-        }
-      }
-    }
-  }
-}`;
-
-const UPDATE_TAG = `mutation UpdateTag($id: ID!, $data: TagInput!) {
-  tags {
-    updateTag(id: $id, data: $data) {
-      data {
-        id
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        published
-        slug
-      }
-      error {
-        code
-        data
-        message
-      }
-    }
-  }
-}`;
-
-const GET_TAG_BY_ID = `query GetTag($id: ID!) {
-  tags {
-		getTag(id: $id) {
-      data {
-        id
-        published
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-    }
-  }
-}`;
-
-const GET_AUTHOR_BY_SLUG = `query Author($slug: String) {
-  authors {
-    listAuthors(where: {slug: $slug}) {
-      data {
-        name
-        slug
-      }
-    }
-  }
-}`;
-
-const LIST_LOCALES = `
-  query ListI18nLocales {
-    i18n {
-      listI18NLocales {
-        data {
-          id
-          code
-          default
-        }
-      }
-    }
-  }`;
 
 export async function listAllLocales() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
@@ -410,7 +13,7 @@ export async function listAllLocales() {
     },
   });
 
-  const response = await webinyHeadlessCms.request(LIST_LOCALES);
+  const response = await webinyHeadlessCms.request(gql.LIST_LOCALES);
 
   return response.i18n.listI18NLocales.data;
 }
@@ -422,7 +25,7 @@ export async function listAllSections() {
     },
   });
 
-  const sectionsData = await webinyHeadlessCms.request(LIST_SECTIONS);
+  const sectionsData = await webinyHeadlessCms.request(gql.LIST_SECTIONS);
 
   return sectionsData.categories.listCategories.data;
 }
@@ -434,7 +37,7 @@ export async function listAllSectionTitles(locales) {
     },
   });
 
-  const sectionsData = await webinyHeadlessCms.request(LIST_SECTIONS);
+  const sectionsData = await webinyHeadlessCms.request(gql.LIST_SECTIONS);
 
   let slugs = [];
   for (const locale of locales) {
@@ -463,7 +66,7 @@ export async function listAllArticlesBySection(locale, section) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES,
+    gql.LIST_ARTICLES,
     variables
   );
 
@@ -494,7 +97,7 @@ export async function listAllAuthorPaths(locales) {
     },
   });
 
-  const authorData = await webinyHeadlessCms.request(LIST_AUTHORS);
+  const authorData = await webinyHeadlessCms.request(gql.LIST_AUTHORS);
 
   let slugs = [];
   for (const locale of locales) {
@@ -517,7 +120,7 @@ export async function listAllTagPaths(locales) {
     },
   });
 
-  const tagsData = await webinyHeadlessCms.request(LIST_TAGS);
+  const tagsData = await webinyHeadlessCms.request(gql.LIST_TAGS);
 
   let slugs = [];
   for (const locale of locales) {
@@ -540,7 +143,7 @@ export async function listAllTags() {
     },
   });
 
-  const tagsData = await webinyHeadlessCms.request(LIST_TAGS);
+  const tagsData = await webinyHeadlessCms.request(gql.LIST_TAGS);
 
   const slugs = tagsData.tags.listTags.data.map((tag) => {
     return {
@@ -568,7 +171,7 @@ export async function listAllArticles() {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_ARTICLES);
+  const articlesData = await webinyHeadlessCms.request(gql.LIST_ARTICLES);
   articlesData.articles.listArticles.data.map((article) => {
     article.content = JSON.parse(article.content.values[0].value);
   });
@@ -609,7 +212,7 @@ export async function listArticlesBySlug(slugs) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES_BY_SLUG,
+    gql.LIST_ARTICLES_BY_SLUG,
     variables
   );
   articlesData.articles.listArticles.data.map((article) => {
@@ -635,7 +238,7 @@ export async function listAllArticlesByTag(locale, tag) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES,
+    gql.LIST_ARTICLES,
     variables
   );
   let articlesByTag = [];
@@ -684,7 +287,7 @@ export async function listAllArticlesByAuthor(locale, authorSlug) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    LIST_ARTICLES_BY_AUTHOR,
+    gql.LIST_ARTICLES_BY_AUTHOR,
     variables
   );
 
@@ -710,7 +313,7 @@ export async function listAllArticleIds() {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_IDS);
+  const articlesData = await webinyHeadlessCms.request(gql.LIST_IDS);
   const ids = articlesData.articles.listArticles.data.map((article) => {
     return {
       params: {
@@ -728,7 +331,7 @@ export async function listAllArticleSlugs(locales) {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(LIST_SLUGS);
+  const articlesData = await webinyHeadlessCms.request(gql.LIST_SLUGS);
   let slugs = [];
   for (const locale of locales) {
     articlesData.articles.listArticles.data.map((article) => {
@@ -744,247 +347,6 @@ export async function listAllArticleSlugs(locales) {
   return slugs;
 }
 
-const GET_ARTICLE = `
-query Article($id: ID!) {
-  articles {
-    getArticle(id: $id) {
-      data {
-        id
-        headlineSearch
-        firstPublishedOn
-        lastPublishedOn
-        slug
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        category {
-          id
-          title {
-            values {
-            locale
-              value
-            }
-          }
-          slug
-        }
-        tags {
-          id
-          title{
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        authors {
-          id
-          name
-        }
-        authorSlugs
-        twitterTitle {
-          values {
-            locale
-            value
-          }
-        }
-        twitterDescription {
-          values {
-            locale
-            value
-          }
-        }
-        facebookTitle {
-          values {
-            locale
-            value
-          }
-        }
-        facebookDescription {
-          values {
-            locale
-            value
-          }
-        }
-        searchTitle {
-          values {
-            locale
-            value
-          }
-        }
-        searchDescription {
-          values {
-            locale
-            value
-          }
-        }
-      }
-    }
-  }
-  }`;
-
-const GET_PAGE_BY_SLUG = `
-query SearchPages($where: PageListWhere) {
-  pages {
-    listPages(where: $where) {
-      data {
-        id
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        twitterTitle {
-          values {
-            locale
-            value
-          }
-        }
-        twitterDescription {
-          values {
-            locale
-            value
-          }
-        }
-        facebookTitle {
-          values {
-            locale
-            value
-          }
-        }
-        facebookDescription {
-          values {
-            locale
-            value
-          }
-        }
-        searchTitle {
-          values {
-            locale
-            value
-          }
-        }
-        searchDescription {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-        published
-      }
-    }
-  }
-}`;
-
-const GET_ARTICLE_BY_SLUG = `
-query SearchArticles($where: ArticleListWhere) {
-  articles {
-    listArticles(where: $where) {
-      data {
-        id
-        headlineSearch
-        published
-        availableLocales
-        firstPublishedOn
-        lastPublishedOn
-        twitterTitle {
-          values {
-            locale
-            value
-          }
-        }
-        twitterDescription {
-          values {
-            locale
-            value
-          }
-        }
-        facebookTitle {
-          values {
-            locale
-            value
-          }
-        }
-        facebookDescription {
-          values {
-            locale
-            value
-          }
-        }
-        searchTitle {
-          values {
-            locale
-            value
-          }
-        }
-        searchDescription {
-          values {
-            locale
-            value
-          }
-        }
-
-        slug
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        category {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        tags {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        authors {
-          id
-          name
-          slug
-        }
-        authorSlugs
-      }
-    }
-  }
-}`;
-
 export async function getArticle(id) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -992,7 +354,7 @@ export async function getArticle(id) {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(GET_ARTICLE, { id });
+  const articlesData = await webinyHeadlessCms.request(gql.GET_ARTICLE, { id });
 
   articlesData.getBasicArticle.data.content = JSON.parse(
     articlesData.getBasicArticle.data.content
@@ -1010,7 +372,7 @@ export async function getMostRecentArticle(locale, slug, apiUrl) {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(SEARCH_ARTICLES, {
+  const articlesData = await webinyHeadlessCms.request(gql.SEARCH_ARTICLES, {
     where: {
       availableLocales_contains: locale.code,
     },
@@ -1046,12 +408,15 @@ export async function getArticleBySlug(locale, slug, apiUrl) {
     },
   });
 
-  const articlesData = await webinyHeadlessCms.request(GET_ARTICLE_BY_SLUG, {
-    where: {
-      availableLocales_contains: locale.code,
-      slug: slug,
-    },
-  });
+  const articlesData = await webinyHeadlessCms.request(
+    gql.GET_ARTICLE_BY_SLUG,
+    {
+      where: {
+        availableLocales_contains: locale.code,
+        slug: slug,
+      },
+    }
+  );
   // console.log("articlesData:", articlesData.articles.listArticles.data[0].content.values);
   let articleData;
   let localisedContent;
@@ -1123,38 +488,6 @@ export async function getHomepageArticles(locale, hpData) {
   return hpArticles;
 }
 
-const GET_TAG_BY_SLUG = `
-query Tag($slug: String) {
-  tags {
-    listTags(where: {slug: $slug}) {
-      data {
-        title {
-          values {
-            locale
-            value
-          }
-        }
-        slug
-      }
-    }
-  }
-}`;
-
-const CREATE_TAG = `mutation CreateTag($data: TagInput!) {
-  tags {
-   createTag(data: $data) {
-     data {
-       id
-       slug
-     }
-     error {
-       code
-       message
-     }
-   }
-  }
- }`;
-
 export async function getTag(id) {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {
     headers: {
@@ -1162,7 +495,7 @@ export async function getTag(id) {
     },
   });
 
-  const tagsData = await webinyHeadlessCms.request(GET_TAG_BY_ID, {
+  const tagsData = await webinyHeadlessCms.request(gql.GET_TAG_BY_ID, {
     id: id,
   });
   let tag = tagsData.tags.getTag.data;
@@ -1179,7 +512,7 @@ export async function getTagBySlug(slug, apiUrl) {
     },
   });
 
-  const tagsData = await webinyHeadlessCms.request(GET_TAG_BY_SLUG, {
+  const tagsData = await webinyHeadlessCms.request(gql.GET_TAG_BY_SLUG, {
     slug,
   });
   return tagsData.tags.listTags.data[0];
@@ -1202,7 +535,10 @@ export async function createTag(url, token, titleValues, slug) {
     },
   };
 
-  const responseData = await webinyHeadlessCms.request(CREATE_TAG, variables);
+  const responseData = await webinyHeadlessCms.request(
+    gql.CREATE_TAG,
+    variables
+  );
   return responseData;
 }
 
@@ -1224,7 +560,10 @@ export async function updateTag(url, token, tagId, titleValues, slug) {
     },
   };
 
-  const responseData = await webinyHeadlessCms.request(UPDATE_TAG, variables);
+  const responseData = await webinyHeadlessCms.request(
+    gql.UPDATE_TAG,
+    variables
+  );
   return responseData;
 }
 
@@ -1238,7 +577,7 @@ export async function getAuthorBySlug(slug, apiUrl) {
     },
   });
 
-  const authorData = await webinyHeadlessCms.request(GET_AUTHOR_BY_SLUG, {
+  const authorData = await webinyHeadlessCms.request(gql.GET_AUTHOR_BY_SLUG, {
     slug,
   });
   return authorData.authors.listAuthors.data[0];
@@ -1257,7 +596,7 @@ export async function getPage(slug) {
     },
   });
 
-  const data = await webinyHeadlessCms.request(GET_PAGE_BY_SLUG, {
+  const data = await webinyHeadlessCms.request(gql.GET_PAGE_BY_SLUG, {
     slug,
   });
   let pageData = data.pages.listPages.data[0];
@@ -1276,99 +615,10 @@ export async function listAuthors() {
     },
   });
 
-  const authorsData = await webinyHeadlessCms.request(LIST_AUTHORS);
+  const authorsData = await webinyHeadlessCms.request(gql.LIST_AUTHORS);
 
   return authorsData.authors.listAuthors.data;
 }
-
-const SEARCH_ARTICLES = `
-query SearchArticles($where: ArticleListWhere) {
-  articles {
-    listArticles(sort: {firstPublishedOn: -1}, where: $where) {
-      data {
-        id
-        availableLocales
-        headlineSearch
-        firstPublishedOn
-        lastPublishedOn
-        slug
-        headline {
-          values {
-            locale
-            value
-          }
-        }
-        content {
-          values {
-            locale
-            value
-          }
-        }
-        category {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        tags {
-          id
-          title {
-            values {
-              locale
-              value
-            }
-          }
-          slug
-        }
-        authors {
-          id
-          name
-        }
-        authorSlugs
-        twitterTitle {
-          values {
-            locale
-            value
-          }
-        }
-        twitterDescription {
-          values {
-            locale
-            value
-          }
-        }
-        facebookTitle {
-          values {
-            locale
-            value
-          }
-        }
-        facebookDescription {
-          values {
-            locale
-            value
-          }
-        }
-        searchTitle {
-          values {
-            locale
-            value
-          }
-        }
-        searchDescription {
-          values {
-            locale
-            value
-          }
-        }
-      }
-    }
-  }
-}`;
 
 export async function searchArticles(url, token, term, locale) {
   const webinyHeadlessCms = new GraphQLClient(url, {
@@ -1383,7 +633,7 @@ export async function searchArticles(url, token, term, locale) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    SEARCH_ARTICLES,
+    gql.SEARCH_ARTICLES,
     variables
   );
 
@@ -1421,7 +671,7 @@ export async function listArticlesInLocale(url, token, locale) {
     },
   };
   const articlesData = await webinyHeadlessCms.request(
-    SEARCH_ARTICLES,
+    gql.SEARCH_ARTICLES,
     variables
   );
 

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -930,7 +930,30 @@ const CREATE_TAG = `mutation CreateTag($data: TagInput!) {
   }
  }`;
 
+const CREATE_CATEGORY = `mutation CreateCategory($data: CategoryInput!) {
+  categories {
+      createCategory(data: $data) {
+        data {
+          id
+          title {
+            values {
+              value                
+              locale
+            }
+          }
+          slug
+        }
+        error  {
+          code
+          message
+          data
+        }
+      }
+  }
+}`;
+
 module.exports = {
+  CREATE_CATEGORY,
   CREATE_LAYOUT,
   CREATE_LAYOUT_SCHEMA,
   CREATE_METADATA,

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -183,15 +183,779 @@ const LIST_LOCALES = `query ListI18nLocales {
   }
 }`;
 
+const LIST_SECTIONS = `
+{
+  categories {
+    listCategories {
+      data {
+        id
+        slug
+        title {
+          values {
+            value
+            locale
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
+const LIST_ARTICLES = `
+{
+  articles {
+  listArticles {
+    data {
+      id
+      availableLocales
+      headlineSearch
+      firstPublishedOn
+      lastPublishedOn
+      slug
+      headline {
+        values {
+          locale
+          value
+        }
+      }
+      content {
+        values {
+          locale
+          value
+        }
+      }
+      category {
+        id
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+      tags {
+        id
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+      authors {
+        id
+        name
+        slug
+      }
+      authorSlugs
+      twitterTitle {
+        values {
+          locale
+          value
+        }
+      }
+      twitterDescription {
+        values {
+          locale
+          value
+        }
+      }
+      facebookTitle {
+        values {
+          locale
+          value
+        }
+      }
+      facebookDescription {
+        values {
+          locale
+          value
+        }
+      }
+      searchTitle {
+        values {
+          locale
+          value
+        }
+      }
+      searchDescription {
+        values {
+          locale
+          value
+        }
+      }
+    }
+  }
+}
+}`;
+
+const LIST_ARTICLES_REVERSE_CHRON = `
+{
+  articles {
+  listArticles(sort: {firstPublishedOn: -1}) {
+    data {
+      id
+      availableLocales
+      headlineSearch
+      firstPublishedOn
+      lastPublishedOn
+      slug
+      headline {
+        values {
+          locale
+          value
+        }
+      }
+      content {
+        values {
+          locale
+          value
+        }
+      }
+      category {
+        id
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+      tags {
+        id
+        title{
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+      authors {
+        id
+        name
+        slug
+      }
+      authorSlugs
+    }
+  }
+}
+  }`;
+
+const LIST_ARTICLES_BY_SLUG = `
+query SearchArticles($where: ArticleListWhere) {
+  articles {
+    listArticles(where: $where) {
+      data {
+        id
+        headlineSearch
+        firstPublishedOn
+        lastPublishedOn
+        slug
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        category {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        tags {
+          id
+          title{
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        authors {
+          id
+          name
+        }
+        authorSlugs
+      }
+    }
+  }
+}`;
+
+const LIST_ARTICLES_BY_AUTHOR = `
+query SearchArticles($where: ArticleListWhere) {
+  articles {
+    listArticles(where: $where) {
+      data {
+        id
+        headlineSearch
+        firstPublishedOn
+        lastPublishedOn
+        slug
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        category {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        tags {
+          id
+          title{
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        authors {
+          id
+          name
+        }
+        authorSlugs
+      }
+    }
+  }
+}`;
+
+const LIST_IDS = `
+{
+  articles {
+    listArticles {
+      data {
+        id
+      }
+    }
+  }
+}`;
+
+const LIST_SLUGS = `
+{
+  articles {
+    listArticles {
+      data {
+        category {
+          slug
+        }
+        slug
+      }
+    }
+  }
+}`;
+
+const LIST_AUTHORS = `
+{
+  authors {
+    listAuthors {
+      data {
+        bio {
+          values {
+            locale
+            value
+          }
+        }
+        name
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+    }
+  }
+}`;
+
+const LIST_TAGS = `{
+  tags {
+    listTags {
+      data {
+        id
+        slug
+        title {
+          values {
+            locale
+            value
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const UPDATE_TAG = `mutation UpdateTag($id: ID!, $data: TagInput!) {
+  tags {
+    updateTag(id: $id, data: $data) {
+      data {
+        id
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        published
+        slug
+      }
+      error {
+        code
+        data
+        message
+      }
+    }
+  }
+}`;
+
+const GET_TAG_BY_ID = `query GetTag($id: ID!) {
+  tags {
+		getTag(id: $id) {
+      data {
+        id
+        published
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+    }
+  }
+}`;
+
+const GET_AUTHOR_BY_SLUG = `query Author($slug: String) {
+  authors {
+    listAuthors(where: {slug: $slug}) {
+      data {
+        name
+        slug
+      }
+    }
+  }
+}`;
+
+const SEARCH_ARTICLES = `
+query SearchArticles($where: ArticleListWhere) {
+  articles {
+    listArticles(sort: {firstPublishedOn: -1}, where: $where) {
+      data {
+        id
+        availableLocales
+        headlineSearch
+        firstPublishedOn
+        lastPublishedOn
+        slug
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        category {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        tags {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        authors {
+          id
+          name
+        }
+        authorSlugs
+        twitterTitle {
+          values {
+            locale
+            value
+          }
+        }
+        twitterDescription {
+          values {
+            locale
+            value
+          }
+        }
+        facebookTitle {
+          values {
+            locale
+            value
+          }
+        }
+        facebookDescription {
+          values {
+            locale
+            value
+          }
+        }
+        searchTitle {
+          values {
+            locale
+            value
+          }
+        }
+        searchDescription {
+          values {
+            locale
+            value
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const GET_ARTICLE = `
+query Article($id: ID!) {
+  articles {
+    getArticle(id: $id) {
+      data {
+        id
+        headlineSearch
+        firstPublishedOn
+        lastPublishedOn
+        slug
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        category {
+          id
+          title {
+            values {
+            locale
+              value
+            }
+          }
+          slug
+        }
+        tags {
+          id
+          title{
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        authors {
+          id
+          name
+        }
+        authorSlugs
+        twitterTitle {
+          values {
+            locale
+            value
+          }
+        }
+        twitterDescription {
+          values {
+            locale
+            value
+          }
+        }
+        facebookTitle {
+          values {
+            locale
+            value
+          }
+        }
+        facebookDescription {
+          values {
+            locale
+            value
+          }
+        }
+        searchTitle {
+          values {
+            locale
+            value
+          }
+        }
+        searchDescription {
+          values {
+            locale
+            value
+          }
+        }
+      }
+    }
+  }
+  }`;
+
+const GET_PAGE_BY_SLUG = `
+query SearchPages($where: PageListWhere) {
+  pages {
+    listPages(where: $where) {
+      data {
+        id
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        twitterTitle {
+          values {
+            locale
+            value
+          }
+        }
+        twitterDescription {
+          values {
+            locale
+            value
+          }
+        }
+        facebookTitle {
+          values {
+            locale
+            value
+          }
+        }
+        facebookDescription {
+          values {
+            locale
+            value
+          }
+        }
+        searchTitle {
+          values {
+            locale
+            value
+          }
+        }
+        searchDescription {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+        published
+      }
+    }
+  }
+}`;
+
+const GET_ARTICLE_BY_SLUG = `
+query SearchArticles($where: ArticleListWhere) {
+  articles {
+    listArticles(where: $where) {
+      data {
+        id
+        headlineSearch
+        published
+        availableLocales
+        firstPublishedOn
+        lastPublishedOn
+        twitterTitle {
+          values {
+            locale
+            value
+          }
+        }
+        twitterDescription {
+          values {
+            locale
+            value
+          }
+        }
+        facebookTitle {
+          values {
+            locale
+            value
+          }
+        }
+        facebookDescription {
+          values {
+            locale
+            value
+          }
+        }
+        searchTitle {
+          values {
+            locale
+            value
+          }
+        }
+        searchDescription {
+          values {
+            locale
+            value
+          }
+        }
+
+        slug
+        headline {
+          values {
+            locale
+            value
+          }
+        }
+        content {
+          values {
+            locale
+            value
+          }
+        }
+        category {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        tags {
+          id
+          title {
+            values {
+              locale
+              value
+            }
+          }
+          slug
+        }
+        authors {
+          id
+          name
+          slug
+        }
+        authorSlugs
+      }
+    }
+  }
+}`;
+
+const GET_TAG_BY_SLUG = `
+query Tag($slug: String) {
+  tags {
+    listTags(where: {slug: $slug}) {
+      data {
+        title {
+          values {
+            locale
+            value
+          }
+        }
+        slug
+      }
+    }
+  }
+}`;
+
+const CREATE_TAG = `mutation CreateTag($data: TagInput!) {
+  tags {
+   createTag(data: $data) {
+     data {
+       id
+       slug
+     }
+     error {
+       code
+       message
+     }
+   }
+  }
+ }`;
+
 module.exports = {
   CREATE_LAYOUT,
   CREATE_LAYOUT_SCHEMA,
-  UPDATE_LAYOUT,
-  LIST_HOMEPAGE_DATA,
-  LIST_LAYOUT_SCHEMAS,
-  GET_LAYOUT,
-  LIST_METADATA,
   CREATE_METADATA,
-  UPDATE_METADATA,
+  CREATE_TAG,
+  LIST_ARTICLES,
+  LIST_ARTICLES_BY_AUTHOR,
+  LIST_ARTICLES_BY_SLUG,
+  LIST_ARTICLES_REVERSE_CHRON,
+  LIST_AUTHORS,
+  LIST_HOMEPAGE_DATA,
+  LIST_IDS,
+  LIST_LAYOUT_SCHEMAS,
   LIST_LOCALES,
+  LIST_METADATA,
+  LIST_SECTIONS,
+  LIST_SLUGS,
+  LIST_TAGS,
+  GET_ARTICLE,
+  GET_ARTICLE_BY_SLUG,
+  GET_AUTHOR_BY_SLUG,
+  GET_LAYOUT,
+  GET_PAGE_BY_SLUG,
+  GET_TAG_BY_ID,
+  GET_TAG_BY_SLUG,
+  SEARCH_ARTICLES,
+  UPDATE_LAYOUT,
+  UPDATE_METADATA,
 };

--- a/lib/section.js
+++ b/lib/section.js
@@ -5,27 +5,7 @@ const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
 
-const CREATE_CATEGORY = `mutation CreateCategory($data: CategoryInput!) {
-  categories {
-      createCategory(data: $data) {
-        data {
-          id
-          title {
-            values {
-              value                
-              locale
-            }
-          }
-          slug
-        }
-        error  {
-          code
-          message
-          data
-        }
-      }
-  }
-}`;
+const gql = require('./graphql/queries');
 
 export async function createSection(url, token, currentLocale, title, slug) {
   const webinyHeadlessCms = new GraphQLClient(url, {
@@ -50,7 +30,7 @@ export async function createSection(url, token, currentLocale, title, slug) {
   };
 
   const responseData = await webinyHeadlessCms.request(
-    CREATE_CATEGORY,
+    gql.CREATE_CATEGORY,
     variables
   );
   return responseData;

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -10,6 +10,66 @@ const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
 
+function createGeneralNewsCategory() {
+  const url = CONTENT_DELIVERY_API_URL;
+
+  let localeOpts = {
+    method: 'POST',
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({query: gql.LIST_LOCALES}),
+  };
+
+  let values = [];
+  fetch(url, localeOpts)
+    .then((res) => res.json())
+    .then((responseParsed) => {
+      // console.log(responseParsed)
+      let locales = responseParsed.data.i18n.listI18NLocales.data;
+
+      locales.map(
+        (locale) => {
+          values.push({
+            value: "News",
+            locale: locale.id
+          })
+
+        });
+      })
+    .then((arg) => {
+      const catVars = {
+        data: {
+          slug: "news",
+          title: {
+            values: values
+          }
+        }
+      };
+
+      let opts = {
+        method: 'POST',
+        headers: {
+          authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+          'Content-Type': 'application/json',
+        },
+
+        body: JSON.stringify({ 
+          query: gql.CREATE_CATEGORY,
+          variables: catVars
+        }),
+      };
+
+      fetch(url, opts)
+        .then((res) => res.json())
+        .then((data) => {
+          console.log("- created general news category in all locales");
+        })
+        .catch(console.error);
+    })
+}
+
 function createHomepageLayouts() {
   const url = CONTENT_DELIVERY_API_URL;
 
@@ -239,6 +299,7 @@ function createMetadata() {
 }
 
 async function main() {
+  createGeneralNewsCategory();
   createHomepageLayouts();
   createMetadata();
 }


### PR DESCRIPTION
This PR builds on [the previous bootstrap work](https://github.com/news-catalyst/next-tinynewsdemo/pull/263#issuecomment-765621148) by creating a general news category in all site locales when bootstrapping the site. 

I had to move some more graphql over to the `lib/graphql/queries.js` and found a non-localised text to fix (article header, search description) along the way, but otherwise this affects `yarn bootstrap`

FYI: categories have a unique constraint on `slug` so this doesn't require checking if the `News` category already exists.