### PR TITLE
Feature/simple run script

### DIFF
--- a/script/run
+++ b/script/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+rm .env.local
+ln -s .env.local-$1 .env.local
+yarn clear && yarn populate && yarn dev


### PR DESCRIPTION
Just realised that I forgot to PR this simple script.

I was working on the front-end against the "oaklyn" env, but to review PR #267 I wanted to switch to the "prod" env, so I do:

`./script/run prod`

This expects:

* `.env.local` to either not exist or merely be a symbolic link.
* `.env.local-prod` to exist and have the settings for the prod env
* 👉  you are okay with `.env.local` being removed (it should just be a symlink!) 👈 

I can then run the following to go back to "oaklyn":

`./script/run oaklyn`

```
 2021-01-26 07:58:30 ⌚ |ruby-2.7.0| Jacquis-Air in ~/Projects/newscatalyst/webiny-stack/frontend-site
± |feature/simple-run-script {4} ?:6 ✗| → ls -la
total 1920
drwxr-xr-x   30 jacqui  staff     960 26 Jan 07:58 .
drwxr-xr-x   19 jacqui  staff     608 17 Dec 07:55 ..
lrwxr-xr-x    1 jacqui  staff      15 26 Jan 07:58 .env.local -> .env.local-prod
-rw-r--r--    1 jacqui  staff     841 25 Jan 13:47 .env.local-oaklyn
-rw-r--r--    1 jacqui  staff     763 11 Jan 07:44 .env.local-prod
-rw-r--r--    1 jacqui  staff     169 16 Dec 10:05 .env.local-template
-rw-r--r--    1 jacqui  staff    1101 30 Jul 07:39 .eslintrc.json
```

^^ my current front-end directory as an example ^^
