### PR TITLE
Flexible article end card

### DIFF
--- a/components/articles/ArticleBody.js
+++ b/components/articles/ArticleBody.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useScrollPercentage } from 'react-scroll-percentage';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
 import { renderBody } from '../../lib/utils.js';
+import DonationBlock from '../plugins/DonationBlock';
 import NewsletterBlock from '../plugins/NewsletterBlock';
 
 export default function ArticleBody({ article, ads, isAmp, metadata }) {
@@ -9,6 +10,9 @@ export default function ArticleBody({ article, ads, isAmp, metadata }) {
 
   const { trackEvent } = useAnalytics();
 
+  const [randomBlockNumber, setRandomBlockNumber] = useState(
+    Math.floor(Math.random() * 2)
+  );
   const [ref, percentage] = useScrollPercentage();
   const [oneQuarterReached, setOneQuarterReached] = useState(false);
   const [oneHalfReached, setOneHalfReached] = useState(false);
@@ -67,11 +71,16 @@ export default function ArticleBody({ article, ads, isAmp, metadata }) {
         <div className="post-text">
           <div>{body}</div>
         </div>
-        <NewsletterBlock
-          metadata={metadata}
-          headline={article.headline}
-          wrap={false}
-        />
+        {randomBlockNumber === 0 && (
+          <NewsletterBlock
+            metadata={metadata}
+            headline={article.headline}
+            wrap={false}
+          />
+        )}
+        {randomBlockNumber === 1 && (
+          <DonationBlock metadata={metadata} wrap={false} />
+        )}
       </div>
     </section>
   );

--- a/components/nav/Donate.js
+++ b/components/nav/Donate.js
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
 
-const Donate = ({ label, url }) => {
+const Donate = ({ label, style, url }) => {
   const { trackEvent } = useAnalytics();
 
   const trackClick = () => {
@@ -15,7 +15,7 @@ const Donate = ({ label, url }) => {
   };
   return (
     <Link href={url}>
-      <a className="site__cta button" onClick={trackClick}>
+      <a style={style} className="site__cta button donate" onClick={trackClick}>
         {label}
       </a>
     </Link>

--- a/components/plugins/DonationBlock.js
+++ b/components/plugins/DonationBlock.js
@@ -6,7 +6,11 @@ export default function DonationBlock({ metadata, wrap = true }) {
       <h4>{metadata.donateBlockHed}</h4>
       <p>{metadata.donateBlockDek}</p>
       <br />
-      <Donate label={metadata.supportCTA} url={metadata.supportURL} />
+      <Donate
+        style={{ backgroundColor: '#fff', color: '#000' }}
+        label={metadata.supportCTA}
+        url={metadata.supportURL}
+      />
     </div>
   );
 

--- a/components/plugins/DonationBlock.js
+++ b/components/plugins/DonationBlock.js
@@ -1,0 +1,14 @@
+import Donate from '../nav/Donate';
+
+export default function DonationBlock({ metadata, wrap = true }) {
+  const block = (
+    <div className={`newsletter ${!wrap && 'block'}`}>
+      <h4>{metadata.donateBlockHed}</h4>
+      <p>{metadata.donateBlockDek}</p>
+      <br />
+      <Donate label={metadata.supportCTA} url={metadata.supportURL} />
+    </div>
+  );
+
+  return wrap ? <div className="block">{block}</div> : block;
+}

--- a/components/tinycms/UpdateSiteMetadata.js
+++ b/components/tinycms/UpdateSiteMetadata.js
@@ -275,6 +275,20 @@ export default function UpdateMetadata(props) {
         value={parsedData['description404']}
       />
 
+      <MetadataTextInput
+        label="Donation Block: Headline"
+        name="donateBlockHed"
+        handleChange={handleChange}
+        value={parsedData['donateBlockHed']}
+      />
+
+      <MetadataTextInput
+        label="Donation Block: Deck"
+        name="donateBlockDek"
+        handleChange={handleChange}
+        value={parsedData['donateBlockDek']}
+      />
+
       {!editData && (
         <div className="field">
           <a href="#" className="button" onClick={() => setEditData(true)}>

--- a/components/tinycms/analytics/AnalyticsNav.js
+++ b/components/tinycms/analytics/AnalyticsNav.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import Link from 'next/link';
+
+const AnalyticsNav = (props) => {
+  return (
+    <aside className="menu">
+      <p className="menu-label">Sections:</p>
+      <ul className="menu-list">
+        <li>
+          <a href="/tinycms/analytics/audience">Audience</a>
+          <ul>
+            <li>
+              <Link href="/tinycms/analytics/audience#donations">
+                <a>Donations</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/audience#subscriptions">
+                <a>Subscriptions</a>
+              </Link>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a href="/tinycms/analytics/newsletter">Newsletters</a>
+          <ul>
+            <li>
+              <Link href="/tinycms/analytics/newsletter#signups">
+                <a>Signup Stats</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/newsletter#campaigns">
+                <a>Mailchimp Campaigns</a>
+              </Link>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a href="/tinycms/analytics/pageviews">Page Views</a>
+          <ul>
+            <li>
+              <Link href="/tinycms/analytics/pageviews#pageviews">
+                <a>Page Views</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/pageviews#depth">
+                <a>Reading Depth</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/pageviews#frequency">
+                <a>Reading Frequency</a>
+              </Link>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a href="/tinycms/analytics/sessions">Sessions</a>
+          <ul>
+            <li>
+              <Link href="/tinycms/analytics/sessions#daily">
+                <a>Daily</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/sessions#geo">
+                <a>Regional</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/sessions#referral">
+                <a>Referral Sources</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="/tinycms/analytics/sessions#time">
+                <a>Time Spent</a>
+              </Link>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </aside>
+  );
+};
+
+export default AnalyticsNav;

--- a/components/tinycms/analytics/CustomDimensions.js
+++ b/components/tinycms/analytics/CustomDimensions.js
@@ -53,7 +53,9 @@ const CustomDimensions = (props) => {
 
   return (
     <section className="section" id="subscriptions" ref={subscriptionsRef}>
-      <h2 className="subtitle">Sessions by audience segment: {props.label}</h2>
+      <h2 className="title is-4">
+        Sessions by audience segment: {props.label}
+      </h2>
 
       <p className="content">
         {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}

--- a/components/tinycms/analytics/DonateClicks.js
+++ b/components/tinycms/analytics/DonateClicks.js
@@ -188,7 +188,7 @@ const DonateClicks = (props) => {
   return (
     <section className="section" id="donations" ref={donationsRef}>
       <div className="content">
-        <p className="subtitle is-5">Donate Button Clicks</p>
+        <p className="title is-4">Donate Button Clicks</p>
 
         <p className="content">
           {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -15,7 +15,7 @@ export default function MailchimpReport(props) {
     <div id="campaigns" ref={campaignsRef}>
       {props.reports.map((report) => (
         <section className="section" key={`mailchimp-report-${report.id}`}>
-          <h2 className="subtitle">
+          <h2 className="title is-4">
             Newsletter Campaign: {report.campaign_title}
           </h2>
 

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -125,7 +125,7 @@ const NewsletterSignupFormData = (props) => {
   return (
     <>
       <section className="section" id="signups" ref={signupRef}>
-        <h2 className="subtitle">Website Signup Form</h2>
+        <h2 className="title is-4">Website Signup Form</h2>
 
         <p className="content">
           {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
@@ -146,7 +146,7 @@ const NewsletterSignupFormData = (props) => {
       </section>
 
       <section className="section">
-        <h2 className="subtitle">Signups by Reading Frequency</h2>
+        <h2 className="title is-4">Signups by Reading Frequency</h2>
 
         <p className="content">
           {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -67,7 +67,7 @@ const PageViews = (props) => {
 
   return (
     <section className="section" id="pageviews" ref={pageviewsRef}>
-      <h2 className="subtitle">Page views</h2>
+      <h2 className="title is-4">Page views</h2>
       <p className="content">
         {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
         {props.endDate.format('dddd, MMMM Do YYYY')}

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -110,7 +110,7 @@ const ReadingDepthData = (props) => {
   return (
     <section className="section" id="depth" ref={depthRef}>
       <div className="content">
-        <p className="subtitle is-5">Reading Depth</p>
+        <p className="title is-4">Reading Depth</p>
 
         <p className="content">
           {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -45,7 +45,7 @@ const ReadingFrequencyData = (props) => {
 
   return (
     <section className="section" id="frequency" ref={frequencyRef}>
-      <h2 className="subtitle">
+      <h2 className="title is-4">
         Page views by audience segment: reading frequency
       </h2>
 

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -8,6 +8,7 @@ import CustomDimensions from '../../../components/tinycms/analytics/CustomDimens
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
 import DonateClicks from '../../../components/tinycms/analytics/DonateClicks';
+import AnalyticsNav from '../../../components/tinycms/analytics/AnalyticsNav';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function Audience(props) {
@@ -91,6 +92,7 @@ export default function Audience(props) {
   return (
     <AdminLayout>
       <AdminNav homePageEditor={false} />
+
       <div className="analytics">
         {!isSignedIn ? (
           <div id="signin-button"></div>
@@ -99,8 +101,30 @@ export default function Audience(props) {
             <div className="container">
               <section className="section">
                 <div className="columns">
-                  <div className="column">
+                  <div className="column is-one-quarter">
+                    <AnalyticsNav />
+                  </div>
+
+                  <div className="column is-three-quarters">
                     <h1 className="title">Audience Overview</h1>
+
+                    <AnalyticsSidebar title="About this Data">
+                      <p className="content">
+                        Donate button clicks are measured using Google Analytics
+                        event tracking.
+                      </p>
+                      <p className="content">
+                        Reading frequency is tracked through a custom dimension
+                        in Google Analytics, and compared against donation
+                        activity via the article path.
+                      </p>
+                      <p className="content">
+                        Sessions by audience segment are all measured using
+                        Google Analytics custom dimensions and are currently
+                        TBD.
+                      </p>
+                    </AnalyticsSidebar>
+
                     <DateRangePickerWrapper
                       startDate={startDate}
                       endDate={endDate}
@@ -108,39 +132,33 @@ export default function Audience(props) {
                       focusedInput={focusedInput}
                       setFocusedInput={setFocusedInput}
                     />
-                  </div>
 
-                  <div className="column">
-                    <AnalyticsSidebar title="About this Data">
-                      <p>tk</p>
-                    </AnalyticsSidebar>
+                    <DonateClicks
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
+
+                    <CustomDimensions
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                      metrics={['ga:sessions']}
+                      dimensions={['ga:dimension4']}
+                      label="Donor"
+                    />
+
+                    <CustomDimensions
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                      metrics={['ga:sessions']}
+                      dimensions={['ga:dimension5']}
+                      label="Subscriber"
+                    />
                   </div>
                 </div>
               </section>
-
-              <DonateClicks
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
-
-              <CustomDimensions
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-                metrics={['ga:sessions']}
-                dimensions={['ga:dimension4']}
-                label="Donor"
-              />
-
-              <CustomDimensions
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-                metrics={['ga:sessions']}
-                dimensions={['ga:dimension5']}
-                label="Subscriber"
-              />
             </div>
           </div>
         )}

--- a/pages/tinycms/analytics/index.js
+++ b/pages/tinycms/analytics/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
+import AnalyticsNav from '../../../components/tinycms/analytics/AnalyticsNav';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function AnalyticsIndex(props) {
@@ -82,86 +82,7 @@ export default function AnalyticsIndex(props) {
 
             <div className="columns">
               <div className="column">
-                <aside className="menu">
-                  <p className="menu-label">Sections:</p>
-                  <ul className="menu-list">
-                    <li>
-                      <a href="/tinycms/analytics/audience">Audience</a>
-                      <ul>
-                        <li>
-                          <Link href="/tinycms/analytics/audience#donations">
-                            <a>Donations</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/audience#subscriptions">
-                            <a>Subscriptions</a>
-                          </Link>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <a href="/tinycms/analytics/newsletter">Newsletters</a>
-                      <ul>
-                        <li>
-                          <Link href="/tinycms/analytics/newsletter#signups">
-                            <a>Signup Stats</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/newsletter#campaigns">
-                            <a>Mailchimp Campaigns</a>
-                          </Link>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <a href="/tinycms/analytics/pageviews">Page Views</a>
-                      <ul>
-                        <li>
-                          <Link href="/tinycms/analytics/pageviews#pageviews">
-                            <a>Page Views</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/pageviews#depth">
-                            <a>Reading Depth</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/pageviews#frequency">
-                            <a>Reading Frequency</a>
-                          </Link>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <a href="/tinycms/analytics/sessions">Sessions</a>
-                      <ul>
-                        <li>
-                          <Link href="/tinycms/analytics/sessions#daily">
-                            <a>Daily</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/sessions#geo">
-                            <a>Regional</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/sessions#referral">
-                            <a>Referral Sources</a>
-                          </Link>
-                        </li>
-                        <li>
-                          <Link href="/tinycms/analytics/sessions#time">
-                            <a>Time Spent</a>
-                          </Link>
-                        </li>
-                      </ul>
-                    </li>
-                  </ul>
-                </aside>
+                <AnalyticsNav />
               </div>
 
               <div className="column">

--- a/pages/tinycms/analytics/newsletter.js
+++ b/pages/tinycms/analytics/newsletter.js
@@ -8,6 +8,7 @@ import MailchimpReport from '../../../components/tinycms/analytics/MailchimpRepo
 import moment from 'moment';
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
+import AnalyticsNav from '../../../components/tinycms/analytics/AnalyticsNav';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
 
 export default function NewsletterOverview(props) {
@@ -99,8 +100,16 @@ export default function NewsletterOverview(props) {
             <div className="container">
               <section className="section">
                 <div className="columns">
-                  <div className="column">
+                  <div className="column is-one-quarter">
+                    <AnalyticsNav />
+                  </div>
+
+                  <div className="column is-three-quarters">
                     <h1 className="title">Newsletter Overview</h1>
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+
                     <DateRangePickerWrapper
                       startDate={startDate}
                       endDate={endDate}
@@ -108,27 +117,21 @@ export default function NewsletterOverview(props) {
                       focusedInput={focusedInput}
                       setFocusedInput={setFocusedInput}
                     />
-                  </div>
 
-                  <div className="column">
-                    <AnalyticsSidebar title="About this Data">
-                      <p>tk</p>
-                    </AnalyticsSidebar>
+                    <NewsletterSignupFormData
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
+
+                    <MailchimpReport
+                      mailchimpKey={props.mailchimpKey}
+                      mailchimpServer={props.mailchimpServer}
+                      reports={props.reports}
+                    />
                   </div>
                 </div>
               </section>
-
-              <NewsletterSignupFormData
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
-
-              <MailchimpReport
-                mailchimpKey={props.mailchimpKey}
-                mailchimpServer={props.mailchimpServer}
-                reports={props.reports}
-              />
             </div>
           </div>
         )}

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import DateRangePickerWrapper from '../../../components/tinycms/analytics/DateRangePickerWrapper';
 import datePickerStyles from '../../../styles/datepicker.js';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
+import AnalyticsNav from '../../../components/tinycms/analytics/AnalyticsNav';
 
 export default function PageViewsPage(props) {
   const [pageViews, setPageViews] = useState({});
@@ -99,45 +100,50 @@ export default function PageViewsPage(props) {
             <div className="container">
               <section className="section">
                 <div className="columns">
-                  <div className="column">
-                    <h1 className="title">Page Views</h1>
-                    <DateRangePickerWrapper
-                      startDate={startDate}
-                      endDate={endDate}
-                      setDates={setDates}
-                      focusedInput={focusedInput}
-                      setFocusedInput={setFocusedInput}
-                    />
-                  </div>
+                  <div className="columns">
+                    <div className="column is-one-quarter">
+                      <AnalyticsNav />
+                    </div>
 
-                  <div className="column">
-                    <AnalyticsSidebar title="About this Data">
-                      <p>tk</p>
-                    </AnalyticsSidebar>
+                    <div className="column is-three-quarters">
+                      <h1 className="title">Page Views</h1>
+
+                      <AnalyticsSidebar title="About this Data">
+                        <p>tk</p>
+                      </AnalyticsSidebar>
+
+                      <DateRangePickerWrapper
+                        startDate={startDate}
+                        endDate={endDate}
+                        setDates={setDates}
+                        focusedInput={focusedInput}
+                        setFocusedInput={setFocusedInput}
+                      />
+
+                      <PageViews
+                        viewID={viewID}
+                        startDate={startDate}
+                        endDate={endDate}
+                        setPageViews={setPageViews}
+                        pageViews={pageViews}
+                      />
+
+                      <ReadingDepthData
+                        viewID={viewID}
+                        startDate={startDate}
+                        endDate={endDate}
+                        pageViews={pageViews}
+                      />
+
+                      <ReadingFrequencyData
+                        viewID={viewID}
+                        startDate={startDate}
+                        endDate={endDate}
+                      />
+                    </div>
                   </div>
                 </div>
               </section>
-
-              <PageViews
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-                setPageViews={setPageViews}
-                pageViews={pageViews}
-              />
-
-              <ReadingDepthData
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-                pageViews={pageViews}
-              />
-
-              <ReadingFrequencyData
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
             </div>
           </div>
         )}

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -9,6 +9,7 @@ import DailySessions from '../../../components/tinycms/analytics/DailySessions';
 import GeoSessions from '../../../components/tinycms/analytics/GeoSessions';
 import ReferralSource from '../../../components/tinycms/analytics/ReferralSource';
 import AnalyticsSidebar from '../../../components/tinycms/analytics/AnalyticsSidebar';
+import AnalyticsNav from '../../../components/tinycms/analytics/AnalyticsNav';
 
 export default function SessionsOverview(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
@@ -99,8 +100,17 @@ export default function SessionsOverview(props) {
             <div className="container">
               <section className="section">
                 <div className="columns">
-                  <div className="column">
+                  <div className="column is-one-quarter">
+                    <AnalyticsNav />
+                  </div>
+
+                  <div className="column is-three-quarters">
                     <h1 className="title">Sessions Overview</h1>
+
+                    <AnalyticsSidebar title="About this Data">
+                      <p>tk</p>
+                    </AnalyticsSidebar>
+
                     <DateRangePickerWrapper
                       startDate={startDate}
                       endDate={endDate}
@@ -108,39 +118,33 @@ export default function SessionsOverview(props) {
                       focusedInput={focusedInput}
                       setFocusedInput={setFocusedInput}
                     />
-                  </div>
 
-                  <div className="column">
-                    <AnalyticsSidebar title="About this Data">
-                      <p>tk</p>
-                    </AnalyticsSidebar>
+                    <DailySessions
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
+
+                    <GeoSessions
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
+
+                    <AverageSessionDuration
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
+
+                    <ReferralSource
+                      viewID={viewID}
+                      startDate={startDate}
+                      endDate={endDate}
+                    />
                   </div>
                 </div>
               </section>
-
-              <DailySessions
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
-
-              <GeoSessions
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
-
-              <AverageSessionDuration
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
-
-              <ReferralSource
-                viewID={viewID}
-                startDate={startDate}
-                endDate={endDate}
-              />
             </div>
           </div>
         )}

--- a/styles/global.js
+++ b/styles/global.js
@@ -1960,6 +1960,11 @@ export default css.global`
     color: #fff;
   }
 
+  .colorone .donation .button,
+    background-color: #fff;
+    color: #000;
+  }
+
   .colorone .ad-wrapper .button {
     font-weight: 700;
   }


### PR DESCRIPTION
Closes #428 

This adds a new donate block (based on the existing newsletter block) and currently uses a randomizer to display either the block at the bottom of articles. I'm reusing the "Donate" button from the global nav and passing in a style for now to make the button visible; I wasn't sure how we wanted this donation block to look style-wise.