### PR TITLE
Removes locale mappings, updates remaining tinycms for hasura

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -12,6 +12,8 @@ export default function Layout({ children, meta, article, sections }) {
     meta = {};
   }
 
+  console.log(sections);
+
   const metaValues = {
     canonical: meta['siteUrl'],
     siteName: meta['shortName'],

--- a/components/tinycms/AdminHeader.js
+++ b/components/tinycms/AdminHeader.js
@@ -7,7 +7,7 @@ export default function AdminHeader(props) {
       <div className="level-left">
         <div className="level-item">
           <h1 className="title">
-            {props.title} ({props.currentLocale.code})
+            {props.title} ({props.currentLocale})
           </h1>
         </div>
       </div>

--- a/components/tinycms/LocaleSwitcher.js
+++ b/components/tinycms/LocaleSwitcher.js
@@ -2,10 +2,8 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 
 export default function LocaleSwitcher({ currentLocale, locales, id }) {
-  const [selectedLocale, setSelectedLocale] = useState(currentLocale.code);
+  const [selectedLocale, setSelectedLocale] = useState(currentLocale);
   const router = useRouter();
-
-  // console.log('currentLocale:', currentLocale, 'locales:', locales);
 
   function localisePath(event) {
     setSelectedLocale(event.target.value);
@@ -34,9 +32,9 @@ export default function LocaleSwitcher({ currentLocale, locales, id }) {
   let localeOptions;
 
   if (locales) {
-    localeOptions = locales.map((locale, index) => (
-      <option key={`locale-${index}`} value={locale.code}>
-        {locale.code}
+    localeOptions = locales.map((localeData, index) => (
+      <option key={`locale-${index}`} value={localeData.locale.code}>
+        {localeData.locale.code}
       </option>
     ));
   }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -388,6 +388,16 @@ const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code
   }
 }`;
 
+const HASURA_LIST_TAGS = `query MyQuery {
+  tags(where: {published: {_eq: true}}) {
+    slug
+    tag_translations {
+      locale_code
+      title
+    }
+  }
+}`;
+
 const HASURA_TAG_PAGE = `query MyQuery($locale_code: String, $tag_slug: String!) {
   categories(where: {published: {_eq: true}}) {
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -716,6 +726,15 @@ export function hasuraGetHomepageData(params) {
     url: params['url'],
     orgSlug: params['orgSlug'],
     query: HASURA_GET_HOMEPAGE_DATA,
+    name: 'MyQuery',
+  });
+}
+
+export function hasuraListAllTags(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_TAGS,
     name: 'MyQuery',
   });
 }

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -513,7 +513,7 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
         }
       }
     }
