### PR TITLE
Bugfix: parse JSON for history tracking

### DIFF
--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -19,7 +19,9 @@ export const useAnalytics = () => {
       ReactGA.event(params);
     },
     setDimension: (dimension, value) => {
-      ReactGA.set({ dimension: value });
+      let fields = {};
+      fields[dimension] = value;
+      ReactGA.set(fields);
     },
     logReadingHistory: () => {
       let history = JSON.parse(storage.getItem('TNCHistory'));

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -5,7 +5,7 @@ export const useAnalytics = () => {
   return {
     init: (trackingId) => {
       console.log('Initialising ReactGA with trackingId:', trackingId);
-      ReactGA.initialize(trackingId);
+      ReactGA.initialize(trackingId, { debug: true });
     },
     trackPageViewed: (path) => {
       if (path) {
@@ -22,6 +22,18 @@ export const useAnalytics = () => {
       let fields = {};
       fields[dimension] = value;
       ReactGA.set(fields);
+    },
+    trackPageViewedWithDimension: (path, dimensionName, dimensionData) => {
+      let fields = {};
+      fields[dimensionName] = dimensionData;
+
+      if (path) {
+        return ReactGA.pageview(path, fields);
+      }
+      return ReactGA.pageview(
+        window.location.pathname + window.location.search,
+        fields
+      );
     },
     logReadingHistory: () => {
       let history = JSON.parse(storage.getItem('TNCHistory'));

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -22,8 +22,9 @@ export const useAnalytics = () => {
       ReactGA.set({ dimension: value });
     },
     logReadingHistory: () => {
-      let history = storage.getItem('TNCHistory');
+      let history = JSON.parse(storage.getItem('TNCHistory'));
       if (!history || !Array.isArray(history)) {
+        console.log('logReadingHistory: resetting history!', history);
         history = [];
       }
 
@@ -42,7 +43,6 @@ export const useAnalytics = () => {
     summarizeReadingHistory: () => {
       let contactFrequency = '0 posts';
       const contactHistory = JSON.parse(storage.getItem('TNCHistory'));
-      console.log(contactHistory);
 
       if (contactHistory) {
         // only count articles

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,6 +37,9 @@ const App = ({ Component, pageProps }) => {
       logReadingHistory();
       const readingHistory = summarizeReadingHistory();
       setDimension('dimension2', readingHistory);
+      console.log('tracking dimension2:', readingHistory);
+      // setDimension('dimension4', false); // donor
+      // setDimension('dimension5', true); // subscriber
       trackPageViewed(url);
     };
     Router.events.on('routeChangeComplete', handleRouteChange);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,6 +22,7 @@ const App = ({ Component, pageProps }) => {
   const {
     init,
     trackPageViewed,
+    trackPageViewedWithDimension,
     setDimension,
     logReadingHistory,
     summarizeReadingHistory,
@@ -38,7 +39,7 @@ const App = ({ Component, pageProps }) => {
       const readingHistory = summarizeReadingHistory();
       setDimension('dimension2', readingHistory);
       console.log('tracking dimension2:', readingHistory);
-      trackPageViewed(url);
+      trackPageViewedWithDimension(url, 'dimension2', readingHistory);
     };
     Router.events.on('routeChangeComplete', handleRouteChange);
     return () => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -38,8 +38,6 @@ const App = ({ Component, pageProps }) => {
       const readingHistory = summarizeReadingHistory();
       setDimension('dimension2', readingHistory);
       console.log('tracking dimension2:', readingHistory);
-      // setDimension('dimension4', false); // donor
-      // setDimension('dimension5', true); // subscriber
       trackPageViewed(url);
     };
     Router.events.on('routeChangeComplete', handleRouteChange);


### PR DESCRIPTION
Closes #395 

The number of articles read wasn't being tracked properly - it was always being reset because a step was missing, to parse the value as JSON first.

This PR fixes the issue and stores the # of articles read.