### PR TITLE
Preview article page query was missing slug

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -272,8 +272,8 @@ const HASURA_GET_HOMEPAGE_DATA = `query MyQuery {
   }
 }`;
 
-const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!) {
-  articles(where: {article_translations: {locale_code: {_eq: $locale_code}}, category: {slug: {_eq: $category_slug}}}) {
+const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($slug: String!, $category_slug: String!, $locale_code: String!) {
+  articles(where: {slug: {_eq: $slug}, article_translations: {locale_code: {_eq: $locale_code}}, category: {slug: {_eq: $category_slug}}}) {
     published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
       article_translation {
         id
@@ -1076,6 +1076,7 @@ export async function hasuraPreviewArticlePage(params) {
     query: HASURA_PREVIEW_ARTICLE_PAGE,
     name: 'MyQuery',
     variables: {
+      slug: params['slug'],
       category_slug: params['categorySlug'],
       locale_code: params['localeCode'],
     },

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -18,7 +18,6 @@ export default function PreviewArticle(props) {
     );
   }
 
-  console.log('PreviewArticle props: ', props);
   return <Article {...props} />;
 }
 
@@ -60,6 +59,7 @@ export async function getStaticProps({ locale, params }) {
     url: apiUrl,
     orgSlug: apiToken,
     localeCode: locale,
+    slug: params.slug,
     categorySlug: params.category,
   });
   if (errors || !data) {
@@ -68,8 +68,6 @@ export async function getStaticProps({ locale, params }) {
       notFound: true,
     };
   } else {
-    console.log('preview article data:', data);
-
     tags = data.tags;
     for (var i = 0; i < tags.length; i++) {
       tags[i].title = hasuraLocaliseText(tags[i].tag_translations, 'title');


### PR DESCRIPTION
Closes #373 

In one of those "how did this ever work?" moments I've realised the reason the preview article page itself wasn't finding the article because the query was only looking up article data by category slug, instead of category slug AND article slug. (The api route for this does a simpler query requesting far less data, and it was correct.)

This PR fixes the bug by adding the article slug as a param and a where clause in the query used on the preview article page.