### PR TITLE
Render pages by current or previous slug

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -569,6 +569,50 @@ const HASURA_GET_LAYOUT = `query MyQuery($locale_code: String!) {
   }
 }`;
 
+const HASURA_GET_PAGE_SLUG_VERSION = `query MyQuery($slug: String!, $locale_code: String = "") {
+  page_slug_versions(where: {slug: {_eq: $slug}, page: {page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}}) {
+    slug
+    page {
+      id
+      author_pages {
+        author {
+          id
+          name
+          slug
+          author_translations(where: {locale_code: {_eq: $locale_code}}) {
+            title
+          }
+        }
+      }
+      page_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        content
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        last_published_at
+        published
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
+      slug
+    }
+  }
+  categories(where: {published: {_eq: true}, category_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations {
+      data
+    }
+  }
+}`;
+
 const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
   pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
     id
@@ -908,7 +952,7 @@ export function hasuraGetPage(params) {
   return fetchGraphQL({
     url: params['url'],
     orgSlug: params['orgSlug'],
-    query: HASURA_GET_PAGE,
+    query: HASURA_GET_PAGE_SLUG_VERSION,
     name: 'MyQuery',
     variables: {
       slug: params['slug'],

--- a/pages/about.js
+++ b/pages/about.js
@@ -77,9 +77,13 @@ export async function getStaticProps({ locale }) {
     };
     // throw errors;
   } else {
-    console.log(data);
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
-    page = data.pages[0];
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -10,7 +10,6 @@ export default function StaticPage({ page, sections, siteMetadata }) {
   const router = useRouter();
   const isAmp = useAmp();
 
-  console.log('static page');
   if (router.isFallback) {
     return <div>Loading...</div>;
   }
@@ -97,13 +96,12 @@ export async function getStaticProps({ locale, params }) {
       notFound: true,
     };
   } else {
-    if (!data.pages || !data.pages[0]) {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
       return {
         notFound: true,
       };
     }
-    page = data.pages[0];
-    console.log('page: ', page);
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -64,20 +64,19 @@ export async function getServerSideProps(context) {
     slug: 'thank-you',
     localeCode: context.locale,
   });
-  if (
-    errors ||
-    !data ||
-    !data.pages ||
-    data.pages.length <= 0 ||
-    !data.pages[0]
-  ) {
+  if (errors || !data) {
     return {
       notFound: true,
     };
     // throw errors;
   } else {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
-    page = data.pages[0];
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(


### PR DESCRIPTION
This PR updates how data for static pages is retrieved, using the new `page_slug_versions` table. I've populated that table via sql data migration with the existing page slugs & ids, then added a couple more for testing purposes.

The query for `hasuraGetPage` now goes through the new table to find the localised page content.

To test:

* load http://localhost:3000/static/donate
* then try http://localhost:3000/static/donate-2

Those should be the same page. 

Next I'm going to do this for articles, then once we're happy with this as a working option for displaying content by old/current slug identifiers, I'll update the sidebar to store the slug + page or article id combo on each save in the google doc.