### PR TITLE
Edit donation options in tinycms metadata

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -3,8 +3,10 @@ import ArticleBody from './articles/ArticleBody';
 import Comments from './articles/Comments';
 import ArticleFooter from './articles/ArticleFooter';
 import Recirculation from './articles/Recirculation';
+import { generateArticleUrl } from '../lib/utils.js';
 import { useAmp } from 'next/amp';
 import Layout from './Layout.js';
+import { useEffect } from 'react';
 
 export default function Article({
   article,
@@ -15,6 +17,12 @@ export default function Article({
   sectionArticles,
 }) {
   const isAmp = useAmp();
+
+  useEffect(() => {
+    // this is used for the canonical link tag in the Layout component
+    let canonicalArticleUrl = generateArticleUrl(window.location.href, article);
+    siteMetadata['canonicalUrl'] = canonicalArticleUrl;
+  }, []);
 
   return (
     <Layout meta={siteMetadata} article={article} sections={sections}>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -19,7 +19,7 @@ export default function Layout({
   }
 
   const metaValues = {
-    canonical: meta['siteUrl'],
+    canonical: meta['canonicalUrl'] || meta['siteUrl'],
     siteName: meta['shortName'],
     searchTitle: meta['searchTitle'],
     searchDescription: meta['searchDescription'],

--- a/components/tinycms/MetadataTextArea.js
+++ b/components/tinycms/MetadataTextArea.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function MetadataTextArea(props) {
+  return (
+    <div className="field" key={props.name}>
+      <label className="label" htmlFor={props.name}>
+        {props.label}
+      </label>
+      <div className="control">
+        <textarea
+          name={props.name}
+          className="textarea"
+          onChange={props.handleChange}
+        >
+          {props.value}
+        </textarea>
+      </div>
+    </div>
+  );
+}

--- a/components/tinycms/MetadataTextArea.js
+++ b/components/tinycms/MetadataTextArea.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export default function MetadataTextArea(props) {
+  console.log('textarea props:', props);
   return (
     <div className="field" key={props.name}>
       <label className="label" htmlFor={props.name}>
@@ -11,9 +12,8 @@ export default function MetadataTextArea(props) {
           name={props.name}
           className="textarea"
           onChange={props.handleChange}
-        >
-          {props.value}
-        </textarea>
+          value={props.value}
+        />
       </div>
     </div>
   );

--- a/components/tinycms/UpdateSiteMetadata.js
+++ b/components/tinycms/UpdateSiteMetadata.js
@@ -37,7 +37,9 @@ export default function UpdateMetadata(props) {
   useEffect(() => {
     if (props.metadata) {
       let parsed = props.metadata;
+      console.log('props.metadata:', props.metadata);
       setParsedData(parsed);
+      console.log('parsedData donation options:', parsed['donationOptions']);
       setRandomDataKey(Math.random());
       let formattedJSON = JSON.stringify(parsed, null, 2);
       setJsonData(formattedJSON);
@@ -53,11 +55,14 @@ export default function UpdateMetadata(props) {
     ev.preventDefault();
 
     let parsed = parsedData;
+
+    console.log('parsedData:', parsedData);
     if (jsonData && (Object.keys(parsedData).length === 0 || editData)) {
       parsed = JSON.parse(jsonData);
       setParsedData(parsed);
     }
 
+    console.log('parsedData:', parsed);
     const { errors, data } = await hasuraUpsertMetadata({
       url: props.apiUrl,
       orgSlug: props.apiToken,

--- a/components/tinycms/UpdateSiteMetadata.js
+++ b/components/tinycms/UpdateSiteMetadata.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { hasuraUpsertMetadata } from '../../lib/site_metadata';
 import Notification from './Notification';
 import MetadataTextInput from './MetadataTextInput';
+import MetadataTextArea from './MetadataTextArea';
 import MetadataSelect from './MetadataSelect';
 import NewsletterBlock from './../plugins/NewsletterBlock';
 import ColorStylePreview from './ColorStylePreview';
@@ -287,6 +288,13 @@ export default function UpdateMetadata(props) {
         name="donateBlockDek"
         handleChange={handleChange}
         value={parsedData['donateBlockDek']}
+      />
+
+      <MetadataTextArea
+        label="Donation Options"
+        name="donationOptions"
+        handleChange={handleChange}
+        value={parsedData['donationOptions']}
       />
 
       {!editData && (

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,14 @@ import { format } from 'date-fns';
 const ORG_SLUG = process.env.ORG_SLUG;
 const HASURA_API_URL = process.env.HASURA_API_URL;
 
+export function generateArticleUrl(baseUrl, article) {
+  let currentUrl = new URL(baseUrl);
+  let relativeArticleUrl =
+    '/articles/' + article.category.slug + '/' + article.slug;
+  let canonicalUrl = new URL(relativeArticleUrl, currentUrl.origin);
+  return canonicalUrl.toString();
+}
+
 export function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
   var vars = query.split('&');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,13 @@ export function generateArticleUrl(baseUrl, article) {
   return canonicalUrl.toString();
 }
 
+export function generatePageUrl(baseUrl, page) {
+  let currentUrl = new URL(baseUrl);
+  let relativeUrl = '/static/' + page.slug;
+  let canonicalUrl = new URL(relativeUrl, currentUrl.origin);
+  return canonicalUrl.toString();
+}
+
 export function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
   var vars = query.split('&');

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { hasuraGetPage, hasuraListAllPageSlugs } from '../../lib/articles.js';
 import { hasuraLocaliseText } from '../../lib/utils';
 import Layout from '../../components/Layout';
-import { renderBody } from '../../lib/utils.js';
+import { generatePageUrl, renderBody } from '../../lib/utils.js';
 
 export default function StaticPage({ page, sections, siteMetadata }) {
   const router = useRouter();
@@ -18,6 +18,9 @@ export default function StaticPage({ page, sections, siteMetadata }) {
     if (!page || page === undefined || page === null || page === {}) {
       router.push('/404');
     }
+    // this is used for the canonical link tag in the Layout component
+    let canonicalPageUrl = generatePageUrl(window.location.href, page);
+    siteMetadata['canonicalUrl'] = canonicalPageUrl;
   }, [page]);
 
   let localisedPage;


### PR DESCRIPTION
Issue #441 

This does part of the work required for #441 by adding a "donation options" field to the tinycms metadata editor. I've added a new reusable component for this as it's a textarea. (I figure we can get fancier with a repeatable component of 3 separate fields that get parsed as JSON in the future if we want.)

<img width="674" alt="Screen Shot 2021-04-09 at 10 42 12 am" src="https://user-images.githubusercontent.com/3397/114112785-6fe1bc00-9920-11eb-9ef6-4ca395dcee09.png">

I filled in this data from the three current options setup in monkeypod.