### PR TITLE
Render articles with current or previous slug

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -345,6 +345,74 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query MyQuery($slug: String!, $category_slu
   }
 }`;
 
+const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query MyQuery($category_slug: String!, $locale_code: String!, $slug: String!) {
+  article_slug_versions(where: {slug: {_eq: $slug}, article: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}}) {
+    article {
+      article_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        id
+        content
+        custom_byline
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        last_published_at
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
+      category {
+        slug
+        id
+        category_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+      slug
+      author_articles {
+        author {
+          name
+          photoUrl
+          twitter
+          slug
+          author_translations(where: {locale_code: {_eq: $locale_code}}) {
+            title
+          }
+        }
+      }
+      tag_articles(where: {tag: {published: {_eq: true}, tag_translations: {locale_code: {_eq: $locale_code}}}}) {
+        tag {
+          tag_translations {
+            title
+          }
+          slug
+        }
+      }
+    }
+  }
+  categories(where: {published: {_eq: true}}) {
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      locale_code
+    }
+    slug
+  }
+  tags(where: {published: {_eq: true}}) {
+    id
+    slug
+    tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+}`;
+
 const HASURA_ARTICLE_PAGE = `query MyQuery($category_slug: String!, $locale_code: String!, $slug: String!) {
   articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}, slug: {_eq: $slug}}) {
     article_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
@@ -1131,7 +1199,7 @@ export async function hasuraArticlePage(params) {
   return fetchGraphQL({
     url: process.env.HASURA_API_URL,
     orgSlug: process.env.ORG_SLUG,
-    query: HASURA_ARTICLE_PAGE,
+    query: HASURA_ARTICLE_PAGE_SLUG_VERSION,
     name: 'MyQuery',
     variables: {
       category_slug: params['categorySlug'],

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -569,6 +569,50 @@ const HASURA_GET_LAYOUT = `query MyQuery($locale_code: String!) {
   }
 }`;
 
+const HASURA_GET_PAGE_SLUG_VERSION = `query MyQuery($slug: String!, $locale_code: String = "") {
+  page_slug_versions(where: {slug: {_eq: $slug}, page: {page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}}) {
+    slug
+    page {
+      id
+      author_pages {
+        author {
+          id
+          name
+          slug
+          author_translations(where: {locale_code: {_eq: $locale_code}}) {
+            title
+          }
+        }
+      }
+      page_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        content
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        last_published_at
+        published
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
+      slug
+    }
+  }
+  categories(where: {published: {_eq: true}, category_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations {
+      data
+    }
+  }
+}`;
+
 const HASURA_GET_PAGE = `query MyQuery($slug: String!, $locale_code: String!) {
   pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
     id
@@ -908,7 +952,7 @@ export function hasuraGetPage(params) {
   return fetchGraphQL({
     url: params['url'],
     orgSlug: params['orgSlug'],
-    query: HASURA_GET_PAGE,
+    query: HASURA_GET_PAGE_SLUG_VERSION,
     name: 'MyQuery',
     variables: {
       slug: params['slug'],

--- a/pages/about.js
+++ b/pages/about.js
@@ -77,9 +77,13 @@ export async function getStaticProps({ locale }) {
     };
     // throw errors;
   } else {
-    console.log(data);
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
-    page = data.pages[0];
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -79,7 +79,12 @@ export async function getStaticProps({ locale, params }) {
     categorySlug: params.category,
     slug: params.slug,
   });
-  if (errors || !data || !data.articles || data.articles.length === 0) {
+  if (
+    errors ||
+    !data ||
+    !data.article_slug_versions ||
+    data.article_slug_versions.length === 0
+  ) {
     return {
       notFound: true,
     };
@@ -93,7 +98,8 @@ export async function getStaticProps({ locale, params }) {
       );
     }
 
-    article = data.articles.find((a) => a.slug === params.slug);
+    article = data.article_slug_versions[0].article;
+    // article = data.articles.find((a) => a.slug === params.slug);
 
     const sectionResponse = await hasuraCategoryPage({
       url: apiUrl,

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -10,7 +10,6 @@ export default function StaticPage({ page, sections, siteMetadata }) {
   const router = useRouter();
   const isAmp = useAmp();
 
-  console.log('static page');
   if (router.isFallback) {
     return <div>Loading...</div>;
   }
@@ -97,13 +96,12 @@ export async function getStaticProps({ locale, params }) {
       notFound: true,
     };
   } else {
-    if (!data.pages || !data.pages[0]) {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
       return {
         notFound: true,
       };
     }
-    page = data.pages[0];
-    console.log('page: ', page);
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -64,20 +64,19 @@ export async function getServerSideProps(context) {
     slug: 'thank-you',
     localeCode: context.locale,
   });
-  if (
-    errors ||
-    !data ||
-    !data.pages ||
-    data.pages.length <= 0 ||
-    !data.pages[0]
-  ) {
+  if (errors || !data) {
     return {
       notFound: true,
     };
     // throw errors;
   } else {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
     sections = data.categories;
-    page = data.pages[0];
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(


### PR DESCRIPTION
This builds on PR #443 doing the same for articles: retrieve and render content for any slug the article was associated with.

To test, try:

* http://localhost:3000/articles/news/collingswood-and-haddon-township-publish-bike-and-pedestrian-master-plan-update-slug
* and then find the same content at http://localhost:3000/articles/news/collingswood-and-haddon-township-publish-bike-and-pedestrian-master-plan