-    page_translations(where:{locale_code: {_eq: $locale_code}}) {
+    page_translations(where: {locale_code: {_eq: $locale_code}}) {
       content
       facebook_description
       facebook_title
@@ -527,6 +527,12 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
       twitter_title
     }
     slug
+  }
+  categories(where: {published: {_eq: true}, category_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
   }
 }`;
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -586,6 +586,11 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
       title
     }
   }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations {
+      data
+    }
+  }
 }`;
 
 const HASURA_GET_ARTICLE_BY_SLUG = `query MyQuery($slug: String!, $locale_code: String!) {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -425,7 +425,13 @@ const HASURA_GET_METADATA_BY_LOCALE = `query MyQuery($locale_code: String!) {
 }`;
 
 const HASURA_LIST_TAGS = `query MyQuery {
+  organization_locales {
+    locale {
+      code
+    }
+  }
   tags(where: {published: {_eq: true}}) {
+    id
     slug
     tag_translations {
       locale_code

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -7,6 +7,26 @@ const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
 
+const HASURA_LIST_ORG_LOCALES = `query MyQuery {
+  organization_locales {
+    locale {
+      code
+    }
+  }
+}`;
+export function hasuraListLocales(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_ORG_LOCALES,
+    name: 'MyQuery',
+    variables: {
+      locale_code: params['localeCode'],
+      slug: params['slug'],
+    },
+  });
+}
+
 const HASURA_SEARCH_ARTICLES = `query MyQuery($locale_code: String!, $term: String!) {
   articles(where: {article_translations: {headline: {_ilike: $term}, locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
     id

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -408,6 +408,22 @@ const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code
   }
 }`;
 
+const HASURA_GET_METADATA_BY_LOCALE = `query MyQuery($locale_code: String!) {
+  organization_locales {
+    locale {
+      code
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}}) {
+    id
+    published
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+}`;
+
 const HASURA_LIST_TAGS = `query MyQuery {
   tags(where: {published: {_eq: true}}) {
     slug
@@ -776,6 +792,18 @@ export function hasuraGetPage(params) {
     name: 'MyQuery',
     variables: {
       slug: params['slug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
+
+export function hasuraGetMetadataByLocale(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_METADATA_BY_LOCALE,
+    name: 'MyQuery',
+    variables: {
       locale_code: params['localeCode'],
     },
   });

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -7,6 +7,11 @@ const CONTENT_DELIVERY_API_ACCESS_TOKEN =
 
 const HASURA_LIST_AUTHORS = `
   query MyQuery($localeCode: String) {
+    organization_locales {
+      locale {
+        code
+      }
+    }
     authors {
       id
       name
@@ -68,6 +73,11 @@ const HASURA_GET_AUTHOR_BY_SLUG = `query MyQuery($slug: String) {
 }`;
 
 const HASURA_GET_AUTHOR_BY_ID = `query MyQuery($id: Int!) {
+  organization_locales {
+    locale {
+      code
+    }
+  }
   authors_by_pk(id: $id) {
     id
     name

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -1,6 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
 import _ from 'lodash';
-import { localiseText } from './utils';
 import { fetchGraphQL } from './utils';
 
 const gql = require('./graphql/queries');
@@ -8,6 +7,20 @@ const gql = require('./graphql/queries');
 const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
 const CONTENT_DELIVERY_API_ACCESS_TOKEN =
   process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+
+const HASURA_LIST_HOMEPAGE_LAYOUT_SCHEMAS = `query MyQuery {
+  homepage_layout_schemas {
+    id
+    name
+    data
+  }
+}`;
+
+const HASURA_UPDATE_HOMEPAGE_LAYOUT_SCHEMA = `mutation MyMutation($id: Int!, $data: jsonb, $name: String) {
+  update_homepage_layout_schemas_by_pk(pk_columns: {id: $id}, _set: {data: $data, name: $name}) {
+    id
+  }
+}`;
 
 const HASURA_GET_STREAM_ARTICLES = `query MyQuery($locale_code: String, $ids: [Int!]) {
   articles(where: {id: {_nin: $ids}, article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}, limit: 10, order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}) {
@@ -96,6 +109,61 @@ const HASURA_GET_HOMEPAGE_DATA = `query MyQuery($locale_code: String!) {
   }
 }`;
 
+const HASURA_GET_HOMEPAGE_LAYOUT_BY_ID = `query MyQuery($id: Int!) {
+  homepage_layout_schemas_by_pk(id: $id) {
+    id
+    data
+    name
+  }
+}`;
+
+export function hasuraGetHomepageLayout(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_HOMEPAGE_LAYOUT_BY_ID,
+    name: 'MyQuery',
+    variables: {
+      id: params['id'],
+    },
+  });
+}
+
+const HASURA_UPSERT_LAYOUT = `mutation MyMutation($name: String!, $data: jsonb!) {
+  insert_homepage_layout_schemas(objects: {name: $name, data: $data}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
+    returning {
+      id
+      name
+    }
+  }
+}`;
+
+export function hasuraUpdateHomepageLayout(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPDATE_HOMEPAGE_LAYOUT_SCHEMA,
+    name: 'MyMutation',
+    variables: {
+      id: params['id'],
+      name: params['name'],
+      data: params['data'],
+    },
+  });
+}
+export function hasuraUpsertHomepageLayout(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_LAYOUT,
+    name: 'MyMutation',
+    variables: {
+      name: params['name'],
+      data: params['data'],
+    },
+  });
+}
+
 export async function hasuraStreamArticles(params) {
   return fetchGraphQL({
     url: process.env.HASURA_API_URL,
@@ -106,6 +174,15 @@ export async function hasuraStreamArticles(params) {
       locale_code: params['localeCode'],
       ids: params['ids'],
     },
+  });
+}
+
+export async function hasuraListHomepageLayoutSchemas(params) {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_LIST_HOMEPAGE_LAYOUT_SCHEMAS,
+    name: 'MyQuery',
   });
 }
 

--- a/lib/section.js
+++ b/lib/section.js
@@ -8,8 +8,30 @@ const CONTENT_DELIVERY_API_ACCESS_TOKEN =
 
 const gql = require('./graphql/queries');
 
