### PR TITLE
Protect preview urls by checking for preview mode on the context

### DIFF
--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -35,9 +35,5 @@ export default async (req, res) => {
     nextPath += '/preview/static/' + req.query.slug;
   }
 
-  // this approach to the redirect does work
-  res.writeHead(301, {
-    Location: nextPath,
-  });
-  res.end();
+  res.redirect(nextPath);
 };

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -50,9 +50,5 @@ export default async (req, res) => {
     articlePath = '/preview/' + article.category.slug + '/' + article.slug;
   }
 
-  console.log('article path:', articlePath);
-  res.writeHead(301, {
-    Location: articlePath,
-  });
-  res.end();
+  res.redirect(articlePath);
 };

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -45,7 +45,17 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ locale, params }) {
+export async function getStaticProps(context) {
+  let locale = context.locale;
+  let preview = context.preview;
+  let params = context.params;
+
+  if (!preview) {
+    return {
+      notFound: true,
+    };
+  }
+
   const apiUrl = process.env.HASURA_API_URL;
   const apiToken = process.env.ORG_SLUG;
 

--- a/pages/preview/about.js
+++ b/pages/preview/about.js
@@ -57,7 +57,15 @@ export default function About({ page, sections, siteMetadata }) {
   );
 }
 
-export async function getStaticProps({ locale }) {
+export async function getStaticProps(context) {
+  let locale = context.locale;
+  let preview = context.preview;
+
+  if (!preview) {
+    return {
+      notFound: true,
+    };
+  }
   const apiUrl = process.env.HASURA_API_URL;
   const apiToken = process.env.ORG_SLUG;
 

--- a/pages/preview/static/[slug].js
+++ b/pages/preview/static/[slug].js
@@ -77,7 +77,16 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ locale, params }) {
+export async function getStaticProps(context) {
+  let locale = context.locale;
+  let preview = context.preview;
+  let params = context.params;
+
+  if (!preview) {
+    return {
+      notFound: true,
+    };
+  }
   const apiUrl = process.env.HASURA_API_URL;
   const apiToken = process.env.ORG_SLUG;
 


### PR DESCRIPTION
Closes #374

This can be a pain to debug - I had to restart my browser at one point because it was caching the preview mode. Then I also forgot that the add-on was using the production URL and had to change it to localhost:3000 (haha, oops). 

Anyway this adds a check for the `context.preview` to the preview versions of the templates. This value should be true when redirected from the api preview route.