### PR TITLE
Feature/hasura preview article

### DIFF
--- a/components/articles/Tags.js
+++ b/components/articles/Tags.js
@@ -1,12 +1,14 @@
 import Link from 'next/link';
-import { localiseText } from '../../lib/utils.js';
+import { hasuraLocaliseText } from '../../lib/utils.js';
 
 export default function Tags({ article, locale }) {
   let tagLinks;
   if (article.tags) {
     tagLinks = article.tags.map((tag, index) => (
       <Link href={`/tags/${tag.slug}`} key={`${tag.slug}-${index}`}>
-        <a className="is-link tag">{localiseText(locale, tag.title)}</a>
+        <a className="is-link tag">
+          {hasuraLocaliseText(tag.tag_translations, 'title')}
+        </a>
       </Link>
     ));
   }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -193,6 +193,75 @@ const HASURA_GET_ARTICLE_BY_SLUG = `query MyQuery($slug: String!, $locale_code: 
   }
 }`;
 
+const HASURA_AUTHOR_PAGE = `query MyQuery($locale_code: String!, $author_slug: String!) {
+  articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, author_articles: {author: {slug: {_eq: $author_slug}}}}) {
+    article_translations(where: {locale_code: {_eq: $locale_code}}) {
+      content
+      custom_byline
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+    }
+    category {
+      slug
+      id
+      category_translations(where: {locale_code: {_eq: $locale_code}}) {
+        title
+      }
+    }
+    slug
+    author_articles(where: {author: {slug: {_eq: $author_slug}}}) {
+      author {
+        name
+        photoUrl
+        slug
+        author_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+    }
+    tag_articles(where: {tag: {published: {_eq: true}, tag_translations: {locale_code: {_eq: $locale_code}}}}) {
+      tag {
+        tag_translations {
+          title
+        }
+        slug
+      }
+    }
+  }
+  categories(where: {published: {_eq: true}}) {
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      locale_code
+    }
+    slug
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+  authors(where: {slug: {_eq: $author_slug}}, limit: 1) {
+    id
+    slug
+    author_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      bio
+    }
+    photoUrl
+    name
+    twitter
+    staff
+  }
+}`;
+
 const HASURA_LIST_ALL_SECTIONS = `query MyQuery {
   categories(where: {published: {_eq: true}}) {
     category_translations {
@@ -261,6 +330,24 @@ export async function hasuraListAllArticleSlugs() {
   });
 }
 
+const HASURA_GET_AUTHOR_SLUGS = `query MyQuery {
+  authors(where: {published: {_eq: true}}) {
+    slug
+    author_translations {
+      locale_code
+    }
+  }
+}`;
+
+export async function hasuraListAllAuthorPaths() {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_GET_AUTHOR_SLUGS,
+    name: 'MyQuery',
+  });
+}
+
 export async function hasuraCategoryPage(params) {
   return fetchGraphQL({
     url: process.env.HASURA_API_URL,
@@ -282,6 +369,19 @@ export async function hasuraArticlePage(params) {
     name: 'MyQuery',
     variables: {
       category_slug: params['categorySlug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
+
+export async function hasuraAuthorPage(params) {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_AUTHOR_PAGE,
+    name: 'MyQuery',
+    variables: {
+      author_slug: params['authorSlug'],
       locale_code: params['localeCode'],
     },
   });

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -7,6 +7,71 @@ const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
 
+const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
+  articles(where: {article_translations: {locale_code: {_eq: $locale_code}}, category: {slug: {_eq: $category_slug}}}) {
+    article_translations(where: {locale_code: {_eq: $locale_code}}) {
+      content
+      custom_byline
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+      updated_at
+    }
+    category {
+      slug
+      id
+      category_translations(where: {locale_code: {_eq: $locale_code}}) {
+        title
+      }
+    }
+    slug
+    author_articles {
+      author {
+        name
+        photoUrl
+        slug
+        author_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+    }
+    tag_articles(where: {tag: {published: {_eq: true}, tag_translations: {locale_code: {_eq: $locale_code}}}}) {
+      tag {
+        tag_translations {
+          title
+        }
+        slug
+      }
+    }
+  }
+  categories(where: {published: {_eq: true}}) {
+    category_translations(where:{locale_code:{_eq: $locale_code}}) {
+      title
+      locale_code
+    }
+    slug
+  }
+  tags(where: {published: {_eq: true}}) {
+    id
+    slug
+    tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+}`;
+
 const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
     article_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -55,6 +120,13 @@ const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code
       locale_code
     }
     slug
