### PR TITLE
Added new s3 bucket for shared assets to config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   images: {
     domains: [
+      'tnc-test-upload-bucket.s3.amazonaws.com',
       'tiny-news-demo-assets-dev.s3.amazonaws.com',
       'wherebyspace.nyc3.digitaloceanspaces.com',
       'tiny-news-demo-assets-oaklyn.s3.amazonaws.com',


### PR DESCRIPTION
I tested the google add-on: once I updated the AWS config (admin tools > toggle config > access, secret access keys + bucket name) the image upload worked fine. 

This PR adds the new s3 shared bucket name to the list of allowed image domains in next's config.