### PR TITLE
about page now using hasura for page content

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,10 +1,45 @@
 import { GraphQLClient } from 'graphql-request';
 import { localiseText } from './utils';
+import { fetchGraphQL } from './utils';
 const gql = require('./graphql/queries');
 
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
+  pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
+    id
+    page_translations {
+      content
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      published
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+    }
+    slug
+  }
+}`;
+
+export function hasuraGetPage(params) {
+  console.log('params:', params);
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_PAGE,
+    name: 'MyQuery',
+    variables: {
+      slug: params['slug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
 
 export async function listAllLocales() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {


### PR DESCRIPTION
Issue #291 

This PR starts the work of migrating pages in the front-end to use Hasura only. We only have one "page" at the moment: `/about`. 

As of this PR:

* we have a general purpose function for looking up pages in Hasura `hasuraGetPage` that takes a slug (`about`) and localeCode (`en-US`)
* the about page template was missing a headline, I added it; it's localised
* the renderBody function seems to work so far without any changes 🤞 

Still to do in a later PR:

* move all locale look-ups site wide to Hasura (#292)
* move author look-ups on the About page to Hasura (#293)