### PR TITLE
bugfix: made GA_TRACKING_ID variable accessible for components/pages

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -84,7 +84,7 @@ export default function Layout({
 
   const isAmp = useAmp();
 
-  const trackingId = process.env.GA_TRACKING_ID;
+  const trackingId = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
 
   return (
     <>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,7 +31,7 @@ const App = ({ Component, pageProps }) => {
     if (isAmp) {
       return true;
     }
-    init(process.env.GA_TRACKING_ID);
+    init(process.env.NEXT_PUBLIC_GA_TRACKING_ID);
     trackPageViewed();
     const handleRouteChange = (url) => {
       logReadingHistory();


### PR DESCRIPTION
Related to #392 

I pulled this commit out of the in-progress analytics dashboard work so we could get some data going into GA. The issue was that the GA id was undefined and nothing was being tracked.