### PR TITLE
Ensure preview article page displays published date/time values

### DIFF
--- a/components/articles/PublishDate.js
+++ b/components/articles/PublishDate.js
@@ -23,6 +23,23 @@ export default function PublishDate({ article }) {
     );
   }
 
+  // prefer official published data if it's present - useful on preview page, mainly,
+  // when the current translation ID might not be equal to the last published translation ID
+  if (
+    article.published_article_translations &&
+    article.published_article_translations[0] &&
+    article.published_article_translations[0].article_translation
+  ) {
+    console.log('article published:', article.published_article_translations);
+    firstPublishedOn = renderDate(
+      article.published_article_translations[0].article_translation
+        .first_published_at
+    );
+    lastPublishedOn = renderDate(
+      article.published_article_translations[0].article_translation
+        .last_published_at
+    );
+  }
   return (
     <>
       <time key="datelines">

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -274,7 +274,15 @@ const HASURA_GET_HOMEPAGE_DATA = `query MyQuery {
 
 const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}}, category: {slug: {_eq: $category_slug}}}) {
+    published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
+      article_translation {
+        id
+        first_published_at
+        last_published_at
+      }
+    }
     article_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+      id
       content
       custom_byline
       facebook_description


### PR DESCRIPTION
Relates to https://github.com/news-catalyst/google-app-scripts/issues/231

This PR ensures that previewing an article will always display the article's actual publish dates - this matters because preview is usually using a more recent version of the content than was published.

To test, preview an article using the link from the sidebar, note the first & last published dates display correctly.