### PR TITLE
Feature/update about queries

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -513,7 +513,7 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
         }
       }
     }
-    page_translations(where:{locale_code: {_eq: $locale_code}}) {
+    page_translations(where: {locale_code: {_eq: $locale_code}}) {
       content
       facebook_description
       facebook_title
@@ -527,6 +527,12 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
       twitter_title
     }
     slug
+  }
+  categories(where: {published: {_eq: true}, category_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
   }
 }`;
 

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -2,87 +2,13 @@
 
 require('dotenv').config({ path: '.env.local' })
 
-const fetch = require("node-fetch");
+const shared = require("./shared");
 
 const apiUrl = process.env.HASURA_API_URL;
 const apiToken = process.env.ORG_SLUG;
 
-const HASURA_LIST_ORG_LOCALES = `query MyQuery {
-  organization_locales {
-    locale {
-      code
-    }
-  }
-}`;
-function hasuraListLocales(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_LIST_ORG_LOCALES,
-    name: 'MyQuery',
-    variables: {
-      locale_code: params['localeCode'],
-      slug: params['slug'],
-    },
-  });
-}
-
-const HASURA_UPSERT_SECTION = `mutation MyMutation($locale_code: String!, $title: String!, $slug: String!, $published: Boolean) {
-  insert_categories(objects: {slug: $slug, category_translations: {data: {locale_code: $locale_code, title: $title}, on_conflict: {constraint: category_translations_locale_code_category_id_key, update_columns: [title]}}, published: $published}, on_conflict: {constraint: categories_organization_id_slug_key, update_columns: [slug, published]}) {
-    returning {
-      id
-      slug
-      published
-    }
-  }
-}`;
-async function fetchGraphQL(params) {
-  let url;
-  let orgSlug;
-  if (!params.hasOwnProperty('url')) {
-    url = HASURA_API_URL;
-  } else {
-    url = params['url'];
-  }
-  if (!params.hasOwnProperty('orgSlug')) {
-    orgSlug = ORG_SLUG;
-  } else {
-    orgSlug = params['orgSlug'];
-  }
-  let operationQuery = params['query'];
-  let operationName = params['name'];
-  let variables = params['variables'];
-
-  const result = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'TNC-Organization': orgSlug,
-    },
-    body: JSON.stringify({
-      query: operationQuery,
-      variables: variables,
-      operationName: operationName,
-    }),
-  });
-
-  return await result.json();
-}
-function hasuraUpsertSection(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_SECTION,
-    name: 'MyMutation',
-    variables: {
-      locale_code: params['localeCode'],
-      slug: params['slug'],
-      published: params['published'],
-      title: params['title'],
-    },
-  });
-}
 async function createGeneralNewsCategory() {
-  const localeResult = await hasuraListLocales({
+  const localeResult = await shared.hasuraListLocales({
     url: apiUrl,
     orgSlug: apiToken,
   });
@@ -96,7 +22,7 @@ async function createGeneralNewsCategory() {
 
   for (var i = 0; i < locales.length; i++) {
     let locale = locales[i].locale.code;
-    const { errors, data } = await hasuraUpsertSection({
+    const { errors, data } = await shared.hasuraUpsertSection({
       url: apiUrl,
       orgSlug: apiToken,
       title: "News",
@@ -113,30 +39,8 @@ async function createGeneralNewsCategory() {
   }
 }
 
-const HASURA_UPSERT_LAYOUT = `mutation MyMutation($name: String!, $data: jsonb!) {
-  insert_homepage_layout_schemas(objects: {name: $name, data: $data}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
-    returning {
-      id
-      name
-    }
-  }
-}`;
-
-function hasuraUpsertHomepageLayout(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_LAYOUT,
-    name: 'MyMutation',
-    variables: {
-      name: params['name'],
-      data: params['data'],
-    },
-  });
-}
-
 async function createHomepageLayout1() {
-  const { errors, data } = await hasuraUpsertHomepageLayout({
+  const { errors, data } = await shared.hasuraUpsertHomepageLayout({
     url: apiUrl,
     orgSlug: apiToken,
     name: "Large Package Story Lead",
@@ -151,7 +55,7 @@ async function createHomepageLayout1() {
 }
 
 async function createHomepageLayout2() {
-  const { errors, data } = await hasuraUpsertHomepageLayout({
+  const { errors, data } = await shared.hasuraUpsertHomepageLayout({
     url: apiUrl,
     orgSlug: apiToken,
     name: "Big Featured Story",
@@ -165,29 +69,6 @@ async function createHomepageLayout2() {
   }
 }
 
-
-const HASURA_UPSERT_METADATA = `mutation MyMutation($published: Boolean, $data: jsonb, $locale_code: String) {
-  insert_site_metadatas(objects: {published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
-    returning {
-      id
-      published
-    }
-  }
-}`;
-
-function hasuraUpsertMetadata(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_METADATA,
-    name: 'MyMutation',
-    variables: {
-      data: params['data'],
-      published: params['published'],
-      locale_code: params['localeCode']
-    },
-  });
-}
 
 async function createMetadata() {
   const data = {
@@ -217,7 +98,7 @@ async function createMetadata() {
     "color": "colorone",
   };
 
-  const localeResult = await hasuraListLocales({
+  const localeResult = await shared.hasuraListLocales({
     url: apiUrl,
     orgSlug: apiToken,
   });
@@ -231,7 +112,7 @@ async function createMetadata() {
 
   for (var i = 0; i < locales.length; i++) {
     let locale = locales[i].locale.code;
-    let result = await hasuraUpsertMetadata({
+    let result = await shared.hasuraUpsertMetadata({
       url: apiUrl,
       orgSlug: apiToken,
       data: data,

--- a/script/populate.js
+++ b/script/populate.js
@@ -6,12 +6,11 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 
+const shared = require("./shared");
 const gql = require('../lib/graphql/queries');
-const { create } = require('domain');
 
-const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
-const CONTENT_DELIVERY_API_ACCESS_TOKEN =
-  process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
 
 function writeCache(name, data) {
   const cachedFile = path.join(process.cwd(), 'cached', `${name}.json`);
@@ -21,112 +20,50 @@ function writeCache(name, data) {
   });
 }
 
-function listLocales() {
-  const query = `
-    query ListI18nLocales {
-      i18n {
-        listI18NLocales {
-          data {
-            id
-            code
-            default
-          }
-        }
-      }
-    }
-  `;
+async function listLocales() {
+  const localeResult = await shared.hasuraListLocales({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
 
-  const url = CONTENT_DELIVERY_API_URL;
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((responseParsed) => {
-      let locales = responseParsed.data.i18n.listI18NLocales.data;
-      writeCache('locales', locales);
-    })
-    .catch(console.error);
+  let locales;
+  if (localeResult.errors) {
+    console.error("Error listing locales:", localeResult.errors);
+  } else {
+    locales = localeResult.data.organization_locales;
+  }
+
+  writeCache('locales', locales);
 }
 
-function listSections() {
-  const query = `
-    {
-      categories {
-        listCategories {
-          data {
-            id
-            slug
-            title {
-              values {
-                value
-                locale
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const url = CONTENT_DELIVERY_API_URL;
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      let sections = data.data.categories.listCategories.data;
-      writeCache('sections', sections);
-    })
-    .catch(console.error);
+async function listSections() {
+  const result = await shared.hasuraListSections({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  let sections;
+  if (result.errors) {
+    console.error("Error listing sections:", result.errors);
+  } else {
+    sections = result.data.categories;
+  }
+  writeCache('sections', sections);
 }
 
-function listTags() {
-  const query = `
-    {
-      tags {
-        listTags {
-          data {
-            id
-            slug
-            title {
-              values {
-                value
-                locale
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const url = CONTENT_DELIVERY_API_URL;
-  console.log(url, CONTENT_DELIVERY_API_ACCESS_TOKEN);
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      let tags = data.data.tags.listTags.data;
-      writeCache('tags', tags);
-    })
-    .catch(console.error);
+async function listTags() {
+  const result = await shared.hasuraListTags({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  let tags;
+  if (result.errors) {
+    console.error("Error listing tags:", result.errors);
+  } else {
+    tags = result.data.tags;
+  }
+  writeCache('tags', tags);
 }
 
 function getAds() {
@@ -145,59 +82,8 @@ function getAds() {
     .catch(console.error);
 }
 
-function createHomepageLayouts() {
-  const url = CONTENT_DELIVERY_API_URL;
-
-  const lpslVars = {
-    data: {
-      name: "Large Package Story Lead",
-      data: "{ \"subfeatured-top\":\"string\", \"subfeatured-bottom\":\"string\", \"featured\":\"string\" }"
-    }
-  };
-
-  const bfsVars = {
-    data: {
-      name: "Big Featured Story",
-      data: "{ \"featured\":\"string\" }"
-    }
-  };
-
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-
-    body: JSON.stringify({
-      query: gql.CREATE_LAYOUT_SCHEMA,
-      variables: lpslVars
-    }),
-  };
-
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      console.log(JSON.stringify(data));
-    })
-    .catch(console.error);
-
-  opts.body = JSON.stringify({
-      query: gql.CREATE_LAYOUT_SCHEMA,
-      variables: bfsVars
-  })
-
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      console.log(JSON.stringify(data));
-    })
-    .catch(console.error);
-}
-
 async function main() {
   console.log("HASURA_API_URL:", process.env.HASURA_API_URL, "ORG_SLUG:", process.env.ORG_SLUG);
-  createHomepageLayouts();
   listLocales();
   listSections();
   listTags();

--- a/script/shared.js
+++ b/script/shared.js
@@ -68,6 +68,45 @@ function hasuraUpsertSection(params) {
     },
   });
 }
+
+const HASURA_LIST_TAGS = `query MyQuery {
+  tags(where: {published: {_eq: true}}) {
+    slug
+    tag_translations {
+      locale_code
+      title
+    }
+  }
+}`;
+
+function hasuraListTags(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_TAGS,
+    name: 'MyQuery',
+  });
+}
+
+const HASURA_LIST_SECTIONS = `query MyQuery {
+  categories(where: {published: {_eq: true}}) {
+    slug
+    category_translations {
+      title
+      locale_code
+    }
+  }
+}`;
+
+function hasuraListSections(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_SECTIONS,
+    name: 'MyQuery',
+  });
+}
+
 const HASURA_LIST_ORG_LOCALES = `query MyQuery {
   organization_locales {
     locale {
@@ -122,6 +161,8 @@ async function fetchGraphQL(params) {
 
 module.exports = {
   hasuraListLocales,
+  hasuraListSections,
+  hasuraListTags,
   hasuraUpsertHomepageLayout,
   hasuraUpsertMetadata,
   hasuraUpsertSection,

--- a/script/shared.js
+++ b/script/shared.js
@@ -1,0 +1,130 @@
+const fetch = require("node-fetch");
+
+const HASURA_UPSERT_METADATA = `mutation MyMutation($published: Boolean, $data: jsonb, $locale_code: String) {
+  insert_site_metadatas(objects: {published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
+    returning {
+      id
+      published
+    }
+  }
+}`;
+
+function hasuraUpsertMetadata(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_METADATA,
+    name: 'MyMutation',
+    variables: {
+      data: params['data'],
+      published: params['published'],
+      locale_code: params['localeCode']
+    },
+  });
+}
+
+const HASURA_UPSERT_LAYOUT = `mutation MyMutation($name: String!, $data: jsonb!) {
+  insert_homepage_layout_schemas(objects: {name: $name, data: $data}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
+    returning {
+      id
+      name
+    }
+  }
+}`;
+
+function hasuraUpsertHomepageLayout(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_LAYOUT,
+    name: 'MyMutation',
+    variables: {
+      name: params['name'],
+      data: params['data'],
+    },
+  });
+}
+
+const HASURA_UPSERT_SECTION = `mutation MyMutation($locale_code: String!, $title: String!, $slug: String!, $published: Boolean) {
+  insert_categories(objects: {slug: $slug, category_translations: {data: {locale_code: $locale_code, title: $title}, on_conflict: {constraint: category_translations_locale_code_category_id_key, update_columns: [title]}}, published: $published}, on_conflict: {constraint: categories_organization_id_slug_key, update_columns: [slug, published]}) {
+    returning {
+      id
+      slug
+      published
+    }
+  }
+}`;
+function hasuraUpsertSection(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_SECTION,
+    name: 'MyMutation',
+    variables: {
+      locale_code: params['localeCode'],
+      slug: params['slug'],
+      published: params['published'],
+      title: params['title'],
+    },
+  });
+}
+const HASURA_LIST_ORG_LOCALES = `query MyQuery {
+  organization_locales {
+    locale {
+      code
+    }
+  }
+}`;
+function hasuraListLocales(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_ORG_LOCALES,
+    name: 'MyQuery',
+    variables: {
+      locale_code: params['localeCode'],
+      slug: params['slug'],
+    },
+  });
+}
+
+async function fetchGraphQL(params) {
+  let url;
+  let orgSlug;
+  if (!params.hasOwnProperty('url')) {
+    url = HASURA_API_URL;
+  } else {
+    url = params['url'];
+  }
+  if (!params.hasOwnProperty('orgSlug')) {
+    orgSlug = ORG_SLUG;
+  } else {
+    orgSlug = params['orgSlug'];
+  }
+  let operationQuery = params['query'];
+  let operationName = params['name'];
+  let variables = params['variables'];
+
+  const result = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'TNC-Organization': orgSlug,
+    },
+    body: JSON.stringify({
+      query: operationQuery,
+      variables: variables,
+      operationName: operationName,
+    }),
+  });
+
+  return await result.json();
+}
+
+module.exports = {
+  hasuraListLocales,
+  hasuraUpsertHomepageLayout,
+  hasuraUpsertMetadata,
+  hasuraUpsertSection,
+  fetchGraphQL
+
+}


### PR DESCRIPTION
Closes #312 

Related to #313 

This streamlines the about page:

* no more cached content
* sections come from `GetPage` call
* locale mappings not needed