### PR TITLE
Bugfix: simplify homepage

### DIFF
--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -6,10 +6,10 @@ import ModalArticleSearch from '../tinycms/ModalArticleSearch';
 export default function BigFeaturedStory(props) {
   const [isModalActive, setModal] = useState(false);
 
-  useEffect(() => {
-    console.log('BigFeaturedStory useEffect props:', props);
-    // props.setFeaturedArticle(props.articles['featured']);
-  }, [props.articles, props.featuredArticle]);
+  // useEffect(() => {
+  //   console.log('BigFeaturedStory useEffect props:', props);
+  //   // props.setFeaturedArticle(props.articles['featured']);
+  // }, [props.articles, props.featuredArticle]);
 
   return (
     <>
@@ -51,10 +51,10 @@ export default function BigFeaturedStory(props) {
                   </button>
                 </div>
               )}
-              {!props.editable && props.articles['featured'] && (
+              {!props.editable && props.featuredArticle && (
                 <FeaturedArticleLink
-                  key={props.articles['featured'].id}
-                  article={props.articles['featured']}
+                  key={props.featuredArticle.id}
+                  article={props.featuredArticle}
                   amp={props.isAmp}
                   locale={props.locale}
                 />

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -13,6 +13,7 @@ export default function FeaturedArticleLink({ locale, article, isAmp }) {
 
   let headline = localiseText(locale, article.headline);
   let searchDescription = localiseText(locale, article.searchDescription);
+  let articleContent = localiseText(locale, article.content);
 
   let categoryTitle;
 
@@ -20,12 +21,24 @@ export default function FeaturedArticleLink({ locale, article, isAmp }) {
     categoryTitle = localiseText(locale, article.category.title);
   }
 
-  if (article && article.content) {
-    mainImageNode = article.content.find((node) => node.type === 'mainImage');
+  try {
+    if (typeof articleContent === 'string') {
+      mainImageNode = JSON.parse(articleContent).find(
+        (node) => node.type === 'mainImage'
+      );
+    } else {
+      mainImageNode = articleContent.find((node) => node.type === 'mainImage');
+    }
+  } catch (err) {
+    console.error(err, typeof articleContent);
+  }
 
+  try {
     if (mainImageNode) {
       mainImage = mainImageNode.children[0];
     }
+  } catch (err) {
+    console.error(err);
   }
 
   return (

--- a/components/homepage/FeaturedArticleLink.js
+++ b/components/homepage/FeaturedArticleLink.js
@@ -46,17 +46,14 @@ export default function FeaturedArticleLink({ locale, article, isAmp }) {
       <div className="asset__meta-container">
         {article.category && (
           <span className="asset__descriptor">
-            <Link href="/[slug]" as={article.category.slug}>
+            <Link href={`/${article.category.slug}`}>
               <a>{article.category.title.values[0].value}</a>
             </Link>
           </span>
         )}
         {article.category && (
           <h4 className="asset__title">
-            <Link
-              href="/articles/[category]/[slug]"
-              as={`/articles/${article.category.slug}/${article.slug}`}
-            >
+            <Link href={`/articles/${article.category.slug}/${article.slug}`}>
               <a className="featured">{headline}</a>
             </Link>
           </h4>

--- a/components/homepage/LargePackageStoryLead.js
+++ b/components/homepage/LargePackageStoryLead.js
@@ -8,12 +8,6 @@ export default function LargePackageStoryLead(props) {
   const [isTopModalActive, setTopModal] = useState(false);
   const [isBottomModalActive, setBottomModal] = useState(false);
 
-  useEffect(() => {
-    props.setFeaturedArticle(props.articles['featured']);
-    props.setSubFeaturedTopArticle(props.articles['subfeatured-top']);
-    props.setSubFeaturedBottomArticle(props.articles['subfeatured-bottom']);
-  }, [props.articles]);
-
   return (
     <>
       <section className="section section-layout__1">

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -398,6 +398,40 @@ export async function getMostRecentArticle(locale, slug, apiUrl) {
   return articleData;
 }
 
+export async function getArticleBySlugNoLocale(slug, apiUrl) {
+  if (apiUrl === undefined) {
+    apiUrl = CONTENT_DELIVERY_API_URL;
+  }
+  const webinyHeadlessCms = new GraphQLClient(apiUrl, {
+    headers: {
+      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
+      accept: 'application/json',
+    },
+  });
+
+  const articlesData = await webinyHeadlessCms.request(
+    gql.GET_ARTICLE_BY_SLUG,
+    {
+      where: {
+        slug: slug,
+      },
+    }
+  );
+  console.log('articlesData:', articlesData);
+  if (
+    articlesData &&
+    articlesData.articles &&
+    articlesData.articles.listArticles &&
+    articlesData.articles.listArticles.data &&
+    articlesData.articles.listArticles.data[0]
+  ) {
+    let articleData = articlesData.articles.listArticles.data[0];
+    return articleData;
+  } else {
+    throw Error(`Unable to find article with slug ${slug}`);
+  }
+}
+
 export async function getArticleBySlug(locale, slug, apiUrl) {
   if (apiUrl === undefined) {
     apiUrl = CONTENT_DELIVERY_API_URL;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,7 @@ export const localiseText = (locale, field) => {
   let localisedValue;
   let text = 'NEEDS TRANSLATION'; // for now, default to this so it's obvious what's missing
 
-  if (field && field.values) {
+  if (field && field.values && typeof field.values === 'object') {
     localisedValue = field.values.find((item) => item.locale === locale.id);
     if (localisedValue) {
       text = localisedValue.value;

--- a/pages/index.js
+++ b/pages/index.js
@@ -113,7 +113,6 @@ export async function getStaticProps({ locale }) {
   );
   //    get selected homepage layout and featured article IDs
   const hpData = await getHomepageData();
-  console.log('hpData:', hpData);
 
   let featuredArticleSlug = hpData.articles['featured'];
   let featured = await getArticleBySlugNoLocale(featuredArticleSlug);

--- a/pages/tinycms/homepage.js
+++ b/pages/tinycms/homepage.js
@@ -40,7 +40,7 @@ export default function HomePageEditor({
   const [notificationMessage, setNotificationMessage] = useState('');
   const [notificationType, setNotificationType] = useState('');
   const [showNotification, setShowNotification] = useState(false);
-  const [selectedLayout, setSelectedLayout] = useState();
+  const [selectedLayout, setSelectedLayout] = useState(hpData.layoutSchema);
   const [featuredArticle, setFeaturedArticle] = useState(
     hpArticles['featured']
   );
@@ -54,9 +54,6 @@ export default function HomePageEditor({
     if (hpData === null) {
       console.log('setting layout to:', layoutSchemas[0]);
       setSelectedLayout(layoutSchemas[0]);
-    } else {
-      console.log('setting layout to hpdata:', hpData);
-      setSelectedLayout(hpData.layoutSchema);
     }
     console.log('selectedLayout:', selectedLayout);
     console.log('hpData:', hpData);


### PR DESCRIPTION
Closes #220

This cleans up the admittedly confusing homepage code. useEffect is used very minimally now, and the props are hopefully a lot more straightforward.

Since both layouts have a "featured" article, we look that up after getting the homepage settings; then, if the settings include subfeatured top or bottom articles, we look those up. All featured articles are passed as props to the page.

I cleaned up the use of `useState` and `useEffect` and favoured using the actual properties when possible; the homepage editor makes use of those state-setting functions, so they have to remain.

I tried:

* rendering big featured story
* homepage editor, switching to large package story
* rendering large package story
* homepage editor, switching back to big featured story
* & rendering it once again

I was working against the [oaklyn api settings](https://djomoky4uky4c.cloudfront.net/graphql) but it should work against any 🤞 of the apis.