### PR TITLE
Bugfix: article static paths query

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -886,10 +886,11 @@ export function hasuraGetArticleBySlug(params) {
 }
 
 const HASURA_LIST_ARTICLE_SLUGS = `query MyQuery {
-  articles {
+  articles(where: {article_translations: {published: {_eq: true}}}) {
     slug
-    article_translations(where: {published: {_eq: true}}) {
+    article_translations(where: {published: {_eq: true}}, distinct_on: locale_code) {
       locale_code
+      published
     }
     category {
       slug
@@ -901,8 +902,6 @@ export async function hasuraListAllArticleSlugs() {
   return fetchGraphQL({
     url: process.env.HASURA_API_URL,
     orgSlug: process.env.ORG_SLUG,
-    // url: params['url'],
-    // orgSlug: params['orgSlug'],
     query: HASURA_LIST_ARTICLE_SLUGS,
     name: 'MyQuery',
   });

--- a/lib/section.js
+++ b/lib/section.js
@@ -23,7 +23,7 @@ const HASURA_LIST_ALL_SECTIONS_BY_LOCALE = `query MyQuery($locale_code: String =
       code
     }
   }
-  categories(where: {published: {_eq: true}}) {
+  categories {
     id
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title

--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -11,11 +11,13 @@ export default async (req, res) => {
     const apiUrl = process.env.HASURA_API_URL;
     const apiToken = process.env.ORG_SLUG;
 
+    let localeCode = req.query.locale;
+
     const { errors, data } = await hasuraGetPage({
       url: apiUrl,
       orgSlug: apiToken,
       slug: 'about',
-      localeCode: locale,
+      localeCode: localeCode,
     });
     if (errors || !data) {
       return res.status(401).json({ message: 'Invalid slug' });


### PR DESCRIPTION
Closes #335 

I fixed the query used to generate static article pages by limiting it to:

* articles that have a published translation (instead of any article with potentially empty sets of translations)
* for each article, one entry per locale it's published in