### PR TITLE
Find locale in query string for previewing static pages

### DIFF
--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -11,11 +11,13 @@ export default async (req, res) => {
     const apiUrl = process.env.HASURA_API_URL;
     const apiToken = process.env.ORG_SLUG;
 
+    let localeCode = req.query.locale;
+
     const { errors, data } = await hasuraGetPage({
       url: apiUrl,
       orgSlug: apiToken,
       slug: 'about',
-      localeCode: locale,
+      localeCode: localeCode,
     });
     if (errors || !data) {
       return res.status(401).json({ message: 'Invalid slug' });


### PR DESCRIPTION
I found this bug when I updated the sidebar to use the static preview url for pages. This fixes the issue by using the locale from the query string, same as the article preview.