### PR TITLE
Bugfix/blank footer

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,11 +14,8 @@ export default function Layout({
   renderNav = true,
 }) {
   if (meta === null || meta === undefined) {
-    console.log('Layout meta is missing');
     meta = {};
   }
-
-  console.log(sections);
 
   const metaValues = {
     canonical: meta['siteUrl'],
@@ -30,6 +27,9 @@ export default function Layout({
     twitterTitle: meta['twitterTitle'],
     twitterDescription: meta['twitterDescription'],
     coverImage: meta['coverImage'],
+    footerTitle: meta['footerTitle'],
+    footerBylineLink: meta['footerBylineLink'],
+    footerBylineName: meta['footerBylineName'],
   };
   if (article) {
     metaValues.section = hasuraLocaliseText(
@@ -173,7 +173,7 @@ export default function Layout({
           )}
           {children}
         </main>
-        <GlobalFooter />
+        <GlobalFooter metadata={metaValues} />
       </div>
       <style jsx global>
         {globalStyles}

--- a/components/articles/ArticleFooter.js
+++ b/components/articles/ArticleFooter.js
@@ -4,18 +4,17 @@ import ArticleFooterAuthor from './ArticleFooterAuthor';
 
 export default function ArticleFooter({ article, isAmp }) {
   let tagLinks;
-  if (article.tags) {
-    tagLinks = article.tags.map((tag) => (
-      <li key={tag.slug}>
-        <Link href={`/tags/${tag.slug}`}>
+  if (article.tag_articles) {
+    tagLinks = article.tag_articles.map((tag_article) => (
+      <li key={tag_article.tag.slug}>
+        <Link href={`/tags/${tag_article.tag.slug}`}>
           <a className="is-link tag">
-            {hasuraLocaliseText(tag.tag_translations, 'title')}
+            {hasuraLocaliseText(tag_article.tag.tag_translations, 'title')}
           </a>
         </Link>
       </li>
     ));
   }
-
   return (
     <div className="section post__meta post__meta--bottom">
       <div className="section__container">

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import {
   hasuraListAllArticleSlugs,
   hasuraArticlePage,
+  hasuraCategoryPage,
 } from '../../../lib/articles.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
 import { getArticleAds } from '../../../lib/ads.js';
@@ -93,7 +94,18 @@ export async function getStaticProps({ locale, params }) {
     }
 
     article = data.articles.find((a) => a.slug === params.slug);
-    sectionArticles = data.articles.filter((a) => a.slug !== params.slug);
+
+    const sectionResponse = await hasuraCategoryPage({
+      url: apiUrl,
+      orgSlug: apiToken,
+      categorySlug: params.category,
+      localeCode: locale,
+    });
+    if (!sectionResponse.errors && sectionResponse.data) {
+      sectionArticles = sectionResponse.data.articles.filter(
+        (a) => a.slug !== params.slug
+      );
+    }
 
     let metadatas = data.site_metadatas;
     try {


### PR DESCRIPTION
Closes #357 

Fixes blank global footer. 

Also realised the tag links weren't showing up because they were iterating off of `article.tags` instead of `article.tag_articles` so I also fixed that in this PR (ArticleFooter).

Note: the build will probably fail on vercel due to free tier Hasura limits being exceeded.