### PR TITLE
Feature/cleanup twitter handle

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -207,3 +207,25 @@ export const renderBody = (article, ads, isAmp) => {
     return [];
   }
 };
+
+// Implementation from https://gist.github.com/codeguy/6684588
+// takes a regular string and returns a slug
+export const slugify = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  value = value.trim();
+  value = value.toLowerCase();
+  var from = 'àáäâèéëêìíïîòóöôùúüûñç·/_,:;';
+  var to = 'aaaaeeeeiiiioooouuuunc------';
+  for (var i = 0, l = from.length; i < l; i++) {
+    value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+  }
+
+  value = value
+    .replace(/[^a-z0-9 -]/g, '') // remove invalid chars
+    .replace(/\s+/g, '-') // collapse whitespace and replace by -
+    .replace(/-+/g, '-'); // collapse dashes
+
+  return value;
+};

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -6,7 +6,7 @@ import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraGetAuthorById, hasuraUpdateAuthor } from '../../../lib/authors';
-import { hasuraLocaliseText } from '../../../lib/utils.js';
+import { hasuraLocaliseText, slugify } from '../../../lib/utils.js';
 
 export default function EditAuthor({
   apiUrl,
@@ -16,7 +16,6 @@ export default function EditAuthor({
   locales,
   awsConfig,
 }) {
-  console.log(author);
   const [notificationMessage, setNotificationMessage] = useState('');
   const [notificationType, setNotificationType] = useState('');
   const [showNotification, setShowNotification] = useState(false);
@@ -64,6 +63,10 @@ export default function EditAuthor({
   async function handleSubmit(ev) {
     let published = true;
     ev.preventDefault();
+
+    let slugifiedName = slugify(name);
+    setSlug(slugifiedName);
+
     let params = {
       url: apiUrl,
       orgSlug: apiToken,
@@ -135,21 +138,6 @@ export default function EditAuthor({
                 value={name}
                 name="name"
                 onChange={(ev) => setName(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="slug">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => setSlug(ev.target.value)}
               />
             </div>
           </div>

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -55,6 +55,12 @@ export default function EditAuthor({
     setStaffYesNo(ev.target.value);
   };
 
+  // removes leading @ from twitter handle before storing
+  function updateTwitter(val) {
+    let cleanedUpVal = val.replace(/@/, '');
+    setTwitter(cleanedUpVal);
+  }
+
   async function handleCancel(ev) {
     ev.preventDefault();
     router.push('/tinycms/authors');
@@ -161,14 +167,15 @@ export default function EditAuthor({
             <label className="label" htmlFor="twitter">
               Twitter
             </label>
-            <div className="control">
+            <div className="control has-icons-left">
               <input
                 className="input"
                 type="text"
                 value={twitter}
                 name="twitter"
-                onChange={(ev) => setTwitter(ev.target.value)}
+                onChange={(ev) => updateTwitter(ev.target.value)}
               />
+              <span className="icon is-small is-left">@</span>
             </div>
           </div>
 

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -7,6 +7,7 @@ import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateAuthor } from '../../../lib/authors';
+import { slugify } from '../../../lib/utils.js';
 
 export default function AddAuthor({
   apiUrl,
@@ -30,9 +31,10 @@ export default function AddAuthor({
 
   const router = useRouter();
 
-  function updateSlug(ev) {
-    let val = ev.target.value;
-    setSlug(val);
+  function updateName(val) {
+    setName(val);
+    let slugifiedVal = slugify(val);
+    setSlug(slugifiedVal);
 
     setDisplayUpload(true);
   }
@@ -40,7 +42,6 @@ export default function AddAuthor({
   const handleChange = (ev) => setStaff(ev.target.value);
 
   async function handleSubmit(ev) {
-    console.log('handle submit button clicked');
     ev.preventDefault();
 
     let published = true;
@@ -60,7 +61,6 @@ export default function AddAuthor({
     const { errors, data } = await hasuraCreateAuthor(params);
 
     if (data && data.insert_authors_one) {
-      console.log(data.insert_authors_one);
       setNotificationMessage('Successfully saved and published the author!');
       setNotificationType('success');
       setShowNotification(true);
@@ -113,22 +113,7 @@ export default function AddAuthor({
                 type="text"
                 value={name}
                 name="name"
-                onChange={(ev) => setName(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="slug">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => updateSlug(ev)}
+                onChange={(ev) => updateName(ev.target.value)}
               />
             </div>
           </div>
@@ -227,7 +212,6 @@ export async function getServerSideProps(context) {
   let locales;
 
   if (errors || !data) {
-    console.log('error listing locales:', errors);
     return {
       notFound: true,
     };

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -31,6 +31,13 @@ export default function AddAuthor({
 
   const router = useRouter();
 
+  // removes leading @ from twitter handle before storing
+  function updateTwitter(val) {
+    let cleanedUpVal = val.replace(/@/, '');
+    setTwitter(cleanedUpVal);
+  }
+
+  // slugifies the name and stores slug plus name values
   function updateName(val) {
     setName(val);
     let slugifiedVal = slugify(val);
@@ -137,14 +144,15 @@ export default function AddAuthor({
             <label className="label" htmlFor="twitter">
               Twitter
             </label>
-            <div className="control">
+            <div className="control has-icons-left">
               <input
                 className="input"
                 type="text"
                 value={twitter}
                 name="twitter"
-                onChange={(ev) => setTwitter(ev.target.value)}
+                onChange={(ev) => updateTwitter(ev.target.value)}
               />
+              <span className="icon is-small is-left">@</span>
             </div>
           </div>
 


### PR DESCRIPTION
Closes #345 

<img width="209" alt="Screen Shot 2021-03-02 at 8 25 51 am" src="https://user-images.githubusercontent.com/3397/109561550-6dc25b80-7b31-11eb-8382-5a061cfd5e19.png">

`@` now prepended to form field on add/edit author, any `@` in the twitter value removed before saving.