### PR TITLE
Set article & page canonical link

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -3,8 +3,10 @@ import ArticleBody from './articles/ArticleBody';
 import Comments from './articles/Comments';
 import ArticleFooter from './articles/ArticleFooter';
 import Recirculation from './articles/Recirculation';
+import { generateArticleUrl } from '../lib/utils.js';
 import { useAmp } from 'next/amp';
 import Layout from './Layout.js';
+import { useEffect } from 'react';
 
 export default function Article({
   article,
@@ -15,6 +17,12 @@ export default function Article({
   sectionArticles,
 }) {
   const isAmp = useAmp();
+
+  useEffect(() => {
+    // this is used for the canonical link tag in the Layout component
+    let canonicalArticleUrl = generateArticleUrl(window.location.href, article);
+    siteMetadata['canonicalUrl'] = canonicalArticleUrl;
+  }, []);
 
   return (
     <Layout meta={siteMetadata} article={article} sections={sections}>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -19,7 +19,7 @@ export default function Layout({
   }
 
   const metaValues = {
-    canonical: meta['siteUrl'],
+    canonical: meta['canonicalUrl'] || meta['siteUrl'],
     siteName: meta['shortName'],
     searchTitle: meta['searchTitle'],
     searchDescription: meta['searchDescription'],

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,14 @@ import { format } from 'date-fns';
 const ORG_SLUG = process.env.ORG_SLUG;
 const HASURA_API_URL = process.env.HASURA_API_URL;
 
+export function generateArticleUrl(baseUrl, article) {
+  let currentUrl = new URL(baseUrl);
+  let relativeArticleUrl =
+    '/articles/' + article.category.slug + '/' + article.slug;
+  let canonicalUrl = new URL(relativeArticleUrl, currentUrl.origin);
+  return canonicalUrl.toString();
+}
+
 export function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
   var vars = query.split('&');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,13 @@ export function generateArticleUrl(baseUrl, article) {
   return canonicalUrl.toString();
 }
 
+export function generatePageUrl(baseUrl, page) {
+  let currentUrl = new URL(baseUrl);
+  let relativeUrl = '/static/' + page.slug;
+  let canonicalUrl = new URL(relativeUrl, currentUrl.origin);
+  return canonicalUrl.toString();
+}
+
 export function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
   var vars = query.split('&');

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { hasuraGetPage, hasuraListAllPageSlugs } from '../../lib/articles.js';
 import { hasuraLocaliseText } from '../../lib/utils';
 import Layout from '../../components/Layout';
-import { renderBody } from '../../lib/utils.js';
+import { generatePageUrl, renderBody } from '../../lib/utils.js';
 
 export default function StaticPage({ page, sections, siteMetadata }) {
   const router = useRouter();
@@ -18,6 +18,9 @@ export default function StaticPage({ page, sections, siteMetadata }) {
     if (!page || page === undefined || page === null || page === {}) {
       router.push('/404');
     }
+    // this is used for the canonical link tag in the Layout component
+    let canonicalPageUrl = generatePageUrl(window.location.href, page);
+    siteMetadata['canonicalUrl'] = canonicalPageUrl;
   }, [page]);
 
   let localisedPage;


### PR DESCRIPTION
This PR sets the canonical link for both articles and static pages to a URL using the current slug of the content. I was able to do this without doing an extra query (or modifying the existing one) because of how the current query works: it uses whatever slug is in the url to find the matching article or page, which then in turn will have the current slug stored in its `slug` field. From there I can make the canonical link. So `/static/donate` will have the canonical `/static/donations` (most recent slug from my testing) and so on.

