### PR TITLE
Fixed lookup of article for preview

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -274,7 +274,7 @@ const HASURA_GET_HOMEPAGE_DATA = `query MyQuery {
 
 const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}}, category: {slug: {_eq: $category_slug}}}) {
-    article_translations(where: {locale_code: {_eq: $locale_code}}) {
+    article_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
       content
       custom_byline
       facebook_description
@@ -586,6 +586,44 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
   }
 }`;
 
+const HASURA_PREVIEW_ARTICLE_BY_SLUG = `query MyQuery($slug: String!, $locale_code: String!) {
+  articles(where: {slug: {_eq: $slug}, article_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    article_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+      content
+      custom_byline
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+    }
+    category {
+      slug
+      id
+      category_translations(where: {locale_code: {_eq: $locale_code}}) {
+        title
+      }
+    }
+    author_articles {
+      author {
+        name
+        photoUrl
+        slug
+        twitter
+        author_translations(where: {locale_code: {_eq: $locale_code}}) {
+          bio
+          title
+        }
+      }
+    }
+  }
+}`;
+
 const HASURA_GET_ARTICLE_BY_SLUG = `query MyQuery($slug: String!, $locale_code: String!) {
   articles(where: {slug: {_eq: $slug}, article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
     slug
@@ -813,6 +851,18 @@ export function hasuraGetMetadataByLocale(params) {
   });
 }
 
+export function hasuraPreviewArticleBySlug(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_PREVIEW_ARTICLE_BY_SLUG,
+    name: 'MyQuery',
+    variables: {
+      slug: params['slug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
 export function hasuraGetArticleBySlug(params) {
   return fetchGraphQL({
     url: params['url'],

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,4 +1,4 @@
-import { hasuraGetArticleBySlug } from '../../lib/articles.js';
+import { hasuraPreviewArticleBySlug } from '../../lib/articles.js';
 
 export default async (req, res) => {
   const apiUrl = process.env.HASURA_API_URL;
@@ -12,7 +12,7 @@ export default async (req, res) => {
 
   let article;
   // Fetch the headless CMS to check if the provided `slug` exists
-  const { errors, data } = await hasuraGetArticleBySlug({
+  const { errors, data } = await hasuraPreviewArticleBySlug({
     url: apiUrl,
     orgSlug: apiToken,
     localeCode: req.query.locale,


### PR DESCRIPTION
Closes #326 

The preview article page _almost_ worked with the latest sidebar code (backed by hasura). I had to make a couple of small fixes:

1. the api route for this page was restricting content to published only - that obviously shouldn't be a constraint when previewing
2. the query now restricts article_translations to be limited to `1` result, ordered by translation `id desc`, in the specified locale

To test:

(Script editor > test > run as add-on > pick an article) 
Run the front-end on localhost:3000

Try changing the headline, then hit preview and open the link; you should see the article with your change.