### PR TITLE
Bugfix/static page previewing & rendering

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -568,7 +568,7 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
         }
       }
     }
-    page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+    page_translations(where: {published: { _eq: true }, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
       content
       facebook_description
       facebook_title
@@ -590,6 +590,47 @@ const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
     }
   }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations {
+      data
+    }
+  }
+}`;
+
+const HASURA_GET_PAGE_PREVIEW = `query MyQuery($slug: String!, $locale_code: String!) {
+  pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}}}) {
+    id
+    author_pages {
+      author {
+        id
+        name
+        slug
+        author_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+    }
+    page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+      content
+      facebook_description
+      facebook_title
+      first_published_at
+      headline
+      last_published_at
+      published
+      search_description
+      search_title
+      twitter_description
+      twitter_title
+    }
+    slug
+  }
+  categories(where: {category_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}}) {
     site_metadata_translations {
       data
     }
@@ -836,6 +877,19 @@ export function hasuraListAllSections(params) {
   });
 }
 
+export function hasuraGetPagePreview(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_PAGE_PREVIEW,
+    name: 'MyQuery',
+    variables: {
+      slug: params['slug'],
+      locale_code: params['localeCode'],
+    },
+  });
+}
+
 export function hasuraGetPage(params) {
   return fetchGraphQL({
     url: params['url'],
@@ -886,6 +940,16 @@ export function hasuraGetArticleBySlug(params) {
   });
 }
 
+const HASURA_LIST_PAGE_SLUGS_PREVIEW = `query MyQuery {
+  pages {
+    slug
+    page_translations(distinct_on: locale_code) {
+      locale_code
+      published
+    }
+  }
+}`;
+
 const HASURA_LIST_PAGE_SLUGS = `query MyQuery {
   pages(where: {page_translations: {published: {_eq: true}}}) {
     slug
@@ -896,6 +960,14 @@ const HASURA_LIST_PAGE_SLUGS = `query MyQuery {
   }
 }`;
 
+export async function hasuraListAllPageSlugsPreview() {
+  return fetchGraphQL({
+    url: process.env.HASURA_API_URL,
+    orgSlug: process.env.ORG_SLUG,
+    query: HASURA_LIST_PAGE_SLUGS_PREVIEW,
+    name: 'MyQuery',
+  });
+}
 export async function hasuraListAllPageSlugs() {
   return fetchGraphQL({
     url: process.env.HASURA_API_URL,

--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -7,27 +7,33 @@ export default async (req, res) => {
     return res.status(401).json({ message: 'Invalid token' });
   }
 
-  if (req.query.slug === 'about') {
-    const apiUrl = process.env.HASURA_API_URL;
-    const apiToken = process.env.ORG_SLUG;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
-    let localeCode = req.query.locale;
+  let localeCode = req.query.locale;
 
-    const { errors, data } = await hasuraGetPage({
-      url: apiUrl,
-      orgSlug: apiToken,
-      slug: 'about',
-      localeCode: localeCode,
-    });
-    if (errors || !data) {
-      return res.status(401).json({ message: 'Invalid slug' });
-    }
+  const { errors, data } = await hasuraGetPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: req.query.slug,
+    localeCode: localeCode,
+  });
+  if (errors || !data) {
+    return res.status(401).json({ message: 'Invalid slug' });
   }
 
   // Enable Preview Mode by setting the cookies
   res.setPreviewData({});
 
-  const nextPath = '/' + req.query.slug;
+  let nextPath;
+  if (localeCode) {
+    nextPath = '/' + localeCode;
+  }
+  if (req.query.slug === 'about') {
+    nextPath += '/preview/' + req.query.slug;
+  } else {
+    nextPath += '/preview/static/' + req.query.slug;
+  }
 
   // this approach to the redirect does work
   res.writeHead(301, {

--- a/pages/preview/about.js
+++ b/pages/preview/about.js
@@ -1,0 +1,99 @@
+import { useAmp } from 'next/amp';
+import { hasuraGetPage } from '../../lib/articles.js';
+import { hasuraLocaliseText } from '../../lib/utils';
+import Layout from '../../components/Layout';
+import { renderBody } from '../../lib/utils.js';
+
+export default function About({ page, sections, siteMetadata }) {
+  const isAmp = useAmp();
+
+  // there will only be one translation returned for a given page + locale
+  const localisedPage = page.page_translations[0];
+  const body = renderBody(page.page_translations, isAmp);
+
+  return (
+    <Layout meta={siteMetadata} sections={sections}>
+      <div className="post">
+        <article className="container">
+          <section key="title" className="section post__header">
+            <div className="section__container">
+              <div className="post__title">{localisedPage.headline}</div>
+            </div>
+          </section>
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container">
+              <div className="post-text">
+                <div>{body}</div>
+              </div>
+            </div>
+          </section>
+          <section className="section post__body rich-text" key="body">
+            <div id="articleText" className="section__container" key="authors">
+              <div className="post__title">Authors</div>
+              <div className="post-text">
+                {page.author_pages.map((authorPage) => (
+                  <div className="author mb-4" key={authorPage.author.name}>
+                    <h4 className="subtitle is-4">
+                      {authorPage.author.name},{' '}
+                      {hasuraLocaliseText(
+                        authorPage.author.author_translations,
+                        'title'
+                      )}
+                    </h4>
+                    <p className="content is-medium">
+                      {hasuraLocaliseText(
+                        authorPage.author.author_translations,
+                        'bio'
+                      )}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </article>
+      </div>
+    </Layout>
+  );
+}
+
+export async function getStaticProps({ locale }) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  let page = {};
+  let sections;
+  let siteMetadata = {};
+
+  const { errors, data } = await hasuraGetPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: 'about',
+    localeCode: locale,
+  });
+  if (errors || !data) {
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    console.log(data);
+    sections = data.categories;
+    page = data.pages[0];
+    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
+  }
+
+  return {
+    props: {
+      page,
+      sections,
+      siteMetadata,
+    },
+  };
+}

--- a/pages/preview/static/[slug].js
+++ b/pages/preview/static/[slug].js
@@ -1,16 +1,18 @@
 import { useRouter } from 'next/router';
 import { useAmp } from 'next/amp';
 import React, { useEffect } from 'react';
-import { hasuraGetPage, hasuraListAllPageSlugs } from '../../lib/articles.js';
-import { hasuraLocaliseText } from '../../lib/utils';
-import Layout from '../../components/Layout';
-import { renderBody } from '../../lib/utils.js';
+import {
+  hasuraGetPagePreview,
+  hasuraListAllPageSlugsPreview,
+} from '../../../lib/articles.js';
+import { hasuraLocaliseText } from '../../../lib/utils';
+import Layout from '../../../components/Layout';
+import { renderBody } from '../../../lib/utils.js';
 
 export default function StaticPage({ page, sections, siteMetadata }) {
   const router = useRouter();
   const isAmp = useAmp();
 
-  console.log('static page');
   if (router.isFallback) {
     return <div>Loading...</div>;
   }
@@ -52,7 +54,7 @@ export default function StaticPage({ page, sections, siteMetadata }) {
 }
 
 export async function getStaticPaths() {
-  const { errors, data } = await hasuraListAllPageSlugs();
+  const { errors, data } = await hasuraListAllPageSlugsPreview();
   if (errors) {
     throw errors;
   }
@@ -83,7 +85,7 @@ export async function getStaticProps({ locale, params }) {
   let sections;
   let siteMetadata = {};
 
-  const { errors, data } = await hasuraGetPage({
+  const { errors, data } = await hasuraGetPagePreview({
     url: apiUrl,
     orgSlug: apiToken,
     slug: params.slug,
@@ -103,7 +105,6 @@ export async function getStaticProps({ locale, params }) {
       };
     }
     page = data.pages[0];
-    console.log('page: ', page);
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {


### PR DESCRIPTION
Closes #368

This adds preview versions of both the About page and the catchall for static pages. 

It fixes the rendering problem with the catchall static pages - it was rendering the category page by mistake. 

This PR also fixes locale code handling in static page preview and adds preview versions of the queries to return unpublished content on preview routes.