### PR TITLE
Added 'published' constraint to article translations returned on article page

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -339,7 +339,7 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $loc
 
 const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!, $slug: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}, slug: {_eq: $slug}}) {
-    article_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+    article_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
       id
       content
       custom_byline


### PR DESCRIPTION
Bugfix: I noticed while working on the unpublish feature that the current article page query was returning the most recent translation... and it was `published: false`; this PR adds the `published: true` constraint to the article_translations returned here.