### PR TITLE
Feature/publish any static page

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,11 +14,8 @@ export default function Layout({
   renderNav = true,
 }) {
   if (meta === null || meta === undefined) {
-    console.log('Layout meta is missing');
     meta = {};
   }
-
-  console.log(sections);
 
   const metaValues = {
     canonical: meta['siteUrl'],
@@ -30,6 +27,9 @@ export default function Layout({
     twitterTitle: meta['twitterTitle'],
     twitterDescription: meta['twitterDescription'],
     coverImage: meta['coverImage'],
+    footerTitle: meta['footerTitle'],
+    footerBylineLink: meta['footerBylineLink'],
+    footerBylineName: meta['footerBylineName'],
   };
   if (article) {
     metaValues.section = hasuraLocaliseText(
@@ -173,7 +173,7 @@ export default function Layout({
           )}
           {children}
         </main>
-        <GlobalFooter />
+        <GlobalFooter metadata={metaValues} />
       </div>
       <style jsx global>
         {globalStyles}

--- a/components/articles/ArticleBody.js
+++ b/components/articles/ArticleBody.js
@@ -5,7 +5,7 @@ import { renderBody } from '../../lib/utils.js';
 import NewsletterBlock from '../plugins/NewsletterBlock';
 
 export default function ArticleBody({ article, ads, isAmp, metadata }) {
-  const body = renderBody(article, ads, isAmp);
+  const body = renderBody(article.article_translations, ads, isAmp);
 
   const { trackEvent } = useAnalytics();
 

--- a/components/articles/ArticleFooter.js
+++ b/components/articles/ArticleFooter.js
@@ -4,18 +4,17 @@ import ArticleFooterAuthor from './ArticleFooterAuthor';
 
 export default function ArticleFooter({ article, isAmp }) {
   let tagLinks;
-  if (article.tags) {
-    tagLinks = article.tags.map((tag) => (
-      <li key={tag.slug}>
-        <Link href={`/tags/${tag.slug}`}>
+  if (article.tag_articles) {
+    tagLinks = article.tag_articles.map((tag_article) => (
+      <li key={tag_article.tag.slug}>
+        <Link href={`/tags/${tag_article.tag.slug}`}>
           <a className="is-link tag">
-            {hasuraLocaliseText(tag.tag_translations, 'title')}
+            {hasuraLocaliseText(tag_article.tag.tag_translations, 'title')}
           </a>
         </Link>
       </li>
     ));
   }
-
   return (
     <div className="section post__meta post__meta--bottom">
       <div className="section__container">

--- a/components/articles/ArticleFooterAuthor.js
+++ b/components/articles/ArticleFooterAuthor.js
@@ -28,9 +28,11 @@ export default function ArticleFooterAuthor({ author, isAmp, i }) {
         <div className="header">
           <span className="name">{renderAuthor(author, i)}</span>
           <span className="contact">
-            <a href={`https://twitter.com/${author.twitter}`}>
-              @{author.twitter}
-            </a>
+            {author.twitter && (
+              <a href={`https://twitter.com/${author.twitter}`}>
+                @{author.twitter}
+              </a>
+            )}
           </span>
         </div>
         <p>{author.bio}</p>

--- a/components/articles/PublishDate.js
+++ b/components/articles/PublishDate.js
@@ -30,7 +30,6 @@ export default function PublishDate({ article }) {
     article.published_article_translations[0] &&
     article.published_article_translations[0].article_translation
   ) {
-    console.log('article published:', article.published_article_translations);
     firstPublishedOn = renderDate(
       article.published_article_translations[0].article_translation
         .first_published_at

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -568,7 +568,7 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
         }
       }
     }
-    page_translations(where: {locale_code: {_eq: $locale_code}}) {
+    page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
       content
       facebook_description
       facebook_title
@@ -883,6 +883,25 @@ export function hasuraGetArticleBySlug(params) {
       slug: params['slug'],
       locale_code: params['localeCode'],
     },
+  });
+}
+
+const HASURA_LIST_PAGE_SLUGS = `query MyQuery {
+  pages(where: {page_translations: {published: {_eq: true}}}) {
+    slug
+    page_translations(where: {published: {_eq: true}}, distinct_on: locale_code) {
+      locale_code
+      published
+    }
+  }
+}`;
+
+export async function hasuraListAllPageSlugs() {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_LIST_PAGE_SLUGS,
+    name: 'MyQuery',
   });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,7 +130,7 @@ export const renderDate = (isoDate, renderTime = true) => {
   return renderedDate;
 };
 
-export const renderBody = (article, ads, isAmp) => {
+export const renderBody = (translations, ads, isAmp) => {
   let adIndex = 0;
   const adPlacement = 5;
 
@@ -193,10 +193,7 @@ export const renderBody = (article, ads, isAmp) => {
     }
   };
 
-  let articleContent = hasuraLocaliseText(
-    article.article_translations,
-    'content'
-  );
+  let articleContent = hasuraLocaliseText(translations, 'content');
   if (
     articleContent &&
     articleContent !== null &&

--- a/pages/about.js
+++ b/pages/about.js
@@ -13,36 +13,46 @@ export default function About({ page, sections, siteMetadata }) {
 
   return (
     <Layout meta={siteMetadata} sections={sections}>
-      <article className="container">
-        <div className="post__title">{localisedPage.headline}</div>
-        <section className="section" key="body">
-          <div id="articleText" className="content">
-            {body}
-          </div>
-        </section>
-        <section className="section" key="authors">
-          <div className="content">
-            <h1 className="title">Authors</h1>
-            {page.author_pages.map((authorPage) => (
-              <div className="author mb-4" key={authorPage.author.name}>
-                <h4 className="subtitle is-4">
-                  {authorPage.author.name},{' '}
-                  {hasuraLocaliseText(
-                    authorPage.author.author_translations,
-                    'title'
-                  )}
-                </h4>
-                <p className="content is-medium">
-                  {hasuraLocaliseText(
-                    authorPage.author.author_translations,
-                    'bio'
-                  )}
-                </p>
+      <div className="post">
+        <article className="container">
+          <section key="title" className="section post__header">
+            <div className="section__container">
+              <div className="post__title">{localisedPage.headline}</div>
+            </div>
+          </section>
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container">
+              <div className="post-text">
+                <div>{body}</div>
               </div>
-            ))}
-          </div>
-        </section>
-      </article>
+            </div>
+          </section>
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container" key="authors">
+              <div className="post__title">Authors</div>
+              <div className="post-text">
+                {page.author_pages.map((authorPage) => (
+                  <div className="author mb-4" key={authorPage.author.name}>
+                    <h4 className="subtitle is-4">
+                      {authorPage.author.name},{' '}
+                      {hasuraLocaliseText(
+                        authorPage.author.author_translations,
+                        'title'
+                      )}
+                    </h4>
+                    <p className="content is-medium">
+                      {hasuraLocaliseText(
+                        authorPage.author.author_translations,
+                        'bio'
+                      )}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </article>
+      </div>
     </Layout>
   );
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -9,7 +9,7 @@ export default function About({ page, sections, siteMetadata }) {
 
   // there will only be one translation returned for a given page + locale
   const localisedPage = page.page_translations[0];
-  const body = renderBody(localisedPage, isAmp);
+  const body = renderBody(page.page_translations, isAmp);
 
   return (
     <Layout meta={siteMetadata} sections={sections}>

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import {
   hasuraListAllArticleSlugs,
   hasuraArticlePage,
+  hasuraCategoryPage,
 } from '../../../lib/articles.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
 import { getArticleAds } from '../../../lib/ads.js';
@@ -93,7 +94,18 @@ export async function getStaticProps({ locale, params }) {
     }
 
     article = data.articles.find((a) => a.slug === params.slug);
-    sectionArticles = data.articles.filter((a) => a.slug !== params.slug);
+
+    const sectionResponse = await hasuraCategoryPage({
+      url: apiUrl,
+      orgSlug: apiToken,
+      categorySlug: params.category,
+      localeCode: locale,
+    });
+    if (!sectionResponse.errors && sectionResponse.data) {
+      sectionArticles = sectionResponse.data.articles.filter(
+        (a) => a.slug !== params.slug
+      );
+    }
 
     let metadatas = data.site_metadatas;
     try {

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -17,32 +17,16 @@ export default function StaticPage({ page, sections, siteMetadata }) {
     <Layout meta={siteMetadata} sections={sections}>
       <div className="post">
         <article className="container">
-          <div className="post__title">{localisedPage.headline}</div>
-          <section className="section post__body rich-text" key="body">
-            <div id="articleText" className="section__container">
-              {body}
+          <section key="title" className="section post__header">
+            <div className="section__container">
+              <div className="post__title">{localisedPage.headline}</div>
             </div>
           </section>
-          <section className="section" key="authors">
-            <div className="content">
-              <h1 className="title">Authors</h1>
-              {page.author_pages.map((authorPage) => (
-                <div className="author mb-4" key={authorPage.author.name}>
-                  <h4 className="subtitle is-4">
-                    {authorPage.author.name},{' '}
-                    {hasuraLocaliseText(
-                      authorPage.author.author_translations,
-                      'title'
-                    )}
-                  </h4>
-                  <p className="content is-medium">
-                    {hasuraLocaliseText(
-                      authorPage.author.author_translations,
-                      'bio'
-                    )}
-                  </p>
-                </div>
-              ))}
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container">
+              <div className="post-text">
+                <div>{body}</div>
+              </div>
             </div>
           </section>
         </article>

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -1,0 +1,117 @@
+import { useAmp } from 'next/amp';
+import { hasuraGetPage, hasuraListAllPageSlugs } from '../../lib/articles.js';
+import { hasuraLocaliseText } from '../../lib/utils';
+import Layout from '../../components/Layout';
+import { renderBody } from '../../lib/utils.js';
+
+export default function StaticPage({ page, sections, siteMetadata }) {
+  const isAmp = useAmp();
+
+  // there will only be one translation returned for a given page + locale
+  const localisedPage = page.page_translations[0];
+  console.log('page translations:', page.page_translations);
+  const body = renderBody(page.page_translations, isAmp);
+  console.log('body:', body);
+
+  return (
+    <Layout meta={siteMetadata} sections={sections}>
+      <div className="post">
+        <article className="container">
+          <div className="post__title">{localisedPage.headline}</div>
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container">
+              {body}
+            </div>
+          </section>
+          <section className="section" key="authors">
+            <div className="content">
+              <h1 className="title">Authors</h1>
+              {page.author_pages.map((authorPage) => (
+                <div className="author mb-4" key={authorPage.author.name}>
+                  <h4 className="subtitle is-4">
+                    {authorPage.author.name},{' '}
+                    {hasuraLocaliseText(
+                      authorPage.author.author_translations,
+                      'title'
+                    )}
+                  </h4>
+                  <p className="content is-medium">
+                    {hasuraLocaliseText(
+                      authorPage.author.author_translations,
+                      'bio'
+                    )}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+        </article>
+      </div>
+    </Layout>
+  );
+}
+
+export async function getStaticPaths() {
+  const { errors, data } = await hasuraListAllPageSlugs();
+  if (errors) {
+    throw errors;
+  }
+
+  let paths = [];
+  for (const page of data.pages) {
+    for (const locale of page.page_translations) {
+      paths.push({
+        params: {
+          slug: page.slug,
+        },
+        locale: locale.locale_code,
+      });
+    }
+  }
+
+  return {
+    paths,
+    fallback: true,
+  };
+}
+
+export async function getStaticProps({ locale, params }) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  let page = {};
+  let sections;
+  let siteMetadata = {};
+
+  const { errors, data } = await hasuraGetPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: params.slug,
+    localeCode: locale,
+  });
+  if (errors || !data) {
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    console.log(data);
+    sections = data.categories;
+    page = data.pages[0];
+    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
+  }
+
+  return {
+    props: {
+      page,
+      sections,
+      siteMetadata,
+    },
+  };
+}


### PR DESCRIPTION
Closes #355 

* adds a general catch all template for rendering static pages under `/static/`
* updates styles (these were non-existent basically) on both about & general catch all templates for pages
* fixes a bug with static page query - it wasn't limiting the translations to the most recent published one, now it is (similar to previous fix for article translations)

This goes with the sidebar PR https://github.com/news-catalyst/google-app-scripts/pull/252