### PR TITLE
Stretch image width out to full container

### DIFF
--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -16,8 +16,8 @@ export default function ImageNode({ node, amp }) {
       <Image
         src={image.imageUrl}
         alt={image.imageAlt}
-        width={image.width}
-        height={image.height}
+        width={710}
+        height={(image.height / image.width) * 710}
       />
       <figcaption>{image.imageAlt}</figcaption>
     </figure>


### PR DESCRIPTION
This was bugging me. This stretches images out to the max width of the article container while calculating the correct height.