+const HASURA_GET_TAG_BY_ID = `query MyQuery($id: Int!) {
+  organization_locales {
+    locale {
+      code
+    }
+  }
+  tags_by_pk(id: $id) {
+    id
+    published
+    tag_translations {
+      title
+    }
+    slug
+  }
+}`;
+
 const HASURA_LIST_ALL_SECTIONS_BY_LOCALE = `query MyQuery($locale_code: String = "") {
+  organization_locales {
+    locale {
+      code
+    }
+  }
   categories(where: {published: {_eq: true}}) {
+    id
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
     }
@@ -27,6 +49,13 @@ const HASURA_UPSERT_SECTION = `mutation MyMutation($locale_code: String!, $title
   }
 }`;
 
+const HASURA_INSERT_TAG = `mutation insert_single_tag($locale_code: String, $title: String, $published: Boolean, $slug: String) {
+  insert_tags_one(object: {slug: $slug, published: $published, tag_translations: {data: {locale_code: $locale_code, title: $title}}}) {
+    id
+    slug
+  }
+}`;
+
 const HASURA_INSERT_SECTION = `mutation insert_single_category($locale_code: String, $title: String, $published: Boolean, $slug: String) {
   insert_categories_one(object: {slug: $slug, published: $published, category_translations: {data: {locale_code: $locale_code, title: $title}}}) {
     id
@@ -35,12 +64,30 @@ const HASURA_INSERT_SECTION = `mutation insert_single_category($locale_code: Str
 }`;
 
 const HASURA_GET_SECTION_BY_ID = `query MyQuery($id: Int!) {
+  organization_locales {
+    locale {
+      code
+    }
+  }
   categories_by_pk(id: $id) {
     id
     published
     category_translations {
       title
     }
+    slug
+  }
+}`;
+
+const HASURA_UPDATE_TAG = `mutation updateTagWithTranslations($tag_id: Int!, $locale_code: String!, $title: String, $published: Boolean, $slug: String) {
+  delete_tag_translations(where: {tag_id: {_eq: $tag_id}, locale_code: {_eq: $locale_code}}) {
+    affected_rows
+  }
+  insert_tag_translations(objects: [{tag_id: $tag_id, locale_code: $locale_code, title: $title}]) {
+    affected_rows
+  }
+  update_tags_by_pk(pk_columns: {id: $tag_id}, _set: {published: $published, slug: $slug}) {
+    published
     slug
   }
 }`;
@@ -85,6 +132,21 @@ export function hasuraUpsertSection(params) {
   });
 }
 
+export function hasuraCreateTag(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_TAG,
+    name: 'insert_single_tag',
+    variables: {
+      locale_code: params['localeCode'],
+      title: params['title'],
+      published: params['published'],
+      slug: params['slug'],
+    },
+  });
+}
+
 export function hasuraCreateSection(params) {
   return fetchGraphQL({
     url: params['url'],
@@ -96,6 +158,18 @@ export function hasuraCreateSection(params) {
       title: params['title'],
       published: params['published'],
       slug: params['slug'],
+    },
+  });
+}
+
+export function hasuraGetTagById(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_TAG_BY_ID,
+    name: 'MyQuery',
+    variables: {
+      id: params['id'],
     },
   });
 }
@@ -112,6 +186,21 @@ export function hasuraGetSectionById(params) {
   });
 }
 
