### PR TITLE
about page authors now from hasura

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1,10 +1,45 @@
 import { GraphQLClient } from 'graphql-request';
 import { localiseText } from './utils';
+import { fetchGraphQL } from './utils';
 const gql = require('./graphql/queries');
 
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
+  pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
+    id
+    page_translations {
+      content
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      published
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+    }
+    slug
+  }
+}`;
+
+export function hasuraGetPage(params) {
+  console.log('params:', params);
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_PAGE,
+    name: 'MyQuery',
+    variables: {
+      slug: params['slug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
 
 export async function listAllLocales() {
   const webinyHeadlessCms = new GraphQLClient(CONTENT_DELIVERY_API_URL, {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -20,7 +20,7 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
         }
       }
     }
-    page_translations {
+    page_translations(where:{locale_code: {_eq: $locale_code}}) {
       content
       facebook_description
       facebook_title

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -10,6 +10,16 @@ const CONTENT_DELIVERY_API_ACCESS_TOKEN =
 const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
   pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
     id
+    author_pages {
+      author {
+        id
+        name
+        slug
+        author_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+    }
     page_translations {
       content
       facebook_description

--- a/pages/about.js
+++ b/pages/about.js
@@ -2,15 +2,14 @@ import { useAmp } from 'next/amp';
 import {
   listAllLocales,
   hasuraGetPage,
-  listAuthors,
   listAllSections,
 } from '../lib/articles.js';
 import { cachedContents } from '../lib/cached';
-import { localiseText } from '../lib/utils';
+import { hasuraLocaliseText } from '../lib/utils';
 import Layout from '../components/Layout';
 import { renderBody } from '../lib/utils.js';
 
-export default function About({ page, authors, currentLocale, sections }) {
+export default function About({ page, currentLocale, sections }) {
   const isAmp = useAmp();
 
   // there will only be one translation returned for a given page + locale
@@ -29,13 +28,20 @@ export default function About({ page, authors, currentLocale, sections }) {
         <section className="section" key="authors">
           <div className="content">
             <h1 className="title">Authors</h1>
-            {authors.map((author) => (
-              <div className="author mb-4" key={author.name}>
+            {page.author_pages.map((authorPage) => (
+              <div className="author mb-4" key={authorPage.author.name}>
                 <h4 className="subtitle is-4">
-                  {author.name}, {localiseText(currentLocale, author.title)}
+                  {authorPage.author.name},{' '}
+                  {hasuraLocaliseText(
+                    authorPage.author.author_translations,
+                    'title'
+                  )}
                 </h4>
                 <p className="content is-medium">
-                  {localiseText(currentLocale, author.bio)}
+                  {hasuraLocaliseText(
+                    authorPage.author.author_translations,
+                    'bio'
+                  )}
                 </p>
               </div>
             ))}
@@ -73,12 +79,10 @@ export async function getStaticProps({ locale }) {
     page = data.pages[0];
   }
 
-  const authors = await listAuthors();
   const sections = await cachedContents('sections', listAllSections);
   return {
     props: {
       page,
-      authors,
       currentLocale,
       sections,
     },


### PR DESCRIPTION
closes #293, #291

* I added a join table between authors and pages to hasura https://github.com/news-catalyst/hasura/pull/38
* both have translations 👀 
* the query for the about page now includes authors, localised (the title and bio)
* creating and updating this content (problem for the google add-on) might be slightly tricky or at least require a couple of requests... 
  * unless hasura has a snazzy way of handling inserting/updating into multiple tables (pages, page_translations, author_pages) at once, with ID lookups.
* authors are scoped to a _page_ not a _page_ _translation_ and I'm thinking of doing the articles in the same way