### PR TITLE
[outdated - use #411] Feature/reading depth analytics

### DIFF
--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 export default function MailchimpReport(props) {
-  console.log('props.reports[0]:', props.reports[0].growth);
   if (!props.reports) console.error('No report passed for mailchimp');
   return (
     <div>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -169,14 +169,17 @@ const Report = (props) => {
 
     let collectedData = {};
     queryResult.forEach((row) => {
-      let percentage = row.dimensions[1];
       let articlePath = row.dimensions[3];
 
-      if (collectedData[articlePath]) {
-        collectedData[articlePath][percentage] = row.metrics[0].values[0];
-      } else {
-        collectedData[articlePath] = {};
-        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      if (articlePath !== '/') {
+        let percentage = row.dimensions[1];
+
+        if (collectedData[articlePath]) {
+          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+        } else {
+          collectedData[articlePath] = {};
+          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+        }
       }
     });
 
@@ -239,29 +242,29 @@ const Report = (props) => {
       )
       .catch((error) => console.error(error));
 
-    const customDimensionDonor = ['ga:dimension4'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [pageViewsMetric],
-      customDimensionDonor
-    )
-      .then((resp) => displayCustomResults(resp, donorData, setDonorData))
-      .catch((error) => console.error(error));
+    // const customDimensionDonor = ['ga:dimension4'];
+    // getMetricsData(
+    //   viewID,
+    //   startDate,
+    //   endDate,
+    //   [pageViewsMetric],
+    //   customDimensionDonor
+    // )
+    //   .then((resp) => displayCustomResults(resp, donorData, setDonorData))
+    //   .catch((error) => console.error(error));
 
-    const customDimensionSubscriber = ['ga:dimension5'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [pageViewsMetric],
-      customDimensionSubscriber
-    )
-      .then((resp) =>
-        displayCustomResults(resp, subscriberData, setSubscriberData)
-      )
-      .catch((error) => console.error(error));
+    // const customDimensionSubscriber = ['ga:dimension5'];
+    // getMetricsData(
+    //   viewID,
+    //   startDate,
+    //   endDate,
+    //   [pageViewsMetric],
+    //   customDimensionSubscriber
+    // )
+    //   .then((resp) =>
+    //     displayCustomResults(resp, subscriberData, setSubscriberData)
+    //   )
+    //   .catch((error) => console.error(error));
 
     const referralDimension = ['ga:source'];
     getMetricsData(
@@ -438,36 +441,25 @@ const Report = (props) => {
           <table className="table is-fullwidth" style={{ width: '100%' }}>
             <thead>
               <tr>
+                <th></th>
+                <th colspan="4">Percentage Read</th>
+              </tr>
+              <tr>
                 <th>Article</th>
-                <th>Percentage Read</th>
+                <th>25%</th>
+                <th>50%</th>
+                <th>75%</th>
+                <th>100%</th>
               </tr>
             </thead>
             <tbody>
               {Object.keys(readingDepthData).map((articlePath) => (
                 <tr>
-                  <td> {articlePath} </td>
-                  <td>
-                    <table>
-                      <tbody>
-                        <tr>
-                          <th>100%</th>
-                          <td>{readingDepthData[articlePath]['100%']}</td>
-                        </tr>
-                        <tr>
-                          <th>75%</th>
-                          <td>{readingDepthData[articlePath]['75%']}</td>
-                        </tr>
-                        <tr>
-                          <th>50%</th>
-                          <td>{readingDepthData[articlePath]['50%']}</td>
-                        </tr>
-                        <tr>
-                          <th>25%</th>
-                          <td>{readingDepthData[articlePath]['25%']}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </td>
+                  <td>{articlePath}</td>
+                  <td>{readingDepthData[articlePath]['25%']}</td>
+                  <td>{readingDepthData[articlePath]['50%']}</td>
+                  <td>{readingDepthData[articlePath]['75%']}</td>
+                  <td>{readingDepthData[articlePath]['100%']}</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -173,14 +173,32 @@ const Report = (props) => {
 
       if (articlePath !== '/') {
         let percentage = row.dimensions[1];
-
+        let count = row.metrics[0].values[0];
         if (collectedData[articlePath]) {
-          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+          collectedData[articlePath][percentage] = count;
         } else {
           collectedData[articlePath] = {};
-          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+          collectedData[articlePath][percentage] = count;
         }
       }
+    });
+
+    Object.keys(collectedData).forEach((path) => {
+      let read25 = 0;
+      let readFullArticleCount = 0;
+      Object.keys(collectedData[path]).forEach((pct) => {
+        if (pct === '25%') {
+          read25 = collectedData[path][pct];
+        }
+        if (pct === '100%') {
+          readFullArticleCount = collectedData[path][pct];
+        }
+      });
+      let readFullArticlePct = 0;
+      if (read25 > 0) {
+        readFullArticlePct = (readFullArticleCount / read25) * 100;
+      }
+      collectedData[path]['readFull'] = Math.round(readFullArticlePct);
     });
 
     setReadingDepthData(collectedData);
@@ -450,6 +468,7 @@ const Report = (props) => {
                 <th>50%</th>
                 <th>75%</th>
                 <th>100%</th>
+                <th>Read Full</th>
               </tr>
             </thead>
             <tbody>
@@ -460,6 +479,7 @@ const Report = (props) => {
                   <td>{readingDepthData[articlePath]['50%']}</td>
                   <td>{readingDepthData[articlePath]['75%']}</td>
                   <td>{readingDepthData[articlePath]['100%']}</td>
+                  <td>{readingDepthData[articlePath]['readFull']}%</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -22,6 +22,7 @@ const Report = (props) => {
   const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
   const [readingDepthData, setReadingDepthData] = useState({});
+  const [sortedReadingDepth, setSortedReadingDepth] = useState([]);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
   const [average, setAverage] = useState(0);
@@ -183,6 +184,7 @@ const Report = (props) => {
       }
     });
 
+    var sortable = [];
     Object.keys(collectedData).forEach((path) => {
       let read25 = 0;
       let readFullArticleCount = 0;
@@ -199,8 +201,16 @@ const Report = (props) => {
         readFullArticlePct = (readFullArticleCount / read25) * 100;
       }
       collectedData[path]['readFull'] = Math.round(readFullArticlePct);
+      sortable.push([path, readFullArticlePct]);
     });
 
+    sortable.sort(function (a, b) {
+      return b[1] - a[1];
+    });
+
+    console.log('sortable:', sortable);
+    setSortedReadingDepth(sortable);
+    console.log('sortedReadingDepth:', sortedReadingDepth);
     setReadingDepthData(collectedData);
   };
 
@@ -472,14 +482,14 @@ const Report = (props) => {
               </tr>
             </thead>
             <tbody>
-              {Object.keys(readingDepthData).map((articlePath) => (
+              {sortedReadingDepth.map((item) => (
                 <tr>
-                  <td>{articlePath}</td>
-                  <td>{readingDepthData[articlePath]['25%']}</td>
-                  <td>{readingDepthData[articlePath]['50%']}</td>
-                  <td>{readingDepthData[articlePath]['75%']}</td>
-                  <td>{readingDepthData[articlePath]['100%']}</td>
-                  <td>{readingDepthData[articlePath]['readFull']}%</td>
+                  <td>{item[0]}</td>
+                  <td>{readingDepthData[item[0]]['25%']}</td>
+                  <td>{readingDepthData[item[0]]['50%']}</td>
+                  <td>{readingDepthData[item[0]]['75%']}</td>
+                  <td>{readingDepthData[item[0]]['100%']}</td>
+                  <td>{readingDepthData[item[0]]['readFull']}%</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -21,6 +21,7 @@ const Report = (props) => {
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
   const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
+  const [readingDepthData, setReadingDepthData] = useState({});
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
   const [average, setAverage] = useState(0);
@@ -96,7 +97,7 @@ const Report = (props) => {
   };
 
   const displayCustomResults = (response, initialData, setData) => {
-    console.log('custom dimension response: ', response);
+    // console.log('custom dimension response: ', response);
 
     const queryResult = response.result.reports[0].data.rows;
 
@@ -119,7 +120,7 @@ const Report = (props) => {
   };
 
   const displayEventResults = (response, initialData, setData) => {
-    console.log('event response: ', response);
+    // console.log('event response: ', response);
     const queryResult = response.result.reports[0].data.rows;
 
     let labels = [];
@@ -141,7 +142,7 @@ const Report = (props) => {
   };
 
   const displaySignupEventResults = (response, initialData, setData) => {
-    console.log('signup response: ', response);
+    // console.log('signup response: ', response);
     const queryResult = response.result.reports[0].data.rows;
 
     let labels = [];
@@ -160,6 +161,26 @@ const Report = (props) => {
       labels,
       values,
     });
+  };
+
+  const displayReadingDepthResults = (response, initialData, setData) => {
+    const queryResult = response.result.reports[0].data.rows;
+    console.log('reading depth: ', queryResult);
+
+    let collectedData = {};
+    queryResult.forEach((row) => {
+      let percentage = row.dimensions[1];
+      let articlePath = row.dimensions[3];
+
+      if (collectedData[articlePath]) {
+        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      } else {
+        collectedData[articlePath] = {};
+        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      }
+    });
+
+    setReadingDepthData(collectedData);
   };
 
   useEffect(() => {
@@ -277,6 +298,14 @@ const Report = (props) => {
     })
       .then((resp) => {
         displaySignupEventResults(resp, signupEventsData, setSignupEventsData);
+      })
+      .catch((error) => console.error(error));
+
+    getMetricsData(viewID, startDate, endDate, eventMetrics, eventDimensions, {
+      filters: 'ga:eventCategory==NTG Article Milestone',
+    })
+      .then((resp) => {
+        displayReadingDepthResults(resp, readingDepthData, setReadingDepthData);
       })
       .catch((error) => console.error(error));
   }, []);
@@ -400,6 +429,50 @@ const Report = (props) => {
             ))}
           </tbody>
         </table>
+      </section>
+
+      <section className="section">
+        <div className="content">
+          <p className="subtitle is-5">Reading Depth</p>
+
+          <table className="table is-fullwidth" style={{ width: '100%' }}>
+            <thead>
+              <tr>
+                <th>Article</th>
+                <th>Percentage Read</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.keys(readingDepthData).map((articlePath) => (
+                <tr>
+                  <td> {articlePath} </td>
+                  <td>
+                    <table>
+                      <tbody>
+                        <tr>
+                          <th>100%</th>
+                          <td>{readingDepthData[articlePath]['100%']}</td>
+                        </tr>
+                        <tr>
+                          <th>75%</th>
+                          <td>{readingDepthData[articlePath]['75%']}</td>
+                        </tr>
+                        <tr>
+                          <th>50%</th>
+                          <td>{readingDepthData[articlePath]['50%']}</td>
+                        </tr>
+                        <tr>
+                          <th>25%</th>
+                          <td>{readingDepthData[articlePath]['25%']}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section className="section"></section>

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -110,9 +110,7 @@ export async function getServerSideProps(context) {
   });
   let report = reportsResponse.reports[0];
   let listId = report.list_id;
-  console.log('reports:', JSON.stringify(report));
   let data = await mailchimp.lists.getListGrowthHistory(listId);
-  console.log('growth for list ' + report.list_id + ':', data);
   report['growth'] = data;
   fullReports.push(report);
 


### PR DESCRIPTION
Closes #405 

- [x] calculate % of people who read each article in full
- [x] display "read full" percentages per article
- [x] order reading depth stats table by % read full article 
- [ ] ~display overall average "x% of all readers read an entire article, y% read half"~

So I was going to do that last checkbox when I realised I didn't know what would be the most useful thing to do - how many visitors to our website read half or more of a single article? What percentage of published articles were read in full by anyone? 

I'm happy to revisit this work and extend it with overall averages, just let me know what we're aiming for. I didn't see this mentioned in the memberkit docs, though those docs do go into many other metrics that I haven't added to the dashboard (yet...) :) 