+export function hasuraUpdateTag(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPDATE_TAG,
+    name: 'updateTagWithTranslations',
+    variables: {
+      tag_id: params['id'],
+      locale_code: params['localeCode'],
+      title: params['title'],
+      published: params['published'],
+      slug: params['slug'],
+    },
+  });
+}
 export function hasuraUpdateSection(params) {
   return fetchGraphQL({
     url: params['url'],

--- a/lib/site_metadata.js
+++ b/lib/site_metadata.js
@@ -100,7 +100,28 @@ export async function createSiteMetadata(url, token, locale, data) {
   );
   return responseData;
 }
+const HASURA_UPSERT_METADATA = `mutation MyMutation($published: Boolean, $data: jsonb, $locale_code: String) {
+  insert_site_metadatas(objects: {published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
+    returning {
+      id
+      published
+    }
+  }
+}`;
 
+export function hasuraUpsertMetadata(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_METADATA,
+    name: 'MyMutation',
+    variables: {
+      data: params['data'],
+      published: params['published'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
 export async function updateSiteMetadata(
   url,
   token,

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -37,7 +37,6 @@ export async function getStaticPaths({ locales }) {
   const apiToken = process.env.ORG_SLUG;
 
   let paths = [];
-  let sections = [];
   const { errors, data } = await hasuraListAllSections({
     url: apiUrl,
     orgSlug: apiToken,
@@ -48,19 +47,17 @@ export async function getStaticPaths({ locales }) {
       paths,
       fallback: true,
     };
-  } else {
-    sections = data.categories;
   }
 
-  for (const locale of locales) {
-    sections.map((section) => {
+  for (const section of data.categories) {
+    for (const locale of section.category_translations) {
       paths.push({
         params: {
           category: section.slug,
         },
-        locale,
+        locale: locale.locale_code,
       });
-    });
+    }
   }
 
   return {

--- a/pages/about.js
+++ b/pages/about.js
@@ -4,7 +4,7 @@ import { hasuraLocaliseText } from '../lib/utils';
 import Layout from '../components/Layout';
 import { renderBody } from '../lib/utils.js';
 
-export default function About({ page, sections }) {
+export default function About({ page, sections, siteMetadata }) {
   const isAmp = useAmp();
 
   // there will only be one translation returned for a given page + locale
@@ -12,7 +12,7 @@ export default function About({ page, sections }) {
   const body = renderBody(localisedPage, isAmp);
 
   return (
-    <Layout meta={localisedPage} sections={sections}>
+    <Layout meta={siteMetadata} sections={sections}>
       <article className="container">
         <div className="post__title">{localisedPage.headline}</div>
         <section className="section" key="body">
@@ -53,6 +53,7 @@ export async function getStaticProps({ locale }) {
 
   let page = {};
   let sections;
+  let siteMetadata = {};
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
@@ -66,14 +67,23 @@ export async function getStaticProps({ locale }) {
     };
     // throw errors;
   } else {
+    console.log(data);
     sections = data.categories;
     page = data.pages[0];
+    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
   }
 
   return {
     props: {
       page,
       sections,
+      siteMetadata,
     },
   };
 }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -102,7 +102,6 @@ export async function getStaticProps({ locale, params }) {
     }
   }
 
-  // const sections = await cachedContents('sections', listAllSections);
   const allAds = await cachedContents('ads', getArticleAds);
   const ads = allAds.filter((ad) => ad.adTypeId === 164);
 

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -61,7 +61,7 @@ export async function getStaticProps({ locale, params }) {
     categorySlug: params.category,
   });
   if (errors || !data) {
-    console.log('error gettig article page:', errors);
+    console.log('error getting article page:', errors);
     return {
       notFound: true,
     };
@@ -86,8 +86,6 @@ export async function getStaticProps({ locale, params }) {
         return new Date(b.updated_at) - new Date(a.updated_at);
       });
       let mostRecentContent = mostRecentContents[0];
-
-      console.log('mostRecentContent:', mostRecentContent.updated_at);
 
       article.article_translations = [mostRecentContent];
     }

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -5,10 +5,8 @@ import AdminNav from '../../../components/nav/AdminNav';
 import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
-import { listAllLocales } from '../../../lib/articles.js';
 import { hasuraGetAuthorById, hasuraUpdateAuthor } from '../../../lib/authors';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
-import { cachedContents } from '../../../lib/cached';
 
 export default function EditAuthor({
   apiUrl,
@@ -251,12 +249,6 @@ export default function EditAuthor({
 }
 
 export async function getServerSideProps(context) {
-  const localeMappings = await cachedContents('locales', listAllLocales);
-
-  const currentLocale = localeMappings.find(
-    (localeMap) => localeMap.code === context.locale
-  );
-
   const apiUrl = process.env.HASURA_API_URL;
   const apiToken = process.env.ORG_SLUG;
 
@@ -269,6 +261,7 @@ export async function getServerSideProps(context) {
   };
 
   let author = {};
+  let locales;
   const { errors, data } = await hasuraGetAuthorById({
     url: apiUrl,
     orgSlug: apiToken,
@@ -278,6 +271,7 @@ export async function getServerSideProps(context) {
     throw errors;
   } else {
     author = data.authors_by_pk;
+    locales = data.organization_locales;
   }
 
   return {
@@ -285,8 +279,8 @@ export async function getServerSideProps(context) {
       apiUrl: apiUrl,
       apiToken: apiToken,
       author: author,
-      currentLocale: currentLocale,
-      locales: localeMappings,
+      currentLocale: context.locale,
+      locales: locales,
       awsConfig: awsConfig,
     },
   };

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -5,10 +5,8 @@ import AdminLayout from '../../../components/AdminLayout.js';
 import AdminHeader from '../../../components/tinycms/AdminHeader';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
-import { listAllLocales } from '../../../lib/articles.js';
 import { hasuraListAllAuthors } from '../../../lib/authors.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
-import { cachedContents } from '../../../lib/cached';
 
 export default function Authors({ authors, currentLocale, locales }) {
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -76,25 +74,20 @@ export default function Authors({ authors, currentLocale, locales }) {
 }
 
 export async function getServerSideProps(context) {
-  const localeMappings = await cachedContents('locales', listAllLocales);
-
-  const currentLocale = localeMappings.find(
-    (localeMap) => localeMap.code === context.locale
-  );
-
-  const { errors, data } = await hasuraListAllAuthors(currentLocale.code);
+  const { errors, data } = await hasuraListAllAuthors(context.locale);
 
   if (errors) {
     console.error(errors);
   }
 
   let authors = data.authors;
+  let locales = data.organization_locales;
 
   return {
     props: {
       authors: authors,
-      currentLocale: currentLocale,
-      locales: localeMappings,
+      currentLocale: context.locale,
+      locales: locales,
     },
   };
 }

--- a/pages/tinycms/homepage-layouts/index.js
+++ b/pages/tinycms/homepage-layouts/index.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { listLayoutSchemas } from '../../../lib/homepage.js';
+import { hasuraListHomepageLayoutSchemas } from '../../../lib/homepage.js';
 import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
 
@@ -53,7 +53,21 @@ export default function HomepageLayouts({ homepageLayouts }) {
 }
 
 export async function getServerSideProps() {
-  let homepageLayouts = await listLayoutSchemas();
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  const { errors, data } = await hasuraListHomepageLayoutSchemas({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  let homepageLayouts;
+  if (errors) {
+    throw errors;
+  } else {
+    homepageLayouts = data.homepage_layout_schemas;
+  }
+
   return {
     props: {
       homepageLayouts: homepageLayouts,

--- a/pages/tinycms/sections/index.js
+++ b/pages/tinycms/sections/index.js
@@ -5,9 +5,7 @@ import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
 import AdminHeader from '../../../components/tinycms/AdminHeader';
 import { hasuraLocaliseText } from '../../../lib/utils';
-import { listAllLocales } from '../../../lib/articles.js';
 import { hasuraListAllSectionsByLocale } from '../../../lib/section.js';
-import { cachedContents } from '../../../lib/cached';
 
 export default function Sections({ sections, currentLocale, locales }) {
   const [message, setMessage] = useState(null);
@@ -63,27 +61,27 @@ export default function Sections({ sections, currentLocale, locales }) {
 }
 
 export async function getServerSideProps(context) {
-  const localeMappings = await cachedContents('locales', listAllLocales);
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
-  const currentLocale = localeMappings.find(
-    (localeMap) => localeMap.code === context.locale
-  );
-
-  const { errors, data } = await hasuraListAllSectionsByLocale(
-    currentLocale.code
-  );
+  const { errors, data } = await hasuraListAllSectionsByLocale({
+    url: apiUrl,
+    orgSlug: apiToken,
+    localeCode: context.locale,
+  });
 
   if (errors) {
     console.error(errors);
   }
 
   let sections = data.categories;
+  let locales = data.organization_locales;
 
   return {
     props: {
       sections: sections,
-      currentLocale: currentLocale,
-      locales: localeMappings,
+      currentLocale: context.locale,
+      locales: locales,
     },
   };
 }

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -2,87 +2,13 @@
 
 require('dotenv').config({ path: '.env.local' })
 
-const fetch = require("node-fetch");
+const shared = require("./shared");
 
 const apiUrl = process.env.HASURA_API_URL;
 const apiToken = process.env.ORG_SLUG;
 
-const HASURA_LIST_ORG_LOCALES = `query MyQuery {
-  organization_locales {
-    locale {
-      code
-    }
-  }
-}`;
-function hasuraListLocales(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_LIST_ORG_LOCALES,
-    name: 'MyQuery',
-    variables: {
-      locale_code: params['localeCode'],
-      slug: params['slug'],
-    },
-  });
-}
-
-const HASURA_UPSERT_SECTION = `mutation MyMutation($locale_code: String!, $title: String!, $slug: String!, $published: Boolean) {
-  insert_categories(objects: {slug: $slug, category_translations: {data: {locale_code: $locale_code, title: $title}, on_conflict: {constraint: category_translations_locale_code_category_id_key, update_columns: [title]}}, published: $published}, on_conflict: {constraint: categories_organization_id_slug_key, update_columns: [slug, published]}) {
-    returning {
-      id
-      slug
-      published
-    }
-  }
-}`;
-async function fetchGraphQL(params) {
-  let url;
-  let orgSlug;
-  if (!params.hasOwnProperty('url')) {
-    url = HASURA_API_URL;
-  } else {
-    url = params['url'];
-  }
-  if (!params.hasOwnProperty('orgSlug')) {
-    orgSlug = ORG_SLUG;
-  } else {
-    orgSlug = params['orgSlug'];
-  }
-  let operationQuery = params['query'];
-  let operationName = params['name'];
-  let variables = params['variables'];
-
-  const result = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'TNC-Organization': orgSlug,
-    },
-    body: JSON.stringify({
-      query: operationQuery,
-      variables: variables,
-      operationName: operationName,
-    }),
-  });
-
-  return await result.json();
-}
-function hasuraUpsertSection(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_SECTION,
-    name: 'MyMutation',
-    variables: {
-      locale_code: params['localeCode'],
-      slug: params['slug'],
-      published: params['published'],
-      title: params['title'],
-    },
-  });
-}
 async function createGeneralNewsCategory() {
-  const localeResult = await hasuraListLocales({
+  const localeResult = await shared.hasuraListLocales({
     url: apiUrl,
     orgSlug: apiToken,
   });
@@ -96,7 +22,7 @@ async function createGeneralNewsCategory() {
 
   for (var i = 0; i < locales.length; i++) {
     let locale = locales[i].locale.code;
-    const { errors, data } = await hasuraUpsertSection({
+    const { errors, data } = await shared.hasuraUpsertSection({
       url: apiUrl,
       orgSlug: apiToken,
       title: "News",
@@ -113,30 +39,8 @@ async function createGeneralNewsCategory() {
   }
 }
 
-const HASURA_UPSERT_LAYOUT = `mutation MyMutation($name: String!, $data: jsonb!) {
-  insert_homepage_layout_schemas(objects: {name: $name, data: $data}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
-    returning {
-      id
-      name
-    }
-  }
-}`;
-
-function hasuraUpsertHomepageLayout(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_LAYOUT,
-    name: 'MyMutation',
-    variables: {
-      name: params['name'],
-      data: params['data'],
-    },
-  });
-}
-
 async function createHomepageLayout1() {
-  const { errors, data } = await hasuraUpsertHomepageLayout({
+  const { errors, data } = await shared.hasuraUpsertHomepageLayout({
     url: apiUrl,
     orgSlug: apiToken,
     name: "Large Package Story Lead",
@@ -151,7 +55,7 @@ async function createHomepageLayout1() {
 }
 
 async function createHomepageLayout2() {
-  const { errors, data } = await hasuraUpsertHomepageLayout({
+  const { errors, data } = await shared.hasuraUpsertHomepageLayout({
     url: apiUrl,
     orgSlug: apiToken,
     name: "Big Featured Story",
@@ -165,29 +69,6 @@ async function createHomepageLayout2() {
   }
 }
 
-
-const HASURA_UPSERT_METADATA = `mutation MyMutation($published: Boolean, $data: jsonb, $locale_code: String) {
-  insert_site_metadatas(objects: {published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
-    returning {
-      id
-      published
-    }
-  }
-}`;
-
-function hasuraUpsertMetadata(params) {
-  return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
-    query: HASURA_UPSERT_METADATA,
-    name: 'MyMutation',
-    variables: {
-      data: params['data'],
-      published: params['published'],
-      locale_code: params['localeCode']
-    },
-  });
-}
 
 async function createMetadata() {
   const data = {
@@ -217,7 +98,7 @@ async function createMetadata() {
     "color": "colorone",
   };
 
-  const localeResult = await hasuraListLocales({
+  const localeResult = await shared.hasuraListLocales({
     url: apiUrl,
     orgSlug: apiToken,
   });
@@ -231,7 +112,7 @@ async function createMetadata() {
 
   for (var i = 0; i < locales.length; i++) {
     let locale = locales[i].locale.code;
-    let result = await hasuraUpsertMetadata({
+    let result = await shared.hasuraUpsertMetadata({
       url: apiUrl,
       orgSlug: apiToken,
       data: data,

--- a/script/populate.js
+++ b/script/populate.js
@@ -6,12 +6,11 @@ const fs = require('fs');
 const path = require('path');
 const fetch = require('node-fetch');
 
+const shared = require("./shared");
 const gql = require('../lib/graphql/queries');
-const { create } = require('domain');
 
-const CONTENT_DELIVERY_API_URL = process.env.CONTENT_DELIVERY_API_URL;
-const CONTENT_DELIVERY_API_ACCESS_TOKEN =
-  process.env.CONTENT_DELIVERY_API_ACCESS_TOKEN;
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
 
 function writeCache(name, data) {
   const cachedFile = path.join(process.cwd(), 'cached', `${name}.json`);
@@ -21,112 +20,50 @@ function writeCache(name, data) {
   });
 }
 
-function listLocales() {
-  const query = `
-    query ListI18nLocales {
-      i18n {
-        listI18NLocales {
-          data {
-            id
-            code
-            default
-          }
-        }
-      }
-    }
-  `;
+async function listLocales() {
+  const localeResult = await shared.hasuraListLocales({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
 
-  const url = CONTENT_DELIVERY_API_URL;
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((responseParsed) => {
-      let locales = responseParsed.data.i18n.listI18NLocales.data;
-      writeCache('locales', locales);
-    })
-    .catch(console.error);
+  let locales;
+  if (localeResult.errors) {
+    console.error("Error listing locales:", localeResult.errors);
+  } else {
+    locales = localeResult.data.organization_locales;
+  }
+
+  writeCache('locales', locales);
 }
 
-function listSections() {
-  const query = `
-    {
-      categories {
-        listCategories {
-          data {
-            id
-            slug
-            title {
-              values {
-                value
-                locale
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const url = CONTENT_DELIVERY_API_URL;
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      let sections = data.data.categories.listCategories.data;
-      writeCache('sections', sections);
-    })
-    .catch(console.error);
+async function listSections() {
+  const result = await shared.hasuraListSections({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  let sections;
+  if (result.errors) {
+    console.error("Error listing sections:", result.errors);
+  } else {
+    sections = result.data.categories;
+  }
+  writeCache('sections', sections);
 }
 
-function listTags() {
-  const query = `
-    {
-      tags {
-        listTags {
-          data {
-            id
-            slug
-            title {
-              values {
-                value
-                locale
-              }
-            }
-          }
-        }
-      }
-    }
-  `;
-  const url = CONTENT_DELIVERY_API_URL;
-  console.log(url, CONTENT_DELIVERY_API_ACCESS_TOKEN);
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ query }),
-  };
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      let tags = data.data.tags.listTags.data;
-      writeCache('tags', tags);
-    })
-    .catch(console.error);
+async function listTags() {
+  const result = await shared.hasuraListTags({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  let tags;
+  if (result.errors) {
+    console.error("Error listing tags:", result.errors);
+  } else {
+    tags = result.data.tags;
+  }
+  writeCache('tags', tags);
 }
 
 function getAds() {
@@ -145,59 +82,8 @@ function getAds() {
     .catch(console.error);
 }
 
-function createHomepageLayouts() {
-  const url = CONTENT_DELIVERY_API_URL;
-
-  const lpslVars = {
-    data: {
-      name: "Large Package Story Lead",
-      data: "{ \"subfeatured-top\":\"string\", \"subfeatured-bottom\":\"string\", \"featured\":\"string\" }"
-    }
-  };
-
-  const bfsVars = {
-    data: {
-      name: "Big Featured Story",
-      data: "{ \"featured\":\"string\" }"
-    }
-  };
-
-  let opts = {
-    method: 'POST',
-    headers: {
-      authorization: CONTENT_DELIVERY_API_ACCESS_TOKEN,
-      'Content-Type': 'application/json',
-    },
-
-    body: JSON.stringify({
-      query: gql.CREATE_LAYOUT_SCHEMA,
-      variables: lpslVars
-    }),
-  };
-
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      console.log(JSON.stringify(data));
-    })
-    .catch(console.error);
-
-  opts.body = JSON.stringify({
-      query: gql.CREATE_LAYOUT_SCHEMA,
-      variables: bfsVars
-  })
-
-  fetch(url, opts)
-    .then((res) => res.json())
-    .then((data) => {
-      console.log(JSON.stringify(data));
-    })
-    .catch(console.error);
-}
-
 async function main() {
   console.log("HASURA_API_URL:", process.env.HASURA_API_URL, "ORG_SLUG:", process.env.ORG_SLUG);
-  createHomepageLayouts();
   listLocales();
   listSections();
   listTags();

--- a/script/shared.js
+++ b/script/shared.js
@@ -68,6 +68,45 @@ function hasuraUpsertSection(params) {
     },
   });
 }
+
+const HASURA_LIST_TAGS = `query MyQuery {
+  tags(where: {published: {_eq: true}}) {
+    slug
+    tag_translations {
+      locale_code
+      title
+    }
+  }
+}`;
+
+function hasuraListTags(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_TAGS,
+    name: 'MyQuery',
+  });
+}
+
+const HASURA_LIST_SECTIONS = `query MyQuery {
+  categories(where: {published: {_eq: true}}) {
+    slug
+    category_translations {
+      title
+      locale_code
+    }
+  }
+}`;
+
+function hasuraListSections(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_SECTIONS,
+    name: 'MyQuery',
+  });
+}
+
 const HASURA_LIST_ORG_LOCALES = `query MyQuery {
   organization_locales {
     locale {
@@ -122,6 +161,8 @@ async function fetchGraphQL(params) {
 
 module.exports = {
   hasuraListLocales,
+  hasuraListSections,
+  hasuraListTags,
   hasuraUpsertHomepageLayout,
   hasuraUpsertMetadata,
   hasuraUpsertSection,

--- a/script/shared.js
+++ b/script/shared.js
@@ -1,0 +1,130 @@
+const fetch = require("node-fetch");
+
+const HASURA_UPSERT_METADATA = `mutation MyMutation($published: Boolean, $data: jsonb, $locale_code: String) {
+  insert_site_metadatas(objects: {published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
+    returning {
+      id
+      published
+    }
+  }
+}`;
+
+function hasuraUpsertMetadata(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_METADATA,
+    name: 'MyMutation',
+    variables: {
+      data: params['data'],
+      published: params['published'],
+      locale_code: params['localeCode']
+    },
+  });
+}
+
+const HASURA_UPSERT_LAYOUT = `mutation MyMutation($name: String!, $data: jsonb!) {
+  insert_homepage_layout_schemas(objects: {name: $name, data: $data}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
+    returning {
+      id
+      name
+    }
+  }
+}`;
+
+function hasuraUpsertHomepageLayout(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_LAYOUT,
+    name: 'MyMutation',
+    variables: {
+      name: params['name'],
+      data: params['data'],
+    },
+  });
+}
+
+const HASURA_UPSERT_SECTION = `mutation MyMutation($locale_code: String!, $title: String!, $slug: String!, $published: Boolean) {
+  insert_categories(objects: {slug: $slug, category_translations: {data: {locale_code: $locale_code, title: $title}, on_conflict: {constraint: category_translations_locale_code_category_id_key, update_columns: [title]}}, published: $published}, on_conflict: {constraint: categories_organization_id_slug_key, update_columns: [slug, published]}) {
+    returning {
+      id
+      slug
+      published
+    }
+  }
+}`;
+function hasuraUpsertSection(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_UPSERT_SECTION,
+    name: 'MyMutation',
+    variables: {
+      locale_code: params['localeCode'],
+      slug: params['slug'],
+      published: params['published'],
+      title: params['title'],
+    },
+  });
+}
+const HASURA_LIST_ORG_LOCALES = `query MyQuery {
+  organization_locales {
+    locale {
+      code
+    }
+  }
+}`;
+function hasuraListLocales(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_ORG_LOCALES,
+    name: 'MyQuery',
+    variables: {
+      locale_code: params['localeCode'],
+      slug: params['slug'],
+    },
+  });
+}
+
+async function fetchGraphQL(params) {
+  let url;
+  let orgSlug;
+  if (!params.hasOwnProperty('url')) {
+    url = HASURA_API_URL;
+  } else {
+    url = params['url'];
+  }
+  if (!params.hasOwnProperty('orgSlug')) {
+    orgSlug = ORG_SLUG;
+  } else {
+    orgSlug = params['orgSlug'];
+  }
+  let operationQuery = params['query'];
+  let operationName = params['name'];
+  let variables = params['variables'];
+
+  const result = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'TNC-Organization': orgSlug,
+    },
+    body: JSON.stringify({
+      query: operationQuery,
+      variables: variables,
+      operationName: operationName,
+    }),
+  });
+
+  return await result.json();
+}
+
+module.exports = {
+  hasuraListLocales,
+  hasuraUpsertHomepageLayout,
+  hasuraUpsertMetadata,
+  hasuraUpsertSection,
+  fetchGraphQL
+
+}


### PR DESCRIPTION
Closes #287 and #313

This PR removes all the locale mappings (from cache files) from the front-end. In cases where I found the page really needed the locales (think this was only in the tinycms) I ensured that we were pulling the valid locales for the organization from Hasura. The pages typically didn't need this list though.

While I was doing this I found a few places that I hadn't updated for Hasura, so I converted those:

* tinycms metadata
* tinycms tags
* tinycms homepage layouts
* tinycms locale switcher