### PR TITLE
bugfix: 404 unpublished articles

### DIFF
--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -79,7 +79,7 @@ export async function getStaticProps({ locale, params }) {
     categorySlug: params.category,
     slug: params.slug,
   });
-  if (errors || !data) {
+  if (errors || !data || !data.articles || data.articles.length === 0) {
     return {
       notFound: true,
     };


### PR DESCRIPTION
Closes #386 

Instead of perpetually showing "loading..." the article page now 404s if unable to retrieve the _published_ article. This fixes situations where the article was published, then unpublished.