### PR TITLE
tinycms: protect against fake bylines

### DIFF
--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -28,7 +28,7 @@ export default function ArticleHeader({ article, isAmp, metadata }) {
   }
 
   let authorPhoto;
-  if (article && article.author_articles) {
+  if (article && article.author_articles && article.author_articles[0]) {
     authorPhoto = article.author_articles[0].author.photoUrl;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -226,3 +226,34 @@ export const slugify = (value) => {
 
   return value;
 };
+
+export const validateAuthorName = (name) => {
+  const fakeNames = [
+    'Staff Reporter',
+    'Staff Editor',
+    'Reporter',
+    'Editor',
+    'Journalist',
+    'Staff Writer',
+    'Staff',
+    'Editorial',
+    'Staff Correspondent',
+    'Correspondent',
+    'Writer',
+    'Commentator',
+    'Investigative Journalist',
+    'Investigative Reporter',
+    'Columnist',
+    'Staff Columnist',
+    'Weekly Columnist',
+  ];
+
+  const regex = new RegExp(fakeNames.join('|'), 'i');
+
+  let isFake = regex.test(name);
+  if (isFake) {
+    return false;
+  } else {
+    return true;
+  }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -248,7 +248,8 @@ export const validateAuthorName = (name) => {
     'Weekly Columnist',
   ];
 
-  const regex = new RegExp(fakeNames.join('|'), 'i');
+  const regexPattern = '^(' + fakeNames.join('|') + ')$';
+  const regex = new RegExp(regexPattern, 'i');
 
   let isFake = regex.test(name);
   if (isFake) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,6 +87,14 @@ export const renderAuthor = (author, i) => {
 
 // solution that works with react elements from https://codepen.io/pascalpp/pen/MKRwjP
 export const renderAuthors = (article) => {
+  if (
+    article.article_translations &&
+    article.article_translations[0] &&
+    article.article_translations[0].custom_byline
+  ) {
+    return article.article_translations[0].custom_byline;
+  }
+
   if (!article.author_articles) {
     return;
   }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -79,7 +79,7 @@ export async function getStaticProps({ locale, params }) {
     categorySlug: params.category,
     slug: params.slug,
   });
-  if (errors || !data) {
+  if (errors || !data || !data.articles || data.articles.length === 0) {
     return {
       notFound: true,
     };

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -93,6 +93,10 @@ export async function getStaticProps(context) {
     article = data.articles.find((a) => a.slug === params.slug);
     if (article && article.article_translations.length > 1) {
       // let mostRecentContent = article.article_translations.map(function(e) { return e.updated_at; }).sort().reverse()[0]
+      console.log(
+        'found more than 1 translation: ',
+        article.article_translations
+      );
       let mostRecentContents = article.article_translations.sort((a, b) => {
         return new Date(b.updated_at) - new Date(a.updated_at);
       });

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -62,20 +62,6 @@ export default function EditAuthor({
 
   // slugifies the name and stores slug plus name values
   function updateName(val) {
-    let nameIsValid = validateAuthorName(val);
-    if (!nameIsValid) {
-      setNotificationMessage(
-        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
-          val
-      );
-      setShowNotification(true);
-      setNotificationType('error');
-      setName('');
-      setSlug('');
-      setDisplayUpload(false);
-      return;
-    }
-    setShowNotification(false);
     setName(val);
     let slugifiedVal = slugify(val);
     setSlug(slugifiedVal);
@@ -97,8 +83,19 @@ export default function EditAuthor({
     let published = true;
     ev.preventDefault();
 
-    // let slugifiedName = slugify(name);
-    // setSlug(slugifiedName);
+    let nameIsValid = validateAuthorName(name);
+    if (!nameIsValid) {
+      setNotificationMessage(
+        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
+          name
+      );
+      setShowNotification(true);
+      setNotificationType('error');
+      setName('');
+      setSlug('');
+      setDisplayUpload(false);
+      return false;
+    }
 
     let params = {
       url: apiUrl,

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -6,7 +6,11 @@ import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraGetAuthorById, hasuraUpdateAuthor } from '../../../lib/authors';
-import { hasuraLocaliseText, slugify } from '../../../lib/utils.js';
+import {
+  hasuraLocaliseText,
+  slugify,
+  validateAuthorName,
+} from '../../../lib/utils.js';
 
 export default function EditAuthor({
   apiUrl,
@@ -19,6 +23,7 @@ export default function EditAuthor({
   const [notificationMessage, setNotificationMessage] = useState('');
   const [notificationType, setNotificationType] = useState('');
   const [showNotification, setShowNotification] = useState(false);
+  const [displayUpload, setDisplayUpload] = useState(true);
 
   const [name, setName] = useState(author.name);
   const [title, setTitle] = useState(
@@ -55,6 +60,28 @@ export default function EditAuthor({
     setStaffYesNo(ev.target.value);
   };
 
+  // slugifies the name and stores slug plus name values
+  function updateName(val) {
+    let nameIsValid = validateAuthorName(val);
+    if (!nameIsValid) {
+      setNotificationMessage(
+        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
+          val
+      );
+      setShowNotification(true);
+      setNotificationType('error');
+      setName('');
+      setSlug('');
+      setDisplayUpload(false);
+      return;
+    }
+    setShowNotification(false);
+    setName(val);
+    let slugifiedVal = slugify(val);
+    setSlug(slugifiedVal);
+    setDisplayUpload(true);
+  }
+
   // removes leading @ from twitter handle before storing
   function updateTwitter(val) {
     let cleanedUpVal = val.replace(/@/, '');
@@ -70,8 +97,8 @@ export default function EditAuthor({
     let published = true;
     ev.preventDefault();
 
-    let slugifiedName = slugify(name);
-    setSlug(slugifiedName);
+    // let slugifiedName = slugify(name);
+    // setSlug(slugifiedName);
 
     let params = {
       url: apiUrl,
@@ -123,15 +150,18 @@ export default function EditAuthor({
           id={author.id}
         />
 
-        <Upload
-          awsConfig={awsConfig}
-          slug={slug}
-          bioImage={bioImage}
-          setBioImage={setBioImage}
-          setNotificationMessage={setNotificationMessage}
-          setNotificationType={setNotificationType}
-          setShowNotification={setShowNotification}
-        />
+        {displayUpload && (
+          <Upload
+            awsConfig={awsConfig}
+            slug={slug}
+            bioImage={bioImage}
+            setBioImage={setBioImage}
+            setNotificationMessage={setNotificationMessage}
+            setNotificationType={setNotificationType}
+            setShowNotification={setShowNotification}
+          />
+        )}
+
         <form onSubmit={handleSubmit}>
           <div className="field">
             <label className="label" htmlFor="name">
@@ -143,7 +173,7 @@ export default function EditAuthor({
                 type="text"
                 value={name}
                 name="name"
-                onChange={(ev) => setName(ev.target.value)}
+                onChange={(ev) => updateName(ev.target.value)}
               />
             </div>
           </div>

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -7,7 +7,7 @@ import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateAuthor } from '../../../lib/authors';
-import { slugify } from '../../../lib/utils.js';
+import { validateAuthorName, slugify } from '../../../lib/utils.js';
 
 export default function AddAuthor({
   apiUrl,
@@ -39,6 +39,20 @@ export default function AddAuthor({
 
   // slugifies the name and stores slug plus name values
   function updateName(val) {
+    let nameIsValid = validateAuthorName(val);
+    if (!nameIsValid) {
+      setNotificationMessage(
+        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
+          val
+      );
+      setShowNotification(true);
+      setNotificationType('error');
+      setName('');
+      setSlug('');
+      setDisplayUpload(false);
+      return;
+    }
+    setShowNotification(false);
     setName(val);
     let slugifiedVal = slugify(val);
     setSlug(slugifiedVal);

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -39,20 +39,6 @@ export default function AddAuthor({
 
   // slugifies the name and stores slug plus name values
   function updateName(val) {
-    let nameIsValid = validateAuthorName(val);
-    if (!nameIsValid) {
-      setNotificationMessage(
-        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
-          val
-      );
-      setShowNotification(true);
-      setNotificationType('error');
-      setName('');
-      setSlug('');
-      setDisplayUpload(false);
-      return;
-    }
-    setShowNotification(false);
     setName(val);
     let slugifiedVal = slugify(val);
     setSlug(slugifiedVal);
@@ -65,6 +51,19 @@ export default function AddAuthor({
   async function handleSubmit(ev) {
     ev.preventDefault();
 
+    let nameIsValid = validateAuthorName(name);
+    if (!nameIsValid) {
+      setNotificationMessage(
+        'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
+          name
+      );
+      setShowNotification(true);
+      setNotificationType('error');
+      setName('');
+      setSlug('');
+      setDisplayUpload(false);
+      return false;
+    }
     let published = true;
     let params = {
       url: apiUrl,


### PR DESCRIPTION
Closes #281 

this adds validation to both the create & edit author forms, doing a case-insensitive match on the name. If the name matches one from a list (see below), an error message is displayed and the name field is blanked out.

```
const fakeNames = [
    'Staff Reporter',
    'Staff Editor',
    'Reporter',
    'Editor',
    'Journalist',
    'Staff Writer',
    'Staff',
    'Editorial',
    'Staff Correspondent',
    'Correspondent',
    'Writer',
    'Commentator',
    'Investigative Journalist',
    'Investigative Reporter',
    'Columnist',
    'Staff Columnist',
    'Weekly Columnist',
  ];
```

Those were just the values that came to mind. This is obviously english-only. 