### PR TITLE
analytics sidebar everywhere

### DIFF
--- a/components/tinycms/analytics/AnalyticsSidebar.js
+++ b/components/tinycms/analytics/AnalyticsSidebar.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const AnalyticsSidebar = (props) => {
+  return (
+    <article className="message">
+      <div className="message-header">
+        <p>{props.title}</p>
+      </div>
+      <div className="message-body">{props.children}</div>
+    </article>
+  );
+};
+
+export default AnalyticsSidebar;

--- a/components/tinycms/analytics/AverageSessionDuration.js
+++ b/components/tinycms/analytics/AverageSessionDuration.js
@@ -51,7 +51,7 @@ const AverageSessionDuration = (props) => {
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="time">
       <div className="content">
         <h2 className="subtitle">Average session duration</h2>
 

--- a/components/tinycms/analytics/AverageSessionDuration.js
+++ b/components/tinycms/analytics/AverageSessionDuration.js
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 import { formatDate } from '../../../lib/utils';
 
 const AverageSessionDuration = (props) => {
+  const timeRef = useRef();
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -46,12 +47,18 @@ const AverageSessionDuration = (props) => {
           labels,
           values,
         });
+
+        if (window.location.hash && window.location.hash === '#time') {
+          if (timeRef) {
+            timeRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section" id="time">
+    <section className="section" id="time" ref={timeRef}>
       <div className="content">
         <h2 className="subtitle">Average session duration</h2>
 

--- a/components/tinycms/analytics/CustomDimensions.js
+++ b/components/tinycms/analytics/CustomDimensions.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const CustomDimensions = (props) => {
+  const subscriptionsRef = useRef();
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -40,12 +41,18 @@ const CustomDimensions = (props) => {
           labels,
           values,
         });
+
+        if (window.location.hash && window.location.hash === '#subscriptions') {
+          if (subscriptionsRef) {
+            subscriptionsRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="subscriptions" ref={subscriptionsRef}>
       <h2 className="subtitle">Sessions by audience segment: {props.label}</h2>
 
       <p className="content">

--- a/components/tinycms/analytics/DailySessions.js
+++ b/components/tinycms/analytics/DailySessions.js
@@ -47,7 +47,7 @@ const DailySessions = (props) => {
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="daily">
       <div className="content">
         <h2 className="subtitle">Sessions per day</h2>
         <p className="content">

--- a/components/tinycms/analytics/DailySessions.js
+++ b/components/tinycms/analytics/DailySessions.js
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 import { formatDate } from '../../../lib/utils';
 
 const DailySessions = (props) => {
+  const dailyRef = useRef();
+
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -42,12 +44,18 @@ const DailySessions = (props) => {
           labels,
           values,
         });
+
+        if (window.location.hash && window.location.hash === '#daily') {
+          if (dailyRef) {
+            dailyRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section" id="daily">
+    <section className="section" id="daily" ref={dailyRef}>
       <div className="content">
         <h2 className="subtitle">Sessions per day</h2>
         <p className="content">

--- a/components/tinycms/analytics/DonateClicks.js
+++ b/components/tinycms/analytics/DonateClicks.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const DonateClicks = (props) => {
+  const donationsRef = useRef();
   const [pageViews, setPageViews] = useState({});
   const [donateTableRows, setDonateTableRows] = useState([]);
   const [donationsFrequencyData, setDonationsFrequencyData] = useState([]);
@@ -127,18 +128,18 @@ const DonateClicks = (props) => {
               );
             });
             setDonateTableRows(donateRows);
+
+            if (window.location.hash && window.location.hash === '#donations') {
+              if (donationsRef) {
+                donationsRef.current.scrollIntoView({ behavior: 'smooth' });
+              }
+            }
           })
           .catch((error) => console.error(error));
       })
       .catch((error) => console.error(error));
 
     let eventMetrics = ['ga:totalEvents'];
-    let eventDimensions = [
-      'ga:eventCategory',
-      'ga:eventAction',
-      'ga:eventLabel',
-      'ga:pagePath',
-    ];
     let donationReadingFrequencyDim = [
       'ga:eventCategory',
       'ga:eventAction',
@@ -161,9 +162,6 @@ const DonateClicks = (props) => {
 
       let donationsByFrequency = {};
       queryResult.forEach((row) => {
-        let category = row.dimensions[0];
-        let action = row.dimensions[1];
-        let label = row.dimensions[2];
         let frequency = row.dimensions[3];
         let count = parseInt(row.metrics[0].values[0]);
 
@@ -188,7 +186,7 @@ const DonateClicks = (props) => {
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="donations" ref={donationsRef}>
       <div className="content">
         <p className="subtitle is-5">Donate Button Clicks</p>
 

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -44,7 +44,7 @@ const GeoSessions = (props) => {
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="geo">
       <div className="content">
         <h2 className="subtitle">Sessions by geographic region</h2>
 

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const GeoSessions = (props) => {
+  const geoRef = useRef();
+
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -39,12 +41,17 @@ const GeoSessions = (props) => {
           labels,
           values,
         });
+        if (window.location.hash && window.location.hash === '#geo') {
+          if (geoRef) {
+            geoRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section" id="geo">
+    <section className="section" id="geo" ref={geoRef}>
       <div className="content">
         <h2 className="subtitle">Sessions by geographic region</h2>
 

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -1,9 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export default function MailchimpReport(props) {
+  const campaignsRef = useRef();
+  useEffect(() => {
+    if (window.location.hash && window.location.hash === '#campaigns') {
+      if (campaignsRef) {
+        campaignsRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [props.reports]);
+
   if (!props.reports) console.error('No report passed for mailchimp');
   return (
-    <div>
+    <div id="campaigns" ref={campaignsRef}>
       {props.reports.map((report) => (
         <section className="section" key={`mailchimp-report-${report.id}`}>
           <h2 className="subtitle">

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const NewsletterSignupFormData = (props) => {
+  const signupRef = useRef();
+
   const [sortedNewsletterRows, setSortedNewsletterRows] = useState([]);
   const [frequencySignups, setFrequencySignups] = useState([]);
 
@@ -111,13 +113,18 @@ const NewsletterSignupFormData = (props) => {
           }
         });
         setSortedNewsletterRows(sortedRows);
+        if (window.location.hash && window.location.hash === '#signups') {
+          if (signupRef) {
+            signupRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
     <>
-      <section className="section">
+      <section className="section" id="signups" ref={signupRef}>
         <h2 className="subtitle">Website Signup Form</h2>
 
         <p className="content">

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const PageViews = (props) => {
+  const pageviewsRef = useRef();
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -54,12 +55,18 @@ const PageViews = (props) => {
           values,
         });
         props.setPageViews(pv);
+
+        if (window.location.hash && window.location.hash === '#pageviews') {
+          if (pageviewsRef) {
+            pageviewsRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="pageviews" ref={pageviewsRef}>
       <h2 className="subtitle">Page views</h2>
       <p className="content">
         {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const ReadingDepthData = (props) => {
+  const depthRef = useRef();
   const [readingDepthTableRows, setReadingDepthTableRows] = useState([]);
 
   useEffect(() => {
@@ -96,12 +97,18 @@ const ReadingDepthData = (props) => {
           }
         });
         setReadingDepthTableRows(readingDepthRows);
+
+        if (window.location.hash && window.location.hash === '#depth') {
+          if (depthRef) {
+            depthRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.pageViews, props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="depth" ref={depthRef}>
       <div className="content">
         <p className="subtitle is-5">Reading Depth</p>
 

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const ReadingFrequencyData = (props) => {
+  const frequencyRef = useRef();
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -33,12 +34,17 @@ const ReadingFrequencyData = (props) => {
           values.push(value);
         });
         setFrequencyData({ ...frequencyData, labels, values });
+        if (window.location.hash && window.location.hash === '#frequency') {
+          if (frequencyRef) {
+            frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="frequency" ref={frequencyRef}>
       <h2 className="subtitle">
         Page views by audience segment: reading frequency
       </h2>

--- a/components/tinycms/analytics/ReferralSource.js
+++ b/components/tinycms/analytics/ReferralSource.js
@@ -46,7 +46,7 @@ const ReferralSource = (props) => {
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section">
+    <section className="section" id="referral">
       <div className="content">
         <h2 className="subtitle">Sessions by referral source</h2>
 

--- a/components/tinycms/analytics/ReferralSource.js
+++ b/components/tinycms/analytics/ReferralSource.js
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { getMetricsData } from '../../../lib/analytics';
 
 const ReferralSource = (props) => {
+  const referralRef = useRef();
+
   const INITIAL_STATE = {
     labels: [],
     values: [],
@@ -41,12 +43,18 @@ const ReferralSource = (props) => {
           labels,
           values,
         });
+
+        if (window.location.hash && window.location.hash === '#referral') {
+          if (referralRef) {
+            referralRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
       })
       .catch((error) => console.error(error));
   }, [props.startDate, props.endDate]);
 
   return (
-    <section className="section" id="referral">
+    <section className="section" id="referral" ref={referralRef}>
       <div className="content">
         <h2 className="subtitle">Sessions by referral source</h2>
 

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -8,6 +8,7 @@ import CustomDimensions from '../../../components/tinycms/analytics/CustomDimens
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
 import DonateClicks from '../../../components/tinycms/analytics/DonateClicks';
+import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function Audience(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -97,14 +98,24 @@ export default function Audience(props) {
           <div>
             <div className="container">
               <section className="section">
-                <h1 className="title">Audience Overview</h1>
-                <DateRangePickerWrapper
-                  startDate={startDate}
-                  endDate={endDate}
-                  setDates={setDates}
-                  focusedInput={focusedInput}
-                  setFocusedInput={setFocusedInput}
-                />
+                <div className="columns">
+                  <div className="column">
+                    <h1 className="title">Audience Overview</h1>
+                    <DateRangePickerWrapper
+                      startDate={startDate}
+                      endDate={endDate}
+                      setDates={setDates}
+                      focusedInput={focusedInput}
+                      setFocusedInput={setFocusedInput}
+                    />
+                  </div>
+
+                  <div className="column">
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+                  </div>
+                </div>
               </section>
 
               <DonateClicks

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
@@ -109,10 +110,26 @@ export default function AnalyticsIndex(props) {
                     <li>
                       <a href="/tinycms/analytics/sessions">Sessions</a>
                       <ul>
-                        <li>Daily</li>
-                        <li>Regional</li>
-                        <li>Referral Sources</li>
-                        <li>Time Spent</li>
+                        <li>
+                          <Link href="/tinycms/analytics/sessions#daily">
+                            <a>Daily</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/sessions#geo">
+                            <a>Regional</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/sessions#referral">
+                            <a>Referral Sources</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/sessions#time">
+                            <a>Time Spent</a>
+                          </Link>
+                        </li>
                       </ul>
                     </li>
                   </ul>

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -120,7 +120,7 @@ export default function AnalyticsIndex(props) {
               </div>
 
               <div className="column">
-                <AnalyticsSidebar headline="About this Data">
+                <AnalyticsSidebar title="About this Data">
                   <p className="content">
                     tinycms analytics data is meant to reveal insights about how
                     your audience is - or is not - interacting with your

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
+import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function AnalyticsIndex(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -119,51 +120,43 @@ export default function AnalyticsIndex(props) {
               </div>
 
               <div className="column">
-                <article className="message">
-                  <div className="message-header">
-                    <p>About this Data</p>
-                    <button className="delete" aria-label="delete"></button>
-                  </div>
-                  <div className="message-body">
-                    <p className="content">
-                      tinycms analytics data is meant to reveal insights about
-                      how your audience is - or is not - interacting with your
-                      published content.
-                    </p>
-                    <p className="content">
-                      Information related to donate button clicks, page views,
-                      reading behavior and sessions come from Google Analytics.
-                      This site is configured for GA as follows:
-                      <ul>
-                        <li>
-                          <b>Tracking ID:</b>{' '}
-                          {process.env.NEXT_PUBLIC_GA_TRACKING_ID}
-                        </li>
-                        <li>
-                          <b>View ID:</b>{' '}
-                          {process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID}
-                        </li>
-                      </ul>
-                    </p>
-                    <p className="content">
-                      Information on newsletter subscriptions come from
-                      Mailchimp. This site is configured for Mailchimp with a
-                      subscribe URL of:{' '}
-                      <pre>
-                        {process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL}
-                      </pre>
-                    </p>
-                    <p className="content">
-                      For a deeper dive on understanding your audience and
-                      measuring the impact of your reporting, News Catalyst
-                      recommends checking out{' '}
-                      <a href="https://source.opennews.org/articles/memberkit-upgrade-your-analytics/">
-                        MemberKit
-                      </a>
-                      .
-                    </p>
-                  </div>
-                </article>
+                <AnalyticsSidebar headline="About this Data">
+                  <p className="content">
+                    tinycms analytics data is meant to reveal insights about how
+                    your audience is - or is not - interacting with your
+                    published content.
+                  </p>
+                  <p className="content">
+                    Information related to donate button clicks, page views,
+                    reading behavior and sessions come from Google Analytics.
+                    This site is configured for GA as follows:
+                    <ul>
+                      <li>
+                        <b>Tracking ID:</b>{' '}
+                        {process.env.NEXT_PUBLIC_GA_TRACKING_ID}
+                      </li>
+                      <li>
+                        <b>View ID:</b>{' '}
+                        {process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID}
+                      </li>
+                    </ul>
+                  </p>
+                  <p className="content">
+                    Information on newsletter subscriptions come from Mailchimp.
+                    This site is configured for Mailchimp with a subscribe URL
+                    of:{' '}
+                    <pre>{process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL}</pre>
+                  </p>
+                  <p className="content">
+                    For a deeper dive on understanding your audience and
+                    measuring the impact of your reporting, News Catalyst
+                    recommends checking out{' '}
+                    <a href="https://source.opennews.org/articles/memberkit-upgrade-your-analytics/">
+                      MemberKit
+                    </a>
+                    .
+                  </p>
+                </AnalyticsSidebar>
               </div>
             </div>
           </section>

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -118,9 +118,21 @@ export default function AnalyticsIndex(props) {
                     <li>
                       <a href="/tinycms/analytics/pageviews">Page Views</a>
                       <ul>
-                        <li>Page Views</li>
-                        <li>Reading Depth</li>
-                        <li>Reading Frequency</li>
+                        <li>
+                          <Link href="/tinycms/analytics/pageviews#pageviews">
+                            <a>Page Views</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/pageviews#depth">
+                            <a>Reading Depth</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/pageviews#frequency">
+                            <a>Reading Frequency</a>
+                          </Link>
+                        </li>
                       </ul>
                     </li>
                     <li>

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -173,24 +173,32 @@ export default function AnalyticsIndex(props) {
                   </p>
                   <p className="content">
                     Information related to donate button clicks, page views,
-                    reading behavior and sessions come from Google Analytics.
-                    This site is configured for GA as follows:
-                    <ul>
-                      <li>
-                        <b>Tracking ID:</b>{' '}
-                        {process.env.NEXT_PUBLIC_GA_TRACKING_ID}
-                      </li>
-                      <li>
-                        <b>View ID:</b>{' '}
-                        {process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID}
-                      </li>
-                    </ul>
+                    reading behavior and sessions come from{' '}
+                    <a href="https://analytics.google.com/">Google Analytics</a>
+                    . This site is configured for GA as follows:
+                  </p>
+
+                  <ul className="content">
+                    <li>
+                      <b>Tracking ID:</b>{' '}
+                      <code>{process.env.NEXT_PUBLIC_GA_TRACKING_ID}</code>
+                    </li>
+                    <li>
+                      <b>View ID:</b>{' '}
+                      <code>{process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID}</code>
+                    </li>
+                  </ul>
+
+                  <p className="content">
+                    Information on newsletter subscriptions come from{' '}
+                    <a href="https://mailchimp.com/">Mailchimp</a>. This site is
+                    configured for Mailchimp with a <b>subscribe URL</b>
+                    of:
                   </p>
                   <p className="content">
-                    Information on newsletter subscriptions come from Mailchimp.
-                    This site is configured for Mailchimp with a subscribe URL
-                    of:{' '}
-                    <pre>{process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL}</pre>
+                    <code>
+                      {process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL}
+                    </code>
                   </p>
                   <p className="content">
                     For a deeper dive on understanding your audience and

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -88,15 +88,31 @@ export default function AnalyticsIndex(props) {
                     <li>
                       <a href="/tinycms/analytics/audience">Audience</a>
                       <ul>
-                        <li>Donations</li>
-                        <li>Subscriptions</li>
+                        <li>
+                          <Link href="/tinycms/analytics/audience#donations">
+                            <a>Donations</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/audience#subscriptions">
+                            <a>Subscriptions</a>
+                          </Link>
+                        </li>
                       </ul>
                     </li>
                     <li>
                       <a href="/tinycms/analytics/newsletter">Newsletters</a>
                       <ul>
-                        <li>Signup Stats</li>
-                        <li>Mailchimp Campaigns</li>
+                        <li>
+                          <Link href="/tinycms/analytics/newsletter#signups">
+                            <a>Signup Stats</a>
+                          </Link>
+                        </li>
+                        <li>
+                          <Link href="/tinycms/analytics/newsletter#campaigns">
+                            <a>Mailchimp Campaigns</a>
+                          </Link>
+                        </li>
                       </ul>
                     </li>
                     <li>

--- a/pages/tinycms/analytics/newsletter.js
+++ b/pages/tinycms/analytics/newsletter.js
@@ -8,6 +8,7 @@ import MailchimpReport from '../../../components/tinycms/analytics/MailchimpRepo
 import moment from 'moment';
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
+import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function NewsletterOverview(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -97,14 +98,24 @@ export default function NewsletterOverview(props) {
           <div>
             <div className="container">
               <section className="section">
-                <h1 className="title">Newsletter Overview</h1>
-                <DateRangePickerWrapper
-                  startDate={startDate}
-                  endDate={endDate}
-                  setDates={setDates}
-                  focusedInput={focusedInput}
-                  setFocusedInput={setFocusedInput}
-                />
+                <div className="columns">
+                  <div className="column">
+                    <h1 className="title">Newsletter Overview</h1>
+                    <DateRangePickerWrapper
+                      startDate={startDate}
+                      endDate={endDate}
+                      setDates={setDates}
+                      focusedInput={focusedInput}
+                      setFocusedInput={setFocusedInput}
+                    />
+                  </div>
+
+                  <div className="column">
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+                  </div>
+                </div>
               </section>
 
               <NewsletterSignupFormData

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -7,6 +7,7 @@ import ReadingFrequencyData from '../../../components/tinycms/analytics/ReadingF
 import moment from 'moment';
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
+import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function PageViewsPage(props) {
   const [pageViews, setPageViews] = useState({});
@@ -97,14 +98,24 @@ export default function PageViewsPage(props) {
           <div>
             <div className="container">
               <section className="section">
-                <h1 className="title">Page Views</h1>
-                <DateRangePickerWrapper
-                  startDate={startDate}
-                  endDate={endDate}
-                  setDates={setDates}
-                  focusedInput={focusedInput}
-                  setFocusedInput={setFocusedInput}
-                />
+                <div className="columns">
+                  <div className="column">
+                    <h1 className="title">Page Views</h1>
+                    <DateRangePickerWrapper
+                      startDate={startDate}
+                      endDate={endDate}
+                      setDates={setDates}
+                      focusedInput={focusedInput}
+                      setFocusedInput={setFocusedInput}
+                    />
+                  </div>
+
+                  <div className="column">
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+                  </div>
+                </div>
               </section>
 
               <PageViews

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -8,6 +8,7 @@ import AverageSessionDuration from '../../../components/tinycms/analytics/Averag
 import DailySessions from '../../../components/tinycms/analytics/DailySessions';
 import GeoSessions from '../../../components/tinycms/analytics/GeoSessions';
 import ReferralSource from '../../../components/tinycms/analytics/ReferralSource';
+import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function SessionsOverview(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -97,14 +98,24 @@ export default function SessionsOverview(props) {
           <div>
             <div className="container">
               <section className="section">
-                <h1 className="title">Sessions Overview</h1>
-                <DateRangePickerWrapper
-                  startDate={startDate}
-                  endDate={endDate}
-                  setDates={setDates}
-                  focusedInput={focusedInput}
-                  setFocusedInput={setFocusedInput}
-                />
+                <div className="columns">
+                  <div className="column">
+                    <h1 className="title">Sessions Overview</h1>
+                    <DateRangePickerWrapper
+                      startDate={startDate}
+                      endDate={endDate}
+                      setDates={setDates}
+                      focusedInput={focusedInput}
+                      setFocusedInput={setFocusedInput}
+                    />
+                  </div>
+
+                  <div className="column">
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+                  </div>
+                </div>
               </section>
 
               <DailySessions


### PR DESCRIPTION
Closes #432
Fixes #433 

This adds the sidebar, which is now a reusable component, to all the analytics pages. Note: it does that but each page's sidebar content is currently set to `tk` :) I haven't thought through what each page should say.

This PR also adds links to subsections of each page to the analytics homepage via scroll-into-view.

And finally, I fixed the little html issues in the homepage sidebar content (#433).