+  }
+  tags(where: {published: {_eq: true}}) {
+    id
+    slug
+    tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
   }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -424,6 +496,19 @@ export async function hasuraCategoryPage(params) {
     url: process.env.HASURA_API_URL,
     orgSlug: process.env.ORG_SLUG,
     query: HASURA_CATEGORY_PAGE,
+    name: 'MyQuery',
+    variables: {
+      category_slug: params['categorySlug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
+
+export async function hasuraPreviewArticlePage(params) {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_PREVIEW_ARTICLE_PAGE,
     name: 'MyQuery',
     variables: {
       category_slug: params['categorySlug'],

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -64,6 +64,64 @@ const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code
   }
 }`;
 
+const HASURA_TAG_PAGE = `query MyQuery($locale_code: String, $tag_slug: String!) {
+  categories(where: {published: {_eq: true}}) {
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      locale_code
+    }
+    slug
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+  tags(where: {slug: {_eq: $tag_slug}}) {
+    id
+    slug
+    tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+    tag_articles(where: {article: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}}) {
+      article {
+        article_translations(where: {locale_code: {_eq: $locale_code}}) {
+          content
+          custom_byline
+          facebook_description
+          facebook_title
+          first_published_at
+          headline
+          last_published_at
+          search_description
+          search_title
+          twitter_description
+          twitter_title
+        }
+        category {
+          slug
+          id
+          category_translations(where: {locale_code: {_eq: $locale_code}}) {
+            title
+          }
+        }
+        slug
+        author_articles {
+          author {
+            name
+            photoUrl
+            slug
+            author_translations(where: {locale_code: {_eq: $locale_code}}) {
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
 const HASURA_CATEGORY_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
     article_translations {
@@ -345,6 +403,19 @@ export async function hasuraListAllAuthorPaths() {
     orgSlug: process.env.ORG_SLUG,
     query: HASURA_GET_AUTHOR_SLUGS,
     name: 'MyQuery',
+  });
+}
+
+export async function hasuraTagPage(params) {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_TAG_PAGE,
+    name: 'MyQuery',
+    variables: {
+      tag_slug: params['tagSlug'],
+      locale_code: params['localeCode'],
+    },
   });
 }
 

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -109,7 +109,6 @@ export async function getStaticProps({ locale, params }) {
   return {
     props: {
       article,
-      locale,
       sections,
       ads,
       siteMetadata,

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -91,13 +91,8 @@ export async function getStaticProps({ locale, params }) {
       );
     }
 
-    console.log('sections: ', sections);
-
     article = data.articles.find((a) => a.slug === params.slug);
-    console.log('found article: ', article);
-
     sectionArticles = data.articles.filter((a) => a.slug !== params.slug);
-    console.log('section articles: ', sectionArticles);
 
     let metadatas = data.site_metadatas;
     try {

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -1,12 +1,9 @@
 import DefaultErrorPage from 'next/error';
 import {
-  listAllLocales,
-  getArticleBySlug,
-  listAllArticleSlugs,
-  listAllSections,
-  listAllTags,
+  hasuraListAllArticleSlugs,
+  hasuraPreviewArticlePage,
 } from '../../../lib/articles.js';
-import { getSiteMetadataForLocale } from '../../../lib/site_metadata.js';
+import { hasuraLocaliseText } from '../../../lib/utils.js';
 import { getArticleAds } from '../../../lib/ads.js';
 import { cachedContents } from '../../../lib/cached';
 import Article from '../../../components/Article.js';
@@ -23,8 +20,24 @@ export default function PreviewArticle(props) {
   return <Article {...props} />;
 }
 
-export async function getStaticPaths({ locales }) {
-  const paths = await listAllArticleSlugs(locales);
+export async function getStaticPaths() {
+  const { errors, data } = await hasuraListAllArticleSlugs();
+  if (errors) {
+    throw errors;
+  }
+
+  let paths = [];
+  for (const article of data.articles) {
+    for (const locale of article.article_translations) {
+      paths.push({
+        params: {
+          category: article.category.slug,
+          slug: article.slug,
+        },
+        locale: locale.locale_code,
+      });
+    }
+  }
   return {
     paths,
     fallback: false,
@@ -32,31 +45,73 @@ export async function getStaticPaths({ locales }) {
 }
 
 export async function getStaticProps({ locale, params }) {
-  const localeMappings = await cachedContents('locales', listAllLocales);
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
-  const currentLocale = localeMappings.find(
-    (localeMap) => localeMap.code === locale
-  );
+  let article = {};
+  let sectionArticles = [];
+  let sections = [];
+  let tags = [];
+  let siteMetadata;
 
-  const article = await getArticleBySlug(
-    currentLocale,
-    params.slug,
-    process.env.CONTENT_DELIVERY_API_URL
-  );
-  const sections = await cachedContents('sections', listAllSections);
-  const tags = await cachedContents('tags', listAllTags);
+  const { errors, data } = await hasuraPreviewArticlePage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    localeCode: locale,
+    categorySlug: params.category,
+  });
+  if (errors || !data) {
+    console.log('error gettig article page:', errors);
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    tags = data.tags;
+    for (var i = 0; i < tags.length; i++) {
+      tags[i].title = hasuraLocaliseText(tags[i].tag_translations, 'title');
+    }
+    sections = data.categories;
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
+
+    article = data.articles.find((a) => a.slug === params.slug);
+    if (article && article.article_translations.length > 1) {
+      // let mostRecentContent = article.article_translations.map(function(e) { return e.updated_at; }).sort().reverse()[0]
+      let mostRecentContents = article.article_translations.sort((a, b) => {
+        return new Date(b.updated_at) - new Date(a.updated_at);
+      });
+      let mostRecentContent = mostRecentContents[0];
+
+      console.log('mostRecentContent:', mostRecentContent.updated_at);
+
+      article.article_translations = [mostRecentContent];
+    }
+    sectionArticles = data.articles.filter((a) => a.slug !== params.slug);
+
+    let metadatas = data.site_metadatas;
+    try {
+      siteMetadata = metadatas[0].site_metadata_translations[0].data;
+    } catch (err) {
+      console.log('failed finding site metadata for ', locale, metadatas);
+    }
+  }
+
   const allAds = await cachedContents('ads', getArticleAds);
   const ads = allAds.filter((ad) => ad.adTypeId === 164);
-  const siteMetadata = await getSiteMetadataForLocale(currentLocale);
 
   return {
     props: {
-      ads,
       article,
-      currentLocale,
       sections,
-      tags,
+      ads,
       siteMetadata,
+      sectionArticles,
+      tags,
     },
   };
 }

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -69,6 +69,13 @@ export async function getStaticProps({ locale, params }) {
     };
   } else {
     tag = data.tags[0];
+
+    if (!tag || tag === undefined) {
+      return {
+        notFound: true,
+      };
+    }
+
     tag.tag_articles.map((tag_article) => {
       articles.push(tag_article.article);
     });

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -1,15 +1,9 @@
+import { useRouter } from 'next/router';
 import Layout from '../../components/Layout.js';
-import {
-  listAllLocales,
-  listAllArticlesByTag,
-  listAllSections,
-  listAllTagPaths,
-  getTagBySlug,
-} from '../../lib/articles.js';
-import { getSiteMetadataForLocale } from '../../lib/site_metadata.js';
+import { listAllTagPaths, hasuraTagPage } from '../../lib/articles.js';
 import { cachedContents } from '../../lib/cached';
 import { getArticleAds } from '../../lib/ads.js';
-import { localiseText } from '../../lib/utils.js';
+import { hasuraLocaliseText } from '../../lib/utils.js';
 import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
 
@@ -17,21 +11,27 @@ export default function TagPage({
   articles,
   tag,
   sections,
-  currentLocale,
   siteMetadata,
   expandedAds,
 }) {
+  const router = useRouter();
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
   const isAmp = useAmp();
-  let tagTitle = localiseText(currentLocale, tag.title);
+
+  let tagTitle = hasuraLocaliseText(tag.tag_translations, 'title');
   return (
-    <Layout meta={siteMetadata} sections={sections} locale={currentLocale}>
+    <Layout meta={siteMetadata} sections={sections}>
       <ArticleStream
         articles={articles}
         sections={sections}
         showCategory={true}
         isAmp={isAmp}
         title={`Articles tagged with ${tagTitle}`}
-        locale={currentLocale}
         metadata={siteMetadata}
         ads={expandedAds}
       />
@@ -48,23 +48,52 @@ export async function getStaticPaths({ locales }) {
 }
 
 export async function getStaticProps({ locale, params }) {
-  const localeMappings = await cachedContents('locales', listAllLocales);
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
-  const currentLocale = localeMappings.find(
-    (localeMap) => localeMap.code === locale
-  );
+  let articles = [];
+  let sections = [];
+  let tag;
+  let siteMetadata;
 
-  const siteMetadata = await getSiteMetadataForLocale(currentLocale);
+  const { errors, data } = await hasuraTagPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    tagSlug: params.slug,
+    localeCode: locale,
+  });
 
-  const articles = await listAllArticlesByTag(currentLocale, params.slug);
-  const sections = await cachedContents('sections', listAllSections);
-  const tag = await getTagBySlug(params.slug);
+  if (errors || !data) {
+    return {
+      notFound: true,
+    };
+  } else {
+    tag = data.tags[0];
+    tag.tag_articles.map((tag_article) => {
+      articles.push(tag_article.article);
+    });
+
+    sections = data.categories;
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
+
+    let metadatas = data.site_metadatas;
+    try {
+      siteMetadata = metadatas[0].site_metadata_translations[0].data;
+    } catch (err) {
+      console.log('failed finding site metadata for ', locale, metadatas);
+    }
+  }
+
   const allAds = await cachedContents('ads', getArticleAds);
   const expandedAds = allAds.filter((ad) => ad.adTypeId === 166);
 
   return {
     props: {
-      currentLocale,
       articles,
       tag,
       sections,


### PR DESCRIPTION
Closes #305 

This PR updates the preview page to use hasura. It works similarly to the article page, except it displays the most recently updated data in the current locale for the specified article.

If we need more particular preview handling, I think we need to do it by `id` or something. We weren't doing that before, though, so I'm hoping this result is the right one. Does that make sense? 

Navigating to http://localhost:3000/preview/covid-19/pandemic-test-article should show you a headline "A PREVIEW Article about the Pandemic" whereas the regular article view at http://localhost:3000/articles/covid-19/pandemic-test-article should show you the published headline "A Test Article about the Pandemic"