### PR TITLE
refactor analytics into separate components and pages - PRs 409, 410 & 411

### DIFF
--- a/components/tinycms/analytics/AverageSessionDuration.js
+++ b/components/tinycms/analytics/AverageSessionDuration.js
@@ -2,30 +2,32 @@ import React, { useState, useEffect } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 import { formatDate } from '../../../lib/utils';
 
-const DailySessions = (props) => {
+const AverageSessionDuration = (props) => {
   const INITIAL_STATE = {
     labels: [],
     values: [],
   };
-  const [reportData, setReportData] = useState(INITIAL_STATE);
-  const [average, setAverage] = useState(0);
+  const [timeReportData, setTimeReportData] = useState(INITIAL_STATE);
+  const [timeAverage, setTimeAverage] = useState(0);
 
   useEffect(() => {
-    const sessionsMetric = 'ga:sessions';
     const dimensions = ['ga:date'];
+    const timeMetric = 'ga:avgSessionDuration';
 
     getMetricsData(
       props.viewID,
       props.startDate,
       props.endDate,
-      [sessionsMetric],
+      [timeMetric],
       dimensions
     )
       .then((response) => {
         const queryResult = response.result.reports[0].data.rows;
         const total = response.result.reports[0].data.totals[0].values[0];
 
-        setAverage(parseInt(total / response.result.reports[0].data.rowCount));
+        setTimeAverage(
+          parseInt(total / response.result.reports[0].data.rowCount)
+        );
 
         let labels = [];
         let values = [];
@@ -37,8 +39,9 @@ const DailySessions = (props) => {
           labels.push(formattedDate);
           values.push(value);
         });
-        setReportData({
-          ...reportData,
+
+        setTimeReportData({
+          ...timeReportData,
           labels,
           values,
         });
@@ -49,20 +52,22 @@ const DailySessions = (props) => {
   return (
     <section className="section">
       <div className="content">
-        <p className="subtitle is-5">Sessions per day</p>
+        <p className="subtitle is-5">Average session duration</p>
+
+        <p>Overall average: {props.timeAverage} seconds</p>
 
         <table className="table is-fullwidth" style={{ width: '100%' }}>
           <thead>
             <tr>
               <th>Date</th>
-              <th>Sessions</th>
+              <th>Seconds</th>
             </tr>
           </thead>
           <tbody>
-            {reportData.labels.map((label, i) => (
-              <tr key={`daily-sessions-row-${i}`}>
-                <td>{label}</td>
-                <td>{reportData.values[i]}</td>
+            {timeReportData.labels.map((label, i) => (
+              <tr key={`time-report-${i}`}>
+                <td> {label} </td>
+                <td> {timeReportData.values[i]} </td>
               </tr>
             ))}
           </tbody>
@@ -72,4 +77,4 @@ const DailySessions = (props) => {
   );
 };
 
-export default DailySessions;
+export default AverageSessionDuration;

--- a/components/tinycms/analytics/AverageSessionDuration.js
+++ b/components/tinycms/analytics/AverageSessionDuration.js
@@ -52,7 +52,7 @@ const AverageSessionDuration = (props) => {
   return (
     <section className="section">
       <div className="content">
-        <p className="subtitle is-5">Average session duration</p>
+        <h2 className="subtitle">Average session duration</h2>
 
         <p>Overall average: {props.timeAverage} seconds</p>
 

--- a/components/tinycms/analytics/CustomDimensions.js
+++ b/components/tinycms/analytics/CustomDimensions.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const CustomDimensions = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [data, setData] = useState(INITIAL_STATE);
+
+  useEffect(() => {
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      props.metrics,
+      props.dimensions
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+
+        if (!queryResult) {
+          console.error('No results found for ' + props.dimensions);
+          return;
+        }
+
+        let labels = [];
+        let values = [];
+
+        queryResult.forEach((row) => {
+          let label = row.dimensions.join(' - ');
+          let value = row.metrics[0].values[0];
+
+          labels.push(label);
+          values.push(value);
+        });
+
+        setData({
+          ...data,
+          labels,
+          values,
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <h2 className="subtitle">Sessions by audience segment: {props.label}</h2>
+
+      <table className="table is-fullwidth" style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>{props.label}</th>
+            <th>Sessions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.labels.map((label, i) => (
+            <tr>
+              <td>{label}</td>
+              <td>{data.values[i]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default CustomDimensions;

--- a/components/tinycms/analytics/CustomDimensions.js
+++ b/components/tinycms/analytics/CustomDimensions.js
@@ -56,12 +56,18 @@ const CustomDimensions = (props) => {
           </tr>
         </thead>
         <tbody>
-          {data.labels.map((label, i) => (
+          {data.labels.length > 0 &&
+            data.labels.map((label, i) => (
+              <tr>
+                <td>{label}</td>
+                <td>{data.values[i]}</td>
+              </tr>
+            ))}
+          {data.labels.length === 0 && (
             <tr>
-              <td>{label}</td>
-              <td>{data.values[i]}</td>
+              <td colSpan="2">No data found</td>
             </tr>
-          ))}
+          )}
         </tbody>
       </table>
     </section>

--- a/components/tinycms/analytics/DailySessions.js
+++ b/components/tinycms/analytics/DailySessions.js
@@ -49,7 +49,7 @@ const DailySessions = (props) => {
   return (
     <section className="section">
       <div className="content">
-        <p className="subtitle is-5">Sessions per day</p>
+        <h2 className="subtitle">Sessions per day</h2>
 
         <table className="table is-fullwidth" style={{ width: '100%' }}>
           <thead>

--- a/components/tinycms/analytics/DailySessions.js
+++ b/components/tinycms/analytics/DailySessions.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const DailySessions = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [reportData, setReportData] = useState(INITIAL_STATE);
+
+  useEffect(() => {
+    const sessionsMetric = 'ga:sessions';
+    const dimensions = ['ga:date'];
+
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      [sessionsMetric],
+      dimensions
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+        const total = response.result.reports[0].data.totals[0].values[0];
+
+        props.setTimeAverage(
+          parseInt(total / response.result.reports[0].data.rowCount)
+        );
+
+        let labels = [];
+        let values = [];
+
+        queryResult.forEach((row) => {
+          let formattedDate = formatDate(row.dimensions[0]);
+          let value = row.metrics[0].values[0];
+
+          labels.push(formattedDate);
+          values.push(value);
+        });
+        setReportData({
+          ...reportData,
+          labels,
+          values,
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <div className="content">
+        <p className="subtitle is-5">Sessions per day</p>
+
+        <table className="table is-fullwidth" style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Sessions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reportData.labels.map((label, i) => (
+              <tr>
+                <td>{label}</td>
+                <td>{reportData.values[i]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default DailySessions;

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const DailySessions = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
+
+  useEffect(() => {
+    const pageViewsMetric = 'ga:pageviews';
+    const sessionsMetric = 'ga:sessions';
+    const geoDimensions = ['ga:country', 'ga:region'];
+
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      [sessionsMetric, pageViewsMetric],
+      geoDimensions
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+
+        let labels = [];
+        let values = [];
+
+        queryResult.forEach((row) => {
+          let label = row.dimensions.join(' - ');
+          let value = row.metrics[0].values[0];
+
+          labels.push(label);
+          values.push(value);
+        });
+
+        setGeoReportData({
+          ...geoReportData,
+          labels,
+          values,
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <div className="content">
+        <p className="subtitle is-5">Sessions by geographic region</p>
+
+        <table className="table is-fullwidth" style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              <th>Country - Region</th>
+              <th>Sessions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {geoReportData.labels.map((label, i) => (
+              <tr>
+                <td>{label}</td>
+                <td> {geoReportData.values[i]} </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default DailySessions;

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -46,7 +46,7 @@ const GeoSessions = (props) => {
   return (
     <section className="section">
       <div className="content">
-        <p className="subtitle is-5">Sessions by geographic region</p>
+        <h2 className="subtitle">Sessions by geographic region</h2>
 
         <table className="table is-fullwidth" style={{ width: '100%' }}>
           <thead>

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
-const DailySessions = (props) => {
+const GeoSessions = (props) => {
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -57,7 +57,7 @@ const DailySessions = (props) => {
           </thead>
           <tbody>
             {geoReportData.labels.map((label, i) => (
-              <tr>
+              <tr key={`geo-report-row-${i}`}>
                 <td>{label}</td>
                 <td> {geoReportData.values[i]} </td>
               </tr>
@@ -69,4 +69,4 @@ const DailySessions = (props) => {
   );
 };
 
-export default DailySessions;
+export default GeoSessions;

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -5,7 +5,7 @@ export default function MailchimpReport(props) {
   return (
     <div>
       {props.reports.map((report) => (
-        <section className="section">
+        <section className="section" key={`mailchimp-report-${report.id}`}>
           <h2 className="subtitle">
             Newsletter Campaign: {report.campaign_title}
           </h2>
@@ -62,18 +62,20 @@ export default function MailchimpReport(props) {
                 <td>{report.list_stats.unsub_rate * 100}%</td>
               </tr>
               {report.growth.history.map((month) => (
-                <tr>
+                <tr key={`report-growth-row-${month.month}`}>
                   <td>Month: {month.month}</td>
                   <td>
                     <table>
-                      <tr>
-                        <th>Subscribed</th>
-                        <td>{month.subscribed}</td>
-                      </tr>
-                      <tr>
-                        <th>Unsubscribed</th>
-                        <td>{month.unsubscribed}</td>
-                      </tr>
+                      <tbody>
+                        <tr>
+                          <th>Subscribed</th>
+                          <td>{month.subscribed}</td>
+                        </tr>
+                        <tr>
+                          <th>Unsubscribed</th>
+                          <td>{month.unsubscribed}</td>
+                        </tr>
+                      </tbody>
                     </table>
                   </td>
                 </tr>

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 export default function MailchimpReport(props) {
-  console.log('props.reports[0]:', props.reports[0].growth);
   if (!props.reports) console.error('No report passed for mailchimp');
   return (
     <div>

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -2,82 +2,88 @@ import React, { useState, useEffect } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const NewsletterSignupFormData = (props) => {
-  const [signupEventsData, setSignupEventsData] = useState({});
   const [sortedNewsletter, setSortedNewsletter] = useState([]);
   const [sortedNewsletterRows, setSortedNewsletterRows] = useState([]);
 
-  let eventMetrics = ['ga:totalEvents'];
-  let eventDimensions = [
-    'ga:eventCategory',
-    'ga:eventAction',
-    'ga:eventLabel',
-    'ga:pagePath',
-    'ga:dimension2',
-  ];
-  getMetricsData(
-    props.viewID,
-    props.startDate,
-    props.endDate,
-    eventMetrics,
-    eventDimensions,
-    {
-      filters: 'ga:eventCategory==NTG Newsletter',
-    }
-  )
-    .then((resp) => {
-      const queryResult = resp.result.reports[0].data.rows;
+  useEffect(() => {
+    let eventMetrics = ['ga:totalEvents'];
+    let eventDimensions = [
+      'ga:eventCategory',
+      'ga:eventAction',
+      'ga:eventLabel',
+      'ga:pagePath',
+      'ga:dimension2',
+    ];
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      eventMetrics,
+      eventDimensions,
+      {
+        filters: 'ga:eventCategory==NTG Newsletter',
+      }
+    )
+      .then((resp) => {
+        const queryResult = resp.result.reports[0].data.rows;
 
-      let collectedData = {};
-      queryResult.forEach((row) => {
-        console.log('row:', row);
+        let collectedData = {};
+        queryResult.forEach((row) => {
+          console.log('row:', row);
 
-        let articlePath = row.dimensions[3];
-        let eventAction = row.dimensions[1];
-        let value = row.metrics[0].values[0];
+          let articlePath = row.dimensions[3];
+          let eventAction = row.dimensions[1];
+          let value = row.metrics[0].values[0];
 
-        if (collectedData[articlePath]) {
-          collectedData[articlePath][eventAction] = value;
-        } else {
-          collectedData[articlePath] = {};
-          collectedData[articlePath][eventAction] = value;
-        }
-      });
+          if (collectedData[articlePath]) {
+            collectedData[articlePath][eventAction] = value;
+          } else {
+            collectedData[articlePath] = {};
+            collectedData[articlePath][eventAction] = value;
+          }
+        });
 
-      var sortable = [];
-      Object.keys(collectedData).forEach((key) => {
-        let views = collectedData[key]['Newsletter Modal Impression 1'];
-        let signups = collectedData[key]['Newsletter Signup'];
-        let conversion = 0;
+        var sortable = [];
+        Object.keys(collectedData).forEach((key) => {
+          let views = collectedData[key]['Newsletter Modal Impression 1'];
+          let signups = collectedData[key]['Newsletter Signup'];
+          let conversion = 0;
 
-        if (views && signups) {
-          conversion = (signups / views) * 100;
-        }
-        collectedData[key]['conversion'] = Math.round(conversion);
-        sortable.push([key, conversion]);
-      });
+          if (views && signups) {
+            conversion = (signups / views) * 100;
+          }
+          collectedData[key]['conversion'] = Math.round(conversion);
+          sortable.push([key, conversion]);
+        });
 
-      sortable.sort(function (a, b) {
-        return b[1] - a[1];
-      });
+        sortable.sort(function (a, b) {
+          return b[1] - a[1];
+        });
 
-      let sortedRows = [];
-      setSortedNewsletter(sortable);
-      sortedNewsletter.map((item) => {
-        sortedRows.push(
-          <tr>
-            <td>{item[0]}</td>
-            <td>
-              {signupEventsData[item[0]]['Newsletter Modal Impression 1']}
-            </td>
-            <td>{signupEventsData[item[0]]['Newsletter Signup']}</td>
-            <td>{signupEventsData[item[0]]['conversion']}%</td>
-          </tr>
-        );
-      });
-      setSortedNewsletterRows(sortedRows);
-      setData(collectedData);
-    })
-    .catch((error) => console.error(error));
+        let sortedRows = [];
+        setSortedNewsletter(sortable);
+        sortedNewsletter.map((item) => {
+          // console.log("item:", item)
+          if (item && item[0]) {
+            // console.log("item:", item, collectedData[item[0]])
+            sortedRows.push(
+              <tr>
+                <td>{item[0]}</td>
+                <td>
+                  {collectedData[item[0]]['Newsletter Modal Impression 1']}
+                </td>
+                <td>{collectedData[item[0]]['Newsletter Signup']}</td>
+                <td>{collectedData[item[0]]['conversion']}%</td>
+              </tr>
+            );
+          } else {
+            console.error('NEWSLETTER MISSING ITEM', sortedNewsletter);
+          }
+        });
+        setSortedNewsletterRows(sortedRows);
+      })
+      .catch((error) => console.error(error));
+  }, []);
 
   return (
     <section className="section">

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -62,12 +62,12 @@ const NewsletterSignupFormData = (props) => {
 
         let sortedRows = [];
         setSortedNewsletter(sortable);
-        sortedNewsletter.map((item) => {
+        sortedNewsletter.map((item, i) => {
           // console.log("item:", item)
           if (item && item[0]) {
             // console.log("item:", item, collectedData[item[0]])
             sortedRows.push(
-              <tr>
+              <tr key={`newsletter-signup-row-${i}`}>
                 <td>{item[0]}</td>
                 <td>
                   {collectedData[item[0]]['Newsletter Modal Impression 1']}

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const NewsletterSignupFormData = (props) => {
-  const [sortedNewsletter, setSortedNewsletter] = useState([]);
   const [sortedNewsletterRows, setSortedNewsletterRows] = useState([]);
 
   useEffect(() => {
@@ -61,8 +60,7 @@ const NewsletterSignupFormData = (props) => {
         });
 
         let sortedRows = [];
-        setSortedNewsletter(sortable);
-        sortedNewsletter.map((item, i) => {
+        sortable.map((item, i) => {
           // console.log("item:", item)
           if (item && item[0]) {
             // console.log("item:", item, collectedData[item[0]])

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const NewsletterSignupFormData = (props) => {
+  const [signupEventsData, setSignupEventsData] = useState({});
+  const [sortedNewsletter, setSortedNewsletter] = useState([]);
+  const [sortedNewsletterRows, setSortedNewsletterRows] = useState([]);
+
+  let eventMetrics = ['ga:totalEvents'];
+  let eventDimensions = [
+    'ga:eventCategory',
+    'ga:eventAction',
+    'ga:eventLabel',
+    'ga:pagePath',
+    'ga:dimension2',
+  ];
+  getMetricsData(
+    props.viewID,
+    props.startDate,
+    props.endDate,
+    eventMetrics,
+    eventDimensions,
+    {
+      filters: 'ga:eventCategory==NTG Newsletter',
+    }
+  )
+    .then((resp) => {
+      const queryResult = resp.result.reports[0].data.rows;
+
+      let collectedData = {};
+      queryResult.forEach((row) => {
+        console.log('row:', row);
+
+        let articlePath = row.dimensions[3];
+        let eventAction = row.dimensions[1];
+        let value = row.metrics[0].values[0];
+
+        if (collectedData[articlePath]) {
+          collectedData[articlePath][eventAction] = value;
+        } else {
+          collectedData[articlePath] = {};
+          collectedData[articlePath][eventAction] = value;
+        }
+      });
+
+      var sortable = [];
+      Object.keys(collectedData).forEach((key) => {
+        let views = collectedData[key]['Newsletter Modal Impression 1'];
+        let signups = collectedData[key]['Newsletter Signup'];
+        let conversion = 0;
+
+        if (views && signups) {
+          conversion = (signups / views) * 100;
+        }
+        collectedData[key]['conversion'] = Math.round(conversion);
+        sortable.push([key, conversion]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
+      let sortedRows = [];
+      setSortedNewsletter(sortable);
+      sortedNewsletter.map((item) => {
+        sortedRows.push(
+          <tr>
+            <td>{item[0]}</td>
+            <td>
+              {signupEventsData[item[0]]['Newsletter Modal Impression 1']}
+            </td>
+            <td>{signupEventsData[item[0]]['Newsletter Signup']}</td>
+            <td>{signupEventsData[item[0]]['conversion']}%</td>
+          </tr>
+        );
+      });
+      setSortedNewsletterRows(sortedRows);
+      setData(collectedData);
+    })
+    .catch((error) => console.error(error));
+
+  return (
+    <section className="section">
+      <h2 className="subtitle">Website Signup Form</h2>
+
+      <table className="table is-fullwidth" style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>Location</th>
+            <th>Views</th>
+            <th>Signups</th>
+            <th>Conversion Rate</th>
+          </tr>
+        </thead>
+        <tbody>{sortedNewsletterRows}</tbody>
+      </table>
+    </section>
+  );
+};
+export default NewsletterSignupFormData;

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const PageViews = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
+
+  useEffect(() => {
+    const pageViewsMetric = 'ga:pageviews';
+    const pvDimensions = ['ga:pagePath'];
+    const orderBy = { fieldName: pageViewsMetric, order: 'DESCENDING' };
+
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      [pageViewsMetric],
+      pvDimensions,
+      orderBy
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+
+        let labels = [];
+        let values = [];
+
+        queryResult.forEach((row) => {
+          let label = row.dimensions[0];
+          if (label === '/') {
+            label += ' (homepage)';
+          }
+          let value = row.metrics[0].values[0];
+
+          labels.push(label);
+          values.push(value);
+        });
+
+        setPageViewReportData({
+          ...pageViewReportData,
+          labels,
+          values,
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <h2 className="subtitle">Page views</h2>
+
+      <table className="table is-fullwidth" style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Views</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pageViewReportData.labels.map((label, i) => (
+            <tr key={`page-view-row-${i}`}>
+              <td>{label}</td>
+              <td>{pageViewReportData.values[i]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default PageViews;

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const ReadingDepthData = (props) => {
+  const [readingDepthData, setReadingDepthData] = useState({});
+  const [readingDepthTableRows, setReadingDepthTableRows] = useState([]);
+
+  useEffect(() => {
+    let eventMetrics = ['ga:totalEvents'];
+    let eventDimensions = [
+      'ga:eventCategory',
+      'ga:eventAction',
+      'ga:eventLabel',
+      'ga:pagePath',
+    ];
+
+    let readingDepthRows = [];
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      eventMetrics,
+      eventDimensions,
+      {
+        filters: 'ga:eventCategory==NTG Article Milestone',
+      }
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+        // console.log('reading depth: ', queryResult);
+
+        let collectedData = {};
+        queryResult.forEach((row) => {
+          let articlePath = row.dimensions[3];
+
+          if (articlePath !== '/') {
+            let percentage = row.dimensions[1];
+            let count = row.metrics[0].values[0];
+            if (collectedData[articlePath]) {
+              collectedData[articlePath][percentage] = count;
+            } else {
+              collectedData[articlePath] = {};
+              collectedData[articlePath][percentage] = count;
+            }
+          }
+        });
+
+        var sortable = [];
+        Object.keys(collectedData).forEach((path) => {
+          let read25 = 0;
+          let readFullArticleCount = 0;
+          Object.keys(collectedData[path]).forEach((pct) => {
+            if (pct === '25%') {
+              read25 = collectedData[path][pct];
+            }
+            if (pct === '100%') {
+              readFullArticleCount = collectedData[path][pct];
+            }
+          });
+          let readFullArticlePct = 0;
+          if (read25 > 0) {
+            readFullArticlePct = (readFullArticleCount / read25) * 100;
+          }
+          collectedData[path]['readFull'] = Math.round(readFullArticlePct);
+          sortable.push([path, readFullArticlePct]);
+        });
+
+        sortable.sort(function (a, b) {
+          return b[1] - a[1];
+        });
+
+        sortable.map((item) => {
+          if (item && item[0] && readingDepthData[item[0]]) {
+            readingDepthRows.push(
+              <tr>
+                <td>{item[0]}</td>
+                <td>{readingDepthData[item[0]]['25%']}</td>
+                <td>{readingDepthData[item[0]]['50%']}</td>
+                <td>{readingDepthData[item[0]]['75%']}</td>
+                <td>{readingDepthData[item[0]]['100%']}</td>
+                <td>{readingDepthData[item[0]]['readFull']}%</td>
+              </tr>
+            );
+          } else {
+            console.log('readingDepthRows:', readingDepthRows);
+            console.log('sortable:', sortable);
+            console.log('collectedData:', collectedData);
+          }
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <div className="content">
+        <p className="subtitle is-5">Reading Depth</p>
+
+        <table className="table is-fullwidth" style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              <th></th>
+              <th colSpan="4">Percentage Read</th>
+            </tr>
+            <tr>
+              <th>Article</th>
+              <th>25%</th>
+              <th>50%</th>
+              <th>75%</th>
+              <th>100%</th>
+              <th>Read Full</th>
+            </tr>
+          </thead>
+          <tbody>{readingDepthTableRows}</tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default ReadingDepthData;

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -69,16 +69,16 @@ const ReadingDepthData = (props) => {
           return b[1] - a[1];
         });
 
-        sortable.map((item) => {
-          if (item && item[0] && readingDepthData[item[0]]) {
+        sortable.map((item, i) => {
+          if (item && item[0] && collectedData[item[0]]) {
             readingDepthRows.push(
-              <tr>
+              <tr key={`reading-depth-row-${i}`}>
                 <td>{item[0]}</td>
-                <td>{readingDepthData[item[0]]['25%']}</td>
-                <td>{readingDepthData[item[0]]['50%']}</td>
-                <td>{readingDepthData[item[0]]['75%']}</td>
-                <td>{readingDepthData[item[0]]['100%']}</td>
-                <td>{readingDepthData[item[0]]['readFull']}%</td>
+                <td>{collectedData[item[0]]['25%']}</td>
+                <td>{collectedData[item[0]]['50%']}</td>
+                <td>{collectedData[item[0]]['75%']}</td>
+                <td>{collectedData[item[0]]['100%']}</td>
+                <td>{collectedData[item[0]]['readFull']}%</td>
               </tr>
             );
           } else {
@@ -87,6 +87,7 @@ const ReadingDepthData = (props) => {
             console.log('collectedData:', collectedData);
           }
         });
+        setReadingDepthTableRows(readingDepthRows);
       })
       .catch((error) => console.error(error));
   }, []);

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const ReadingFrequencyData = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [frequencyData, setFrequencyData] = useState(INITIAL_STATE);
+  const pageViewsMetric = 'ga:pageviews';
+
+  const customDimensionFrequency = ['ga:dimension2'];
+  getMetricsData(
+    props.viewID,
+    props.startDate,
+    props.endDate,
+    [pageViewsMetric],
+    customDimensionFrequency
+  )
+    .then((response) => {
+      const queryResult = response.result.reports[0].data.rows;
+
+      let labels = [];
+      let values = [];
+
+      queryResult.forEach((row) => {
+        let label = row.dimensions.join(' - ');
+        let value = row.metrics[0].values[0];
+
+        labels.push(label);
+        values.push(value);
+      });
+      setFrequencyData({ ...frequencyData, labels, values });
+    })
+    .catch((error) => console.error(error));
+
+  return (
+    <section className="section">
+      <h2 className="subtitle">
+        Page views by audience segment: reading frequency
+      </h2>
+
+      <table className="table is-fullwidth" style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>Number of Articles</th>
+            <th>Sessions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {frequencyData.labels.map((label, i) => (
+            <tr>
+              <td>{label}</td>
+              <td>{frequencyData.values[i]} </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+};
+
+export default ReadingFrequencyData;

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -7,32 +7,35 @@ const ReadingFrequencyData = (props) => {
     values: [],
   };
   const [frequencyData, setFrequencyData] = useState(INITIAL_STATE);
-  const pageViewsMetric = 'ga:pageviews';
 
-  const customDimensionFrequency = ['ga:dimension2'];
-  getMetricsData(
-    props.viewID,
-    props.startDate,
-    props.endDate,
-    [pageViewsMetric],
-    customDimensionFrequency
-  )
-    .then((response) => {
-      const queryResult = response.result.reports[0].data.rows;
+  useEffect(() => {
+    const pageViewsMetric = 'ga:pageviews';
 
-      let labels = [];
-      let values = [];
+    const customDimensionFrequency = ['ga:dimension2'];
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      [pageViewsMetric],
+      customDimensionFrequency
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
 
-      queryResult.forEach((row) => {
-        let label = row.dimensions.join(' - ');
-        let value = row.metrics[0].values[0];
+        let labels = [];
+        let values = [];
 
-        labels.push(label);
-        values.push(value);
-      });
-      setFrequencyData({ ...frequencyData, labels, values });
-    })
-    .catch((error) => console.error(error));
+        queryResult.forEach((row) => {
+          let label = row.dimensions.join(' - ');
+          let value = row.metrics[0].values[0];
+
+          labels.push(label);
+          values.push(value);
+        });
+        setFrequencyData({ ...frequencyData, labels, values });
+      })
+      .catch((error) => console.error(error));
+  }, []);
 
   return (
     <section className="section">

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -52,7 +52,7 @@ const ReadingFrequencyData = (props) => {
         </thead>
         <tbody>
           {frequencyData.labels.map((label, i) => (
-            <tr>
+            <tr key={i}>
               <td>{label}</td>
               <td>{frequencyData.values[i]} </td>
             </tr>

--- a/components/tinycms/analytics/ReferralSource.js
+++ b/components/tinycms/analytics/ReferralSource.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { getMetricsData } from '../../../lib/analytics';
+
+const ReferralSource = (props) => {
+  const INITIAL_STATE = {
+    labels: [],
+    values: [],
+  };
+  const [referralData, setReferralData] = useState(INITIAL_STATE);
+
+  useEffect(() => {
+    const referralDimension = ['ga:source'];
+    const sessionsMetric = 'ga:sessions';
+
+    getMetricsData(
+      props.viewID,
+      props.startDate,
+      props.endDate,
+      [sessionsMetric],
+      referralDimension
+    )
+      .then((response) => {
+        const queryResult = response.result.reports[0].data.rows;
+
+        let labels = [];
+        let values = [];
+
+        queryResult.forEach((row) => {
+          let label = row.dimensions[0];
+          if (label === '/') {
+            label += ' (homepage)';
+          }
+          let value = row.metrics[0].values[0];
+
+          labels.push(label);
+          values.push(value);
+        });
+
+        setReferralData({
+          ...referralData,
+          labels,
+          values,
+        });
+      })
+      .catch((error) => console.error(error));
+  }, []);
+
+  return (
+    <section className="section">
+      <div className="content">
+        <h2 className="subtitle">Sessions by referral source</h2>
+
+        <table className="table is-fullwidth" style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              <th>Subscriber</th>
+              <th>Sessions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {referralData.labels.map((label, i) => (
+              <tr key={`referral-data-row-${i}`}>
+                <td>{label}</td>
+                <td>{referralData.values[i]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};
+
+export default ReferralSource;

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -169,14 +169,17 @@ const Report = (props) => {
 
     let collectedData = {};
     queryResult.forEach((row) => {
-      let percentage = row.dimensions[1];
       let articlePath = row.dimensions[3];
 
-      if (collectedData[articlePath]) {
-        collectedData[articlePath][percentage] = row.metrics[0].values[0];
-      } else {
-        collectedData[articlePath] = {};
-        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      if (articlePath !== '/') {
+        let percentage = row.dimensions[1];
+
+        if (collectedData[articlePath]) {
+          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+        } else {
+          collectedData[articlePath] = {};
+          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+        }
       }
     });
 
@@ -239,29 +242,29 @@ const Report = (props) => {
       )
       .catch((error) => console.error(error));
 
-    const customDimensionDonor = ['ga:dimension4'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [pageViewsMetric],
-      customDimensionDonor
-    )
-      .then((resp) => displayCustomResults(resp, donorData, setDonorData))
-      .catch((error) => console.error(error));
+    // const customDimensionDonor = ['ga:dimension4'];
+    // getMetricsData(
+    //   viewID,
+    //   startDate,
+    //   endDate,
+    //   [pageViewsMetric],
+    //   customDimensionDonor
+    // )
+    //   .then((resp) => displayCustomResults(resp, donorData, setDonorData))
+    //   .catch((error) => console.error(error));
 
-    const customDimensionSubscriber = ['ga:dimension5'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [pageViewsMetric],
-      customDimensionSubscriber
-    )
-      .then((resp) =>
-        displayCustomResults(resp, subscriberData, setSubscriberData)
-      )
-      .catch((error) => console.error(error));
+    // const customDimensionSubscriber = ['ga:dimension5'];
+    // getMetricsData(
+    //   viewID,
+    //   startDate,
+    //   endDate,
+    //   [pageViewsMetric],
+    //   customDimensionSubscriber
+    // )
+    //   .then((resp) =>
+    //     displayCustomResults(resp, subscriberData, setSubscriberData)
+    //   )
+    //   .catch((error) => console.error(error));
 
     const referralDimension = ['ga:source'];
     getMetricsData(
@@ -438,36 +441,25 @@ const Report = (props) => {
           <table className="table is-fullwidth" style={{ width: '100%' }}>
             <thead>
               <tr>
+                <th></th>
+                <th colspan="4">Percentage Read</th>
+              </tr>
+              <tr>
                 <th>Article</th>
-                <th>Percentage Read</th>
+                <th>25%</th>
+                <th>50%</th>
+                <th>75%</th>
+                <th>100%</th>
               </tr>
             </thead>
             <tbody>
               {Object.keys(readingDepthData).map((articlePath) => (
                 <tr>
-                  <td> {articlePath} </td>
-                  <td>
-                    <table>
-                      <tbody>
-                        <tr>
-                          <th>100%</th>
-                          <td>{readingDepthData[articlePath]['100%']}</td>
-                        </tr>
-                        <tr>
-                          <th>75%</th>
-                          <td>{readingDepthData[articlePath]['75%']}</td>
-                        </tr>
-                        <tr>
-                          <th>50%</th>
-                          <td>{readingDepthData[articlePath]['50%']}</td>
-                        </tr>
-                        <tr>
-                          <th>25%</th>
-                          <td>{readingDepthData[articlePath]['25%']}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </td>
+                  <td>{articlePath}</td>
+                  <td>{readingDepthData[articlePath]['25%']}</td>
+                  <td>{readingDepthData[articlePath]['50%']}</td>
+                  <td>{readingDepthData[articlePath]['75%']}</td>
+                  <td>{readingDepthData[articlePath]['100%']}</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { addDays } from 'date-fns';
 import { getMetricsData } from '../../../lib/analytics';
-import { formatDate } from '../../../lib/utils';
+import AverageSessionDuration from './AverageSessionDuration';
 import DailySessions from './DailySessions';
 import GeoSessions from './GeoSessions';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
@@ -16,42 +16,14 @@ const Report = (props) => {
   const [viewID, setViewID] = useState(
     process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
   );
-  const dimensions = ['ga:date'];
   const sessionsMetric = 'ga:sessions';
   // const [eventsData, setEventsData] = useState(INITIAL_STATE);
   // const [donorData, setDonorData] = useState(INITIAL_STATE);
   // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
-  const [timeReportData, setTimeReportData] = useState(INITIAL_STATE);
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
-  const [average, setAverage] = useState(0);
-  const [timeAverage, setTimeAverage] = useState(0);
-
-  const displayTimeResults = (response, initialData, setData) => {
-    const queryResult = response.result.reports[0].data.rows;
-    const total = response.result.reports[0].data.totals[0].values[0];
-
-    setTimeAverage(parseInt(total / response.result.reports[0].data.rowCount));
-
-    let labels = [];
-    let values = [];
-
-    queryResult.forEach((row) => {
-      let formattedDate = formatDate(row.dimensions[0]);
-      let value = row.metrics[0].values[0];
-
-      labels.push(formattedDate);
-      values.push(value);
-    });
-
-    setData({
-      ...initialData,
-      labels,
-      values,
-    });
-  };
 
   const displayResults = (response, initialData, setData) => {
     const queryResult = response.result.reports[0].data.rows;
@@ -102,13 +74,6 @@ const Report = (props) => {
 
   useEffect(() => {
     const pageViewsMetric = 'ga:pageviews';
-    const timeMetric = 'ga:avgSessionDuration';
-
-    getMetricsData(viewID, startDate, endDate, [timeMetric], dimensions)
-      .then((resp) =>
-        displayTimeResults(resp, timeReportData, setTimeReportData)
-      )
-      .catch((error) => console.error(error));
 
     const pvDimensions = ['ga:pagePath'];
     const orderBy = { fieldName: pageViewsMetric, order: 'DESCENDING' };
@@ -172,38 +137,14 @@ const Report = (props) => {
         </p>
       </section>
 
-      <DailySessions
-        setTimeAverage={setTimeAverage}
+      <DailySessions viewID={viewID} startDate={startDate} endDate={endDate} />
+
+      <GeoSessions viewID={viewID} startDate={startDate} endDate={endDate} />
+      <AverageSessionDuration
         viewID={viewID}
         startDate={startDate}
         endDate={endDate}
       />
-
-      <GeoSessions viewID={viewID} startDate={startDate} endDate={endDate} />
-      <section className="section">
-        <div className="content">
-          <p className="subtitle is-5">Average session duration</p>
-
-          <p>Overall average: {timeAverage} seconds</p>
-
-          <table className="table is-fullwidth" style={{ width: '100%' }}>
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Seconds</th>
-              </tr>
-            </thead>
-            <tbody>
-              {timeReportData.labels.map((label, i) => (
-                <tr>
-                  <td> {label} </td>
-                  <td> {timeReportData.values[i]} </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
 
       <section className="section">
         <div className="content">

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -9,55 +9,16 @@ import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
 import ReferralSource from './ReferralSource';
 import PageViews from './PageViews';
+import CustomDimensions from './CustomDimensions';
 
 const Report = (props) => {
-  const INITIAL_STATE = {
-    labels: [],
-    values: [],
-  };
   const [viewID, setViewID] = useState(
     process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
   );
-  // const [eventsData, setEventsData] = useState(INITIAL_STATE);
-  // const [donorData, setDonorData] = useState(INITIAL_STATE);
-  // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
 
-  const displayCustomResults = (response, initialData, setData) => {
-    // console.log('custom dimension response: ', response);
-
-    const queryResult = response.result.reports[0].data.rows;
-
-    let labels = [];
-    let values = [];
-
-    queryResult.forEach((row) => {
-      let label = row.dimensions.join(' - ');
-      let value = row.metrics[0].values[0];
-
-      labels.push(label);
-      values.push(value);
-    });
-
-    setData({
-      ...initialData,
-      labels,
-      values,
-    });
-  };
-
   useEffect(() => {
-    // const customDimensionDonor = ['ga:dimension4'];
-    // getMetricsData(
-    //   viewID,
-    //   startDate,
-    //   endDate,
-    //   [pageViewsMetric],
-    //   customDimensionDonor
-    // )
-    //   .then((resp) => displayCustomResults(resp, donorData, setDonorData))
-    //   .catch((error) => console.error(error));
     // const customDimensionSubscriber = ['ga:dimension5'];
     // getMetricsData(
     //   viewID,
@@ -107,26 +68,14 @@ const Report = (props) => {
         endDate={endDate}
       />
 
-      {/* <section className="section">
-        <h2 className="subtitle">Sessions by audience segment: donor</h2>
-
-        <table className="table is-fullwidth" style={{ width: '100%' }}>
-          <thead>
-            <tr>
-              <th>Donor</th>
-              <th>Sessions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {donorData.labels.map((label, i) => (
-              <tr>
-                <td>{label}</td>
-                <td>{donorData.values[i]}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section> */}
+      <CustomDimensions
+        viewID={viewID}
+        startDate={startDate}
+        endDate={endDate}
+        metrics={['ga:sessions']}
+        dimensions={['ga:dimension4']}
+        label="Donor"
+      />
 
       {/* <section className="section">
         <h2 className="subtitle">Sessions by audience segment: subscriber</h2>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,13 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { addDays } from 'date-fns';
-import { getMetricsData } from '../../../lib/analytics';
-import AverageSessionDuration from './AverageSessionDuration';
-import DailySessions from './DailySessions';
-import GeoSessions from './GeoSessions';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
-import ReferralSource from './ReferralSource';
 import PageViews from './PageViews';
 import CustomDimensions from './CustomDimensions';
 
@@ -18,21 +13,6 @@ const Report = (props) => {
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
 
-  useEffect(() => {
-    // const customDimensionSubscriber = ['ga:dimension5'];
-    // getMetricsData(
-    //   viewID,
-    //   startDate,
-    //   endDate,
-    //   [pageViewsMetric],
-    //   customDimensionSubscriber
-    // )
-    //   .then((resp) =>
-    //     displayCustomResults(resp, subscriberData, setSubscriberData)
-    //   )
-    //   .catch((error) => console.error(error));
-  }, []);
-
   return (
     <div className="container">
       <section className="section">
@@ -41,17 +21,6 @@ const Report = (props) => {
           {endDate.toLocaleDateString()}.
         </p>
       </section>
-
-      <DailySessions viewID={viewID} startDate={startDate} endDate={endDate} />
-
-      <GeoSessions viewID={viewID} startDate={startDate} endDate={endDate} />
-      <AverageSessionDuration
-        viewID={viewID}
-        startDate={startDate}
-        endDate={endDate}
-      />
-
-      <ReferralSource viewID={viewID} startDate={startDate} endDate={endDate} />
 
       <PageViews viewID={viewID} startDate={startDate} endDate={endDate} />
 

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -8,6 +8,7 @@ import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
 import ReferralSource from './ReferralSource';
+import PageViews from './PageViews';
 
 const Report = (props) => {
   const INITIAL_STATE = {
@@ -20,33 +21,8 @@ const Report = (props) => {
   // const [eventsData, setEventsData] = useState(INITIAL_STATE);
   // const [donorData, setDonorData] = useState(INITIAL_STATE);
   // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
-  const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
-
-  const displayResults = (response, initialData, setData) => {
-    const queryResult = response.result.reports[0].data.rows;
-
-    let labels = [];
-    let values = [];
-
-    queryResult.forEach((row) => {
-      let label = row.dimensions[0];
-      if (label === '/') {
-        label += ' (homepage)';
-      }
-      let value = row.metrics[0].values[0];
-
-      labels.push(label);
-      values.push(value);
-    });
-
-    setData({
-      ...initialData,
-      labels,
-      values,
-    });
-  };
 
   const displayCustomResults = (response, initialData, setData) => {
     // console.log('custom dimension response: ', response);
@@ -72,23 +48,6 @@ const Report = (props) => {
   };
 
   useEffect(() => {
-    const pageViewsMetric = 'ga:pageviews';
-
-    const pvDimensions = ['ga:pagePath'];
-    const orderBy = { fieldName: pageViewsMetric, order: 'DESCENDING' };
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [pageViewsMetric],
-      pvDimensions,
-      orderBy
-    )
-      .then((resp) =>
-        displayResults(resp, pageViewReportData, setPageViewReportData)
-      )
-      .catch((error) => console.error(error));
-
     // const customDimensionDonor = ['ga:dimension4'];
     // getMetricsData(
     //   viewID,
@@ -99,7 +58,6 @@ const Report = (props) => {
     // )
     //   .then((resp) => displayCustomResults(resp, donorData, setDonorData))
     //   .catch((error) => console.error(error));
-
     // const customDimensionSubscriber = ['ga:dimension5'];
     // getMetricsData(
     //   viewID,
@@ -134,26 +92,8 @@ const Report = (props) => {
 
       <ReferralSource viewID={viewID} startDate={startDate} endDate={endDate} />
 
-      <section className="section">
-        <h2 className="subtitle">Page views</h2>
+      <PageViews viewID={viewID} startDate={startDate} endDate={endDate} />
 
-        <table className="table is-fullwidth" style={{ width: '100%' }}>
-          <thead>
-            <tr>
-              <th>Path</th>
-              <th>Views</th>
-            </tr>
-          </thead>
-          <tbody>
-            {pageViewReportData.labels.map((label, i) => (
-              <tr>
-                <td>{label}</td>
-                <td>{pageViewReportData.values[i]}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
       <ReadingDepthData
         viewID={viewID}
         startDate={startDate}

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -173,14 +173,32 @@ const Report = (props) => {
 
       if (articlePath !== '/') {
         let percentage = row.dimensions[1];
-
+        let count = row.metrics[0].values[0];
         if (collectedData[articlePath]) {
-          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+          collectedData[articlePath][percentage] = count;
         } else {
           collectedData[articlePath] = {};
-          collectedData[articlePath][percentage] = row.metrics[0].values[0];
+          collectedData[articlePath][percentage] = count;
         }
       }
+    });
+
+    Object.keys(collectedData).forEach((path) => {
+      let read25 = 0;
+      let readFullArticleCount = 0;
+      Object.keys(collectedData[path]).forEach((pct) => {
+        if (pct === '25%') {
+          read25 = collectedData[path][pct];
+        }
+        if (pct === '100%') {
+          readFullArticleCount = collectedData[path][pct];
+        }
+      });
+      let readFullArticlePct = 0;
+      if (read25 > 0) {
+        readFullArticlePct = (readFullArticleCount / read25) * 100;
+      }
+      collectedData[path]['readFull'] = Math.round(readFullArticlePct);
     });
 
     setReadingDepthData(collectedData);
@@ -450,6 +468,7 @@ const Report = (props) => {
                 <th>50%</th>
                 <th>75%</th>
                 <th>100%</th>
+                <th>Read Full</th>
               </tr>
             </thead>
             <tbody>
@@ -460,6 +479,7 @@ const Report = (props) => {
                   <td>{readingDepthData[articlePath]['50%']}</td>
                   <td>{readingDepthData[articlePath]['75%']}</td>
                   <td>{readingDepthData[articlePath]['100%']}</td>
+                  <td>{readingDepthData[articlePath]['readFull']}%</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -7,6 +7,7 @@ import GeoSessions from './GeoSessions';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
+import ReferralSource from './ReferralSource';
 
 const Report = (props) => {
   const INITIAL_STATE = {
@@ -16,12 +17,10 @@ const Report = (props) => {
   const [viewID, setViewID] = useState(
     process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
   );
-  const sessionsMetric = 'ga:sessions';
   // const [eventsData, setEventsData] = useState(INITIAL_STATE);
   // const [donorData, setDonorData] = useState(INITIAL_STATE);
   // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
-  const [referralData, setReferralData] = useState(INITIAL_STATE);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
 
@@ -113,19 +112,6 @@ const Report = (props) => {
     //     displayCustomResults(resp, subscriberData, setSubscriberData)
     //   )
     //   .catch((error) => console.error(error));
-
-    const referralDimension = ['ga:source'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [sessionsMetric],
-      referralDimension
-    )
-      .then((resp) => {
-        displayResults(resp, referralData, setReferralData);
-      })
-      .catch((error) => console.error(error));
   }, []);
 
   return (
@@ -146,28 +132,7 @@ const Report = (props) => {
         endDate={endDate}
       />
 
-      <section className="section">
-        <div className="content">
-          <h2 className="subtitle">Sessions by referral source</h2>
-
-          <table className="table is-fullwidth" style={{ width: '100%' }}>
-            <thead>
-              <tr>
-                <th>Subscriber</th>
-                <th>Sessions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {referralData.labels.map((label, i) => (
-                <tr>
-                  <td>{label}</td>
-                  <td>{referralData.values[i]}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <ReferralSource viewID={viewID} startDate={startDate} endDate={endDate} />
 
       <section className="section">
         <h2 className="subtitle">Page views</h2>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -22,6 +22,7 @@ const Report = (props) => {
   const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
   const [readingDepthData, setReadingDepthData] = useState({});
+  const [sortedReadingDepth, setSortedReadingDepth] = useState([]);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
   const [average, setAverage] = useState(0);
@@ -183,6 +184,7 @@ const Report = (props) => {
       }
     });
 
+    var sortable = [];
     Object.keys(collectedData).forEach((path) => {
       let read25 = 0;
       let readFullArticleCount = 0;
@@ -199,8 +201,16 @@ const Report = (props) => {
         readFullArticlePct = (readFullArticleCount / read25) * 100;
       }
       collectedData[path]['readFull'] = Math.round(readFullArticlePct);
+      sortable.push([path, readFullArticlePct]);
     });
 
+    sortable.sort(function (a, b) {
+      return b[1] - a[1];
+    });
+
+    console.log('sortable:', sortable);
+    setSortedReadingDepth(sortable);
+    console.log('sortedReadingDepth:', sortedReadingDepth);
     setReadingDepthData(collectedData);
   };
 
@@ -472,14 +482,14 @@ const Report = (props) => {
               </tr>
             </thead>
             <tbody>
-              {Object.keys(readingDepthData).map((articlePath) => (
+              {sortedReadingDepth.map((item) => (
                 <tr>
-                  <td>{articlePath}</td>
-                  <td>{readingDepthData[articlePath]['25%']}</td>
-                  <td>{readingDepthData[articlePath]['50%']}</td>
-                  <td>{readingDepthData[articlePath]['75%']}</td>
-                  <td>{readingDepthData[articlePath]['100%']}</td>
-                  <td>{readingDepthData[articlePath]['readFull']}%</td>
+                  <td>{item[0]}</td>
+                  <td>{readingDepthData[item[0]]['25%']}</td>
+                  <td>{readingDepthData[item[0]]['50%']}</td>
+                  <td>{readingDepthData[item[0]]['75%']}</td>
+                  <td>{readingDepthData[item[0]]['100%']}</td>
+                  <td>{readingDepthData[item[0]]['readFull']}%</td>
                 </tr>
               ))}
             </tbody>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 import { addDays } from 'date-fns';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
-import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
-import PageViews from './PageViews';
 import CustomDimensions from './CustomDimensions';
 
 const Report = (props) => {
@@ -22,14 +20,6 @@ const Report = (props) => {
         </p>
       </section>
 
-      <PageViews viewID={viewID} startDate={startDate} endDate={endDate} />
-
-      <ReadingDepthData
-        viewID={viewID}
-        startDate={startDate}
-        endDate={endDate}
-      />
-
       <section className="section"></section>
       <ReadingFrequencyData
         viewID={viewID}
@@ -45,27 +35,6 @@ const Report = (props) => {
         dimensions={['ga:dimension4']}
         label="Donor"
       />
-
-      {/* <section className="section">
-        <h2 className="subtitle">Sessions by audience segment: subscriber</h2>
-
-        <table className="table is-fullwidth" style={{ width: '100%' }}>
-          <thead>
-            <tr>
-              <th>Subscriber</th>
-              <th>Sessions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {subscriberData.labels.map((label, i) => (
-              <tr>
-                <td>{label}</td>
-                <td>{subscriberData.values[i]}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section> */}
 
       <p className="title is-2">Newsletter Data</p>
 

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -3,6 +3,7 @@ import { addDays } from 'date-fns';
 import { getMetricsData } from '../../../lib/analytics';
 import { formatDate } from '../../../lib/utils';
 import DailySessions from './DailySessions';
+import GeoSessions from './GeoSessions';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
@@ -22,7 +23,6 @@ const Report = (props) => {
   // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
   const [timeReportData, setTimeReportData] = useState(INITIAL_STATE);
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
-  const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
@@ -77,27 +77,6 @@ const Report = (props) => {
     });
   };
 
-  const displayGeo = (response) => {
-    const queryResult = response.result.reports[0].data.rows;
-
-    let labels = [];
-    let values = [];
-
-    queryResult.forEach((row) => {
-      let label = row.dimensions.join(' - ');
-      let value = row.metrics[0].values[0];
-
-      labels.push(label);
-      values.push(value);
-    });
-
-    setGeoReportData({
-      ...geoReportData,
-      labels,
-      values,
-    });
-  };
-
   const displayCustomResults = (response, initialData, setData) => {
     // console.log('custom dimension response: ', response);
 
@@ -144,17 +123,6 @@ const Report = (props) => {
       .then((resp) =>
         displayResults(resp, pageViewReportData, setPageViewReportData)
       )
-      .catch((error) => console.error(error));
-
-    const geoDimensions = ['ga:country', 'ga:region'];
-    getMetricsData(
-      viewID,
-      startDate,
-      endDate,
-      [sessionsMetric, pageViewsMetric],
-      geoDimensions
-    )
-      .then((resp) => displayGeo(resp))
       .catch((error) => console.error(error));
 
     // const customDimensionDonor = ['ga:dimension4'];
@@ -211,28 +179,7 @@ const Report = (props) => {
         endDate={endDate}
       />
 
-      <section className="section">
-        <div className="content">
-          <p className="subtitle is-5">Sessions by geographic region</p>
-
-          <table className="table is-fullwidth" style={{ width: '100%' }}>
-            <thead>
-              <tr>
-                <th>Country - Region</th>
-                <th>Sessions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {geoReportData.labels.map((label, i) => (
-                <tr>
-                  <td>{label}</td>
-                  <td> {geoReportData.values[i]} </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <GeoSessions viewID={viewID} startDate={startDate} endDate={endDate} />
       <section className="section">
         <div className="content">
           <p className="subtitle is-5">Average session duration</p>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { addDays } from 'date-fns';
 import { getMetricsData } from '../../../lib/analytics';
 import { formatDate } from '../../../lib/utils';
+import DailySessions from './DailySessions';
 import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingDepthData from './ReadingDepthData';
 import ReadingFrequencyData from './ReadingFrequencyData';
@@ -14,10 +15,11 @@ const Report = (props) => {
   const [viewID, setViewID] = useState(
     process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
   );
-  const [reportData, setReportData] = useState(INITIAL_STATE);
+  const dimensions = ['ga:date'];
+  const sessionsMetric = 'ga:sessions';
   // const [eventsData, setEventsData] = useState(INITIAL_STATE);
   // const [donorData, setDonorData] = useState(INITIAL_STATE);
-  const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
+  // const [subscriberData, setSubscriberData] = useState(INITIAL_STATE);
   const [timeReportData, setTimeReportData] = useState(INITIAL_STATE);
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
   const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
@@ -120,15 +122,8 @@ const Report = (props) => {
   };
 
   useEffect(() => {
-    const sessionsMetric = 'ga:sessions';
-    const usersMetric = 'ga:users';
     const pageViewsMetric = 'ga:pageviews';
     const timeMetric = 'ga:avgSessionDuration';
-
-    const dimensions = ['ga:date'];
-    getMetricsData(viewID, startDate, endDate, [sessionsMetric], dimensions)
-      .then((resp) => displayTimeResults(resp, reportData, setReportData))
-      .catch((error) => console.error(error));
 
     getMetricsData(viewID, startDate, endDate, [timeMetric], dimensions)
       .then((resp) =>
@@ -198,14 +193,6 @@ const Report = (props) => {
         displayResults(resp, referralData, setReferralData);
       })
       .catch((error) => console.error(error));
-
-    let eventMetrics = ['ga:totalEvents'];
-    let eventDimensions = [
-      'ga:eventCategory',
-      'ga:eventAction',
-      'ga:eventLabel',
-      'ga:pagePath',
-    ];
   }, []);
 
   return (
@@ -216,28 +203,14 @@ const Report = (props) => {
           {endDate.toLocaleDateString()}.
         </p>
       </section>
-      <section className="section">
-        <div className="content">
-          <p className="subtitle is-5">Sessions per day</p>
 
-          <table className="table is-fullwidth" style={{ width: '100%' }}>
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Sessions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {reportData.labels.map((label, i) => (
-                <tr>
-                  <td>{label}</td>
-                  <td>{reportData.values[i]}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <DailySessions
+        setTimeAverage={setTimeAverage}
+        viewID={viewID}
+        startDate={startDate}
+        endDate={endDate}
+      />
+
       <section className="section">
         <div className="content">
           <p className="subtitle is-5">Sessions by geographic region</p>

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { addDays } from 'date-fns';
-import CustomDimensions from './CustomDimensions';
 
 const Report = (props) => {
   const [viewID, setViewID] = useState(
@@ -19,14 +18,6 @@ const Report = (props) => {
       </section>
 
       <section className="section"></section>
-      <CustomDimensions
-        viewID={viewID}
-        startDate={startDate}
-        endDate={endDate}
-        metrics={['ga:sessions']}
-        dimensions={['ga:dimension4']}
-        label="Donor"
-      />
     </div>
   );
 };

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { addDays } from 'date-fns';
-import NewsletterSignupFormData from './NewsletterSignupFormData';
 import ReadingFrequencyData from './ReadingFrequencyData';
 import CustomDimensions from './CustomDimensions';
 
@@ -34,14 +33,6 @@ const Report = (props) => {
         metrics={['ga:sessions']}
         dimensions={['ga:dimension4']}
         label="Donor"
-      />
-
-      <p className="title is-2">Newsletter Data</p>
-
-      <NewsletterSignupFormData
-        viewID={viewID}
-        startDate={startDate}
-        endDate={endDate}
       />
     </div>
   );

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { addDays } from 'date-fns';
-import ReadingFrequencyData from './ReadingFrequencyData';
 import CustomDimensions from './CustomDimensions';
 
 const Report = (props) => {
@@ -20,12 +19,6 @@ const Report = (props) => {
       </section>
 
       <section className="section"></section>
-      <ReadingFrequencyData
-        viewID={viewID}
-        startDate={startDate}
-        endDate={endDate}
-      />
-
       <CustomDimensions
         viewID={viewID}
         startDate={startDate}

--- a/components/tinycms/analytics/Report.js
+++ b/components/tinycms/analytics/Report.js
@@ -21,6 +21,7 @@ const Report = (props) => {
   const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
   const [geoReportData, setGeoReportData] = useState(INITIAL_STATE);
   const [referralData, setReferralData] = useState(INITIAL_STATE);
+  const [readingDepthData, setReadingDepthData] = useState({});
   const [startDate, setStartDate] = useState(addDays(new Date(), -30));
   const [endDate, setEndDate] = useState(new Date());
   const [average, setAverage] = useState(0);
@@ -96,7 +97,7 @@ const Report = (props) => {
   };
 
   const displayCustomResults = (response, initialData, setData) => {
-    console.log('custom dimension response: ', response);
+    // console.log('custom dimension response: ', response);
 
     const queryResult = response.result.reports[0].data.rows;
 
@@ -119,7 +120,7 @@ const Report = (props) => {
   };
 
   const displayEventResults = (response, initialData, setData) => {
-    console.log('event response: ', response);
+    // console.log('event response: ', response);
     const queryResult = response.result.reports[0].data.rows;
 
     let labels = [];
@@ -141,7 +142,7 @@ const Report = (props) => {
   };
 
   const displaySignupEventResults = (response, initialData, setData) => {
-    console.log('signup response: ', response);
+    // console.log('signup response: ', response);
     const queryResult = response.result.reports[0].data.rows;
 
     let labels = [];
@@ -160,6 +161,26 @@ const Report = (props) => {
       labels,
       values,
     });
+  };
+
+  const displayReadingDepthResults = (response, initialData, setData) => {
+    const queryResult = response.result.reports[0].data.rows;
+    console.log('reading depth: ', queryResult);
+
+    let collectedData = {};
+    queryResult.forEach((row) => {
+      let percentage = row.dimensions[1];
+      let articlePath = row.dimensions[3];
+
+      if (collectedData[articlePath]) {
+        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      } else {
+        collectedData[articlePath] = {};
+        collectedData[articlePath][percentage] = row.metrics[0].values[0];
+      }
+    });
+
+    setReadingDepthData(collectedData);
   };
 
   useEffect(() => {
@@ -277,6 +298,14 @@ const Report = (props) => {
     })
       .then((resp) => {
         displaySignupEventResults(resp, signupEventsData, setSignupEventsData);
+      })
+      .catch((error) => console.error(error));
+
+    getMetricsData(viewID, startDate, endDate, eventMetrics, eventDimensions, {
+      filters: 'ga:eventCategory==NTG Article Milestone',
+    })
+      .then((resp) => {
+        displayReadingDepthResults(resp, readingDepthData, setReadingDepthData);
       })
       .catch((error) => console.error(error));
   }, []);
@@ -400,6 +429,50 @@ const Report = (props) => {
             ))}
           </tbody>
         </table>
+      </section>
+
+      <section className="section">
+        <div className="content">
+          <p className="subtitle is-5">Reading Depth</p>
+
+          <table className="table is-fullwidth" style={{ width: '100%' }}>
+            <thead>
+              <tr>
+                <th>Article</th>
+                <th>Percentage Read</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.keys(readingDepthData).map((articlePath) => (
+                <tr>
+                  <td> {articlePath} </td>
+                  <td>
+                    <table>
+                      <tbody>
+                        <tr>
+                          <th>100%</th>
+                          <td>{readingDepthData[articlePath]['100%']}</td>
+                        </tr>
+                        <tr>
+                          <th>75%</th>
+                          <td>{readingDepthData[articlePath]['75%']}</td>
+                        </tr>
+                        <tr>
+                          <th>50%</th>
+                          <td>{readingDepthData[articlePath]['50%']}</td>
+                        </tr>
+                        <tr>
+                          <th>25%</th>
+                          <td>{readingDepthData[articlePath]['25%']}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section className="section"></section>

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { addDays } from 'date-fns';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import AdminLayout from '../../../components/AdminLayout';
+import AdminNav from '../../../components/nav/AdminNav';
+import CustomDimensions from '../../../components/tinycms/analytics/CustomDimensions';
+
+export default function Audience(props) {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const [viewID, setViewID] = useState(
+    process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
+  );
+  const [startDate, setStartDate] = useState(addDays(new Date(), -30));
+  const [endDate, setEndDate] = useState(new Date());
+
+  const initAuth = () => {
+    return window.gapi.auth2.init({
+      client_id: props.clientID, //paste your client ID here
+      scope: 'https://www.googleapis.com/auth/analytics.readonly',
+    });
+  };
+
+  const checkSignedIn = () => {
+    return new Promise((resolve, reject) => {
+      initAuth() //calls the previous function
+        .then(() => {
+          const auth = window.gapi.auth2.getAuthInstance(); //returns the GoogleAuth object
+          resolve(auth.isSignedIn.get()); //returns whether the current user is currently signed in
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  };
+
+  const renderButton = () => {
+    window.gapi.signin2.render('signin-button', {
+      scope: 'profile email',
+      width: 240,
+      height: 50,
+      longtitle: true,
+      theme: 'dark',
+      onsuccess: onSuccess,
+      onfailure: onFailure,
+    });
+  };
+
+  const onSuccess = (googleUser) => {
+    console.log('Logged in as: ' + googleUser.getBasicProfile().getName());
+  };
+
+  const onFailure = (error) => {
+    console.error(error);
+  };
+
+  const updateSignin = (signedIn) => {
+    setIsSignedIn(signedIn);
+    if (!signedIn) {
+      renderButton();
+    }
+  };
+
+  const init = () => {
+    //(2)
+    checkSignedIn()
+      .then((signedIn) => {
+        updateSignin(signedIn);
+      })
+      .catch((error) => {
+        console.log('checkSignedIn error: ', error);
+        console.error(error);
+      });
+  };
+
+  useEffect(() => {
+    window.gapi.load('auth2', init); //(1)
+  });
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+      <div className="analytics">
+        <section className="section">
+          <h1 className="title">Analytics Dashboard v1: Audience Overview</h1>
+        </section>
+        {!isSignedIn ? (
+          <div id="signin-button"></div>
+        ) : (
+          <div>
+            <div className="container">
+              <section className="section">
+                <p className="content">
+                  Data from {startDate.toLocaleDateString()} to{' '}
+                  {endDate.toLocaleDateString()}.
+                </p>
+              </section>
+
+              <CustomDimensions
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+                metrics={['ga:sessions']}
+                dimensions={['ga:dimension4']}
+                label="Donor"
+              />
+
+              <CustomDimensions
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+                metrics={['ga:sessions']}
+                dimensions={['ga:dimension5']}
+                label="Subscriber"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}
+export async function getServerSideProps(context) {
+  const clientID = process.env.ANALYTICS_CLIENT_ID;
+  const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+
+  mailchimp.setConfig({
+    apiKey: process.env.MAILCHIMP_API_KEY,
+    server: process.env.MAILCHIMP_SERVER_PREFIX,
+  });
+
+  let fullReports = [];
+  let reportsResponse = await mailchimp.reports.getAllCampaignReports({
+    since_send_time: addDays(new Date(), -30),
+  });
+  let report = reportsResponse.reports[0];
+  let listId = report.list_id;
+  let data = await mailchimp.lists.getListGrowthHistory(listId);
+  report['growth'] = data;
+  fullReports.push(report);
+
+  return {
+    props: {
+      clientID: clientID,
+      clientSecret: clientSecret,
+      mailchimpKey: process.env.MAILCHIMP_API_KEY,
+      mailchimpServer: process.env.MAILCHIMP_SERVER_PREFIX,
+      reports: fullReports,
+    },
+  };
+}

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -110,9 +110,7 @@ export async function getServerSideProps(context) {
   });
   let report = reportsResponse.reports[0];
   let listId = report.list_id;
-  console.log('reports:', JSON.stringify(report));
   let data = await mailchimp.lists.getListGrowthHistory(listId);
-  console.log('growth for list ' + report.list_id + ':', data);
   report['growth'] = data;
   fullReports.push(report);
 

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -4,7 +4,6 @@ import mailchimp from '@mailchimp/mailchimp_marketing';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import Report from '../../../components/tinycms/analytics/Report';
-import MailchimpReport from '../../../components/tinycms/analytics/MailchimpReport';
 
 export default function AnalyticsIndex(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -3,7 +3,6 @@ import { addDays } from 'date-fns';
 import mailchimp from '@mailchimp/mailchimp_marketing';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
-import Report from '../../../components/tinycms/analytics/Report';
 
 export default function AnalyticsIndex(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -82,7 +81,22 @@ export default function AnalyticsIndex(props) {
           <div id="signin-button"></div>
         ) : (
           <div>
-            <Report />
+            <ul>
+              <li>
+                <a href="/tinycms/analytics/sessions">Sessions Overview</a>
+              </li>
+              <li>
+                <a href="/tinycms/analytics/newsletter">Newsletters Overview</a>
+              </li>
+              <li>
+                <a href="/tinycms/analytics/pageviews">
+                  Page Views & Reading Overview
+                </a>
+              </li>
+              <li>
+                <a href="/tinycms/analytics/audience">Audience Overview</a>
+              </li>
+            </ul>
           </div>
         )}
       </div>
@@ -93,28 +107,10 @@ export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
 
-  mailchimp.setConfig({
-    apiKey: process.env.MAILCHIMP_API_KEY,
-    server: process.env.MAILCHIMP_SERVER_PREFIX,
-  });
-
-  let fullReports = [];
-  let reportsResponse = await mailchimp.reports.getAllCampaignReports({
-    since_send_time: addDays(new Date(), -30),
-  });
-  let report = reportsResponse.reports[0];
-  let listId = report.list_id;
-  let data = await mailchimp.lists.getListGrowthHistory(listId);
-  report['growth'] = data;
-  fullReports.push(report);
-
   return {
     props: {
       clientID: clientID,
       clientSecret: clientSecret,
-      mailchimpKey: process.env.MAILCHIMP_API_KEY,
-      mailchimpServer: process.env.MAILCHIMP_SERVER_PREFIX,
-      reports: fullReports,
     },
   };
 }

--- a/pages/tinycms/analytics/newsletter.js
+++ b/pages/tinycms/analytics/newsletter.js
@@ -3,11 +3,17 @@ import { addDays } from 'date-fns';
 import mailchimp from '@mailchimp/mailchimp_marketing';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
-import Report from '../../../components/tinycms/analytics/Report';
+import NewsletterSignupFormData from '../../../components/tinycms/analytics/NewsletterSignupFormData';
 import MailchimpReport from '../../../components/tinycms/analytics/MailchimpReport';
 
-export default function AnalyticsIndex(props) {
+export default function NewsletterOverview(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const [viewID, setViewID] = useState(
+    process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
+  );
+  const [startDate, setStartDate] = useState(addDays(new Date(), -30));
+  const [endDate, setEndDate] = useState(new Date());
 
   const initAuth = () => {
     return window.gapi.auth2.init({
@@ -77,13 +83,34 @@ export default function AnalyticsIndex(props) {
       <AdminNav homePageEditor={false} />
       <div className="analytics">
         <section className="section">
-          <h1 className="title">Analytics Dashboard v1</h1>
+          <h1 className="title">
+            Analytics Dashboard v1: Newsletters Overview
+          </h1>
         </section>
         {!isSignedIn ? (
           <div id="signin-button"></div>
         ) : (
           <div>
-            <Report />
+            <div className="container">
+              <section className="section">
+                <p className="content">
+                  Data from {startDate.toLocaleDateString()} to{' '}
+                  {endDate.toLocaleDateString()}.
+                </p>
+              </section>
+
+              <NewsletterSignupFormData
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+
+              <MailchimpReport
+                mailchimpKey={props.mailchimpKey}
+                mailchimpServer={props.mailchimpServer}
+                reports={props.reports}
+              />
+            </div>
           </div>
         )}
       </div>

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -5,6 +5,7 @@ import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import PageViews from '../../../components/tinycms/analytics/PageViews';
 import ReadingDepthData from '../../../components/tinycms/analytics/ReadingDepthData';
+import ReadingFrequencyData from '../../../components/tinycms/analytics/ReadingFrequencyData';
 
 export default function PageViewsPage(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -83,7 +84,9 @@ export default function PageViewsPage(props) {
       <AdminNav homePageEditor={false} />
       <div className="analytics">
         <section className="section">
-          <h1 className="title">Analytics Dashboard v1: Page Views</h1>
+          <h1 className="title">
+            Analytics Dashboard v1: Page Views & Reading
+          </h1>
         </section>
         {!isSignedIn ? (
           <div id="signin-button"></div>
@@ -104,6 +107,12 @@ export default function PageViewsPage(props) {
               />
 
               <ReadingDepthData
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+
+              <ReadingFrequencyData
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react';
+import { addDays } from 'date-fns';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import AdminLayout from '../../../components/AdminLayout';
+import AdminNav from '../../../components/nav/AdminNav';
+import PageViews from '../../../components/tinycms/analytics/PageViews';
+import ReadingDepthData from '../../../components/tinycms/analytics/ReadingDepthData';
+
+export default function PageViewsPage(props) {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const [viewID, setViewID] = useState(
+    process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
+  );
+  const [startDate, setStartDate] = useState(addDays(new Date(), -30));
+  const [endDate, setEndDate] = useState(new Date());
+
+  const initAuth = () => {
+    return window.gapi.auth2.init({
+      client_id: props.clientID, //paste your client ID here
+      scope: 'https://www.googleapis.com/auth/analytics.readonly',
+    });
+  };
+
+  const checkSignedIn = () => {
+    return new Promise((resolve, reject) => {
+      initAuth() //calls the previous function
+        .then(() => {
+          const auth = window.gapi.auth2.getAuthInstance(); //returns the GoogleAuth object
+          resolve(auth.isSignedIn.get()); //returns whether the current user is currently signed in
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  };
+
+  const renderButton = () => {
+    window.gapi.signin2.render('signin-button', {
+      scope: 'profile email',
+      width: 240,
+      height: 50,
+      longtitle: true,
+      theme: 'dark',
+      onsuccess: onSuccess,
+      onfailure: onFailure,
+    });
+  };
+
+  const onSuccess = (googleUser) => {
+    console.log('Logged in as: ' + googleUser.getBasicProfile().getName());
+  };
+
+  const onFailure = (error) => {
+    console.error(error);
+  };
+
+  const updateSignin = (signedIn) => {
+    setIsSignedIn(signedIn);
+    if (!signedIn) {
+      renderButton();
+    }
+  };
+
+  const init = () => {
+    //(2)
+    checkSignedIn()
+      .then((signedIn) => {
+        updateSignin(signedIn);
+      })
+      .catch((error) => {
+        console.log('checkSignedIn error: ', error);
+        console.error(error);
+      });
+  };
+
+  useEffect(() => {
+    window.gapi.load('auth2', init); //(1)
+  });
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+      <div className="analytics">
+        <section className="section">
+          <h1 className="title">Analytics Dashboard v1: Page Views</h1>
+        </section>
+        {!isSignedIn ? (
+          <div id="signin-button"></div>
+        ) : (
+          <div>
+            <div className="container">
+              <section className="section">
+                <p className="content">
+                  Data from {startDate.toLocaleDateString()} to{' '}
+                  {endDate.toLocaleDateString()}.
+                </p>
+              </section>
+
+              <PageViews
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+
+              <ReadingDepthData
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}
+export async function getServerSideProps(context) {
+  const clientID = process.env.ANALYTICS_CLIENT_ID;
+  const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+
+  mailchimp.setConfig({
+    apiKey: process.env.MAILCHIMP_API_KEY,
+    server: process.env.MAILCHIMP_SERVER_PREFIX,
+  });
+
+  let fullReports = [];
+  let reportsResponse = await mailchimp.reports.getAllCampaignReports({
+    since_send_time: addDays(new Date(), -30),
+  });
+  let report = reportsResponse.reports[0];
+  let listId = report.list_id;
+  let data = await mailchimp.lists.getListGrowthHistory(listId);
+  report['growth'] = data;
+  fullReports.push(report);
+
+  return {
+    props: {
+      clientID: clientID,
+      clientSecret: clientSecret,
+      mailchimpKey: process.env.MAILCHIMP_API_KEY,
+      mailchimpServer: process.env.MAILCHIMP_SERVER_PREFIX,
+      reports: fullReports,
+    },
+  };
+}

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import { addDays } from 'date-fns';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import AdminLayout from '../../../components/AdminLayout';
+import AdminNav from '../../../components/nav/AdminNav';
+import AverageSessionDuration from '../../../components/tinycms/analytics/AverageSessionDuration';
+import DailySessions from '../../../components/tinycms/analytics/DailySessions';
+import GeoSessions from '../../../components/tinycms/analytics/GeoSessions';
+import ReferralSource from '../../../components/tinycms/analytics/ReferralSource';
+
+export default function SessionsOverview(props) {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  const [viewID, setViewID] = useState(
+    process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
+  );
+  const [startDate, setStartDate] = useState(addDays(new Date(), -30));
+  const [endDate, setEndDate] = useState(new Date());
+
+  const initAuth = () => {
+    return window.gapi.auth2.init({
+      client_id: props.clientID, //paste your client ID here
+      scope: 'https://www.googleapis.com/auth/analytics.readonly',
+    });
+  };
+
+  const checkSignedIn = () => {
+    return new Promise((resolve, reject) => {
+      initAuth() //calls the previous function
+        .then(() => {
+          const auth = window.gapi.auth2.getAuthInstance(); //returns the GoogleAuth object
+          resolve(auth.isSignedIn.get()); //returns whether the current user is currently signed in
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  };
+
+  const renderButton = () => {
+    window.gapi.signin2.render('signin-button', {
+      scope: 'profile email',
+      width: 240,
+      height: 50,
+      longtitle: true,
+      theme: 'dark',
+      onsuccess: onSuccess,
+      onfailure: onFailure,
+    });
+  };
+
+  const onSuccess = (googleUser) => {
+    console.log('Logged in as: ' + googleUser.getBasicProfile().getName());
+  };
+
+  const onFailure = (error) => {
+    console.error(error);
+  };
+
+  const updateSignin = (signedIn) => {
+    setIsSignedIn(signedIn);
+    if (!signedIn) {
+      renderButton();
+    }
+  };
+
+  const init = () => {
+    //(2)
+    checkSignedIn()
+      .then((signedIn) => {
+        updateSignin(signedIn);
+      })
+      .catch((error) => {
+        console.log('checkSignedIn error: ', error);
+        console.error(error);
+      });
+  };
+
+  useEffect(() => {
+    window.gapi.load('auth2', init); //(1)
+  });
+
+  return (
+    <AdminLayout>
+      <AdminNav homePageEditor={false} />
+      <div className="analytics">
+        <section className="section">
+          <h1 className="title">Analytics Dashboard v1: Sessions Overview</h1>
+        </section>
+        {!isSignedIn ? (
+          <div id="signin-button"></div>
+        ) : (
+          <div>
+            <div className="container">
+              <section className="section">
+                <p className="content">
+                  Data from {startDate.toLocaleDateString()} to{' '}
+                  {endDate.toLocaleDateString()}.
+                </p>
+              </section>
+
+              <DailySessions
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+
+              <GeoSessions
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+              <AverageSessionDuration
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+
+              <ReferralSource
+                viewID={viewID}
+                startDate={startDate}
+                endDate={endDate}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}
+export async function getServerSideProps(context) {
+  const clientID = process.env.ANALYTICS_CLIENT_ID;
+  const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+
+  mailchimp.setConfig({
+    apiKey: process.env.MAILCHIMP_API_KEY,
+    server: process.env.MAILCHIMP_SERVER_PREFIX,
+  });
+
+  let fullReports = [];
+  let reportsResponse = await mailchimp.reports.getAllCampaignReports({
+    since_send_time: addDays(new Date(), -30),
+  });
+  let report = reportsResponse.reports[0];
+  let listId = report.list_id;
+  let data = await mailchimp.lists.getListGrowthHistory(listId);
+  report['growth'] = data;
+  fullReports.push(report);
+
+  return {
+    props: {
+      clientID: clientID,
+      clientSecret: clientSecret,
+      mailchimpKey: process.env.MAILCHIMP_API_KEY,
+      mailchimpServer: process.env.MAILCHIMP_SERVER_PREFIX,
+      reports: fullReports,
+    },
+  };
+}


### PR DESCRIPTION
This PR:

* moves all data fetching and html rendering into separate components
* breaks up components into separate pages: sessions, newsletter, pageviews/reading & audience
* by separating the pages, breaks up google analytics API calls and avoids the RESOURCE EXHAUSTED / over quota issues in the other 2 open analytics PRs
* links to these separate reports from the analytics index of the tinycms
* includes the work in PRs #409 and #410 