### PR TITLE
Tinycms redesign sections, tags and notifications

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+
   presets: [['next/babel', { 'preset-react': { runtime: 'automatic' } }]],
-  plugins: ['babel-plugin-macros', ['styled-components', { ssr: true }]],
+  plugins: ['babel-plugin-macros', ['styled-components', { ssr: true, displayName: true, preprocess: false }]],
 }

--- a/components/AdminLayout.js
+++ b/components/AdminLayout.js
@@ -1,6 +1,4 @@
 import Head from 'next/head';
-import 'bulma/css/bulma.min.css';
-import styles from '../styles/bulma.js';
 import { signIn, useSession } from 'next-auth/client';
 
 export default function AdminLayout({ children }) {
@@ -43,9 +41,6 @@ export default function AdminLayout({ children }) {
         )}
         {true && <>{children}</>}
       </main>
-      <style jsx global>
-        {styles}
-      </style>
     </>
   );
 }

--- a/components/nav/AdminNav.js
+++ b/components/nav/AdminNav.js
@@ -55,7 +55,7 @@ export default function NewAdminNav(props) {
               <Link href="/tinycms/authors">
                 <NavItem>Authors</NavItem>
               </Link>
-              <Link href="/tinycms/metadata">
+              <Link href="/tinycms/settings">
                 <NavItem>Settings</NavItem>
               </Link>
               <Link href="/tinycms/sections">

--- a/components/nav/AdminNav.js
+++ b/components/nav/AdminNav.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { signOut } from 'next-auth/client';
 
 // const NavBar = tw.nav`flex items-center flex-wrap p-3`;
-const NavBar = tw.header`flex h-32 items-center bg-gray-100`;
+const NavBar = tw.header`flex h-16 items-center bg-gray-100`;
 const NavBarContainer = tw.div`w-full container-md mx-auto px-6`;
 const NavBarInnerContainer = tw.div`flex justify-between flex-col md:flex-row`;
 
@@ -42,7 +42,9 @@ export default function NewAdminNav(props) {
           <NavBarInnerContainer>
             <BrandContainer>
               <Link href="/tinycms">
-                <a href="/tinycms">TinyCMS</a>
+                <a tw="text-4xl" href="/tinycms">
+                  TinyCMS
+                </a>
               </Link>
             </BrandContainer>
             <NavItemsDiv>

--- a/components/nav/AdminNav.js
+++ b/components/nav/AdminNav.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { signOut } from 'next-auth/client';
 
 // const NavBar = tw.nav`flex items-center flex-wrap p-3`;
-const NavBar = tw.header`flex h-32 items-center bg-white`;
+const NavBar = tw.header`flex h-32 items-center bg-gray-100`;
 const NavBarContainer = tw.div`w-full container-md mx-auto px-6`;
 const NavBarInnerContainer = tw.div`flex justify-between flex-col md:flex-row`;
 

--- a/components/plugins/DonationOptionsBlock.js
+++ b/components/plugins/DonationOptionsBlock.js
@@ -5,8 +5,13 @@ export default function DonationOptionsBlock({ metadata, wrap = true }) {
     return null;
   }
 
-  let parsedOptions = JSON.parse(metadata.donationOptions);
-  console.log('donationOptions:', parsedOptions);
+  let parsedOptions = [];
+  try {
+    parsedOptions = JSON.parse(metadata.donationOptions);
+    console.log('donationOptions:', parsedOptions);
+  } catch (e) {
+    console.error(e);
+  }
 
   const block = parsedOptions.map((option, i) => (
     <div className="column is-one-third is-centered">

--- a/components/plugins/MembershipBlock.js
+++ b/components/plugins/MembershipBlock.js
@@ -1,0 +1,14 @@
+import DonationOptionsBlock from './DonationOptionsBlock';
+
+export default function MembershipBlock({ metadata, wrap = true }) {
+  const block = (
+    <div className={`newsletter ${!wrap && 'block'}`}>
+      <h4>{metadata.membershipHed}</h4>
+      <p>{metadata.membershipDek}</p>
+      <br />
+      <DonationOptionsBlock metadata={metadata} />
+    </div>
+  );
+
+  return wrap ? <div className="block">{block}</div> : block;
+}

--- a/components/tinycms/AdminHeader.js
+++ b/components/tinycms/AdminHeader.js
@@ -1,24 +1,21 @@
 import React from 'react';
 import LocaleSwitcher from './LocaleSwitcher';
+import tw from 'twin.macro';
 
 export default function AdminHeader(props) {
   return (
-    <div>
-      <div className="level-left">
-        <div className="level-item">
-          <h1 className="title">
-            {props.title} ({props.currentLocale})
-          </h1>
-        </div>
+    <div tw="block pt-8 mx-auto grid flex justify-center grid-cols-2 gap-4">
+      <div tw="mr-8">
+        <span tw="text-xl font-bold">
+          {props.title} ({props.currentLocale})
+        </span>
       </div>
-      <div className="level-right">
-        <div className="level-item">
-          <LocaleSwitcher
-            locales={props.locales}
-            currentLocale={props.currentLocale}
-            id={props.id}
-          />
-        </div>
+      <div tw="ml-8">
+        <LocaleSwitcher
+          locales={props.locales}
+          currentLocale={props.currentLocale}
+          id={props.id}
+        />
       </div>
     </div>
   );

--- a/components/tinycms/DesignSettings.js
+++ b/components/tinycms/DesignSettings.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import tw from 'twin.macro';
-
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
-
-export default function DesignSettings(props) {
-  return <SettingsHeader>Design Settings</SettingsHeader>;
-}

--- a/components/tinycms/DesignSettings.js
+++ b/components/tinycms/DesignSettings.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+
+export default function DesignSettings(props) {
+  return <SettingsHeader>Design Settings</SettingsHeader>;
+}

--- a/components/tinycms/MembershipSettings.js
+++ b/components/tinycms/MembershipSettings.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import tw from 'twin.macro';
-
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
-
-export default function MembershipSettings(props) {
-  return <SettingsHeader>Membership Settings</SettingsHeader>;
-}

--- a/components/tinycms/MembershipSettings.js
+++ b/components/tinycms/MembershipSettings.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+
+export default function MembershipSettings(props) {
+  return <SettingsHeader>Membership Settings</SettingsHeader>;
+}

--- a/components/tinycms/NewsletterSettings.js
+++ b/components/tinycms/NewsletterSettings.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import tw from 'twin.macro';
-
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
-
-export default function NewsletterSettings(props) {
-  return <SettingsHeader>Newsletter Settings</SettingsHeader>;
-}

--- a/components/tinycms/NewsletterSettings.js
+++ b/components/tinycms/NewsletterSettings.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+
+export default function NewsletterSettings(props) {
+  return <SettingsHeader>Newsletter Settings</SettingsHeader>;
+}

--- a/components/tinycms/Notification.js
+++ b/components/tinycms/Notification.js
@@ -1,20 +1,73 @@
+import tw, { css, styled } from 'twin.macro';
+
+const DangerContainer = styled.div`bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`;
+const SuccessContainer = styled.div`bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative`;
+
 export default function Notification(props) {
   let messages = props.message;
   if (typeof props.message === 'string') {
     messages = [props.message];
   }
-  return (
-    <div className={`notification is-${props.notificationType}`}>
-      <button
-        className="delete"
-        onClick={() => props.setShowNotification(false)}
-      ></button>
-      {messages.map((msg) => (
-        <div key={msg}>
-          {msg}
-          <br />
-        </div>
-      ))}
-    </div>
-  );
+  let alertBox;
+  if (props.notificationType === 'success') {
+    alertBox = (
+      <div tw="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative">
+        <strong tw="font-bold">Success!</strong>{' '}
+        {messages.map((msg) => (
+          <span key={msg} tw="block sm:inline">
+            {msg}
+          </span>
+        ))}
+        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
+          <svg
+            tw="fill-current h-6 w-6 text-green-500"
+            role="button"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+          >
+            <title>Close</title>
+            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
+          </svg>
+        </span>
+      </div>
+    );
+  } else {
+    alertBox = (
+      <div tw="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
+        <strong tw="font-bold">Uh oh!</strong>
+        <span tw="block sm:inline">Something went wrong...</span>
+        {messages.map((msg) => (
+          <span key={msg} tw="block sm:inline">
+            {msg}
+          </span>
+        ))}
+        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
+          <svg
+            tw="fill-current h-6 w-6 text-red-500"
+            role="button"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+          >
+            <title>Close</title>
+            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
+          </svg>
+        </span>
+      </div>
+    );
+  }
+  return alertBox;
+
+  // <div className={`notification is-${props.notificationType}`}>
+  //   <button
+  //     className="delete"
+  //     onClick={() => props.setShowNotification(false)}
+  //   ></button>
+  //   {messages.map((msg) => (
+  //     <div key={msg}>
+  //       {msg}
+  //       <br />
+  //     </div>
+  //   ))}
+  // </div>
+  // );
 }

--- a/components/tinycms/SeoSettings.js
+++ b/components/tinycms/SeoSettings.js
@@ -1,8 +1,0 @@
-import React from 'react';
-import tw from 'twin.macro';
-
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
-
-export default function SeoSettings(props) {
-  return <SettingsHeader>SEO/Social Settings</SettingsHeader>;
-}

--- a/components/tinycms/SeoSettings.js
+++ b/components/tinycms/SeoSettings.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+
+export default function SeoSettings(props) {
+  return <SettingsHeader>SEO/Social Settings</SettingsHeader>;
+}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -1,8 +1,260 @@
 import React from 'react';
-import tw from 'twin.macro';
+import tw, { css, styled } from 'twin.macro';
 
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+const SettingsHeader = tw.h1`text-4xl font-bold leading-normal mt-0 mb-2 text-black`;
+const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
+const DesignContainer = tw.div`grid grid-cols-2 gap-4`;
+const DesignHeader = tw.h1`text-2xl font-bold leading-normal mt-0 mb-2 text-black`;
+const SingleColumnContainer = tw.div`grid grid-cols-1 gap-4`;
+const StyleOneHead = styled.span`
+  font-family: 'Libre Franklin', sans-serif;
+`;
+const StyleOneBody = styled.span`
+  font-family: 'Domine', serif;
+`;
+const StyleTwoHead = styled.span`
+  font-family: 'Source Serif Pro', sans-serif;
+`;
+const StyleTwoBody = styled.span`
+  font-family: 'Source Sans Pro', sans-serif;
+`;
+const StyleThreeHead = styled.span`
+  font-family: 'Roboto Condensed', sans-serif;
+`;
+const StyleThreeBody = styled.span`
+  font-family: 'Roboto', sans-serif;
+`;
+const StyleFourHead = styled.span`
+  font-family: 'Arbutus Slab', serif;
+`;
+const StyleFourBody = styled.span`
+  font-family: 'Mulish', sans-serif;
+`;
+const ColorContainer = styled.div`
+  float: left;
+`;
+const ColorLabel = styled.span(
+  css`
+    float: left;
+    ${tw`p-2 mt-1`}
+  `
+);
+const ColorRadioFloat = styled.input`
+  float: left;
+  margin-right: 1em;
+`;
+const ColorOnePrimaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: rgba(54, 102, 209, 1);
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
+const ColorOneSecondaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: rgba(209, 131, 65, 0.12);
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
+const ColorTwoPrimaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: rgba(209, 219, 189, 1);
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
+const ColorTwoSecondaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: rgba(25, 52, 65, 1);
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
+const ColorThreePrimaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: #000000;
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
+const ColorThreeSecondaryBox = styled.div(
+  css`
+    margin-right: 0.5em;
+    background-color: rgba(231, 229, 228, 1);
+    width: 20px;
+    height: 20px;
+    float: left;
+    clear: both;
+    ${tw`h-6 w-6 p-4`}
+  `
+);
 
 export default function SiteInfoSettings(props) {
-  return <SettingsHeader>Site Information</SettingsHeader>;
+  return (
+    <div tw="space-x-4 space-y-4">
+      <SettingsHeader>Site Information</SettingsHeader>
+
+      <SiteInfoFieldsContainer>
+        <label for="siteName">
+          <span tw="mt-1 font-bold">Site name</span>
+          <input
+            type="text"
+            name="siteName"
+            value={props.siteName}
+            onChange={props.handleChange}
+          />
+        </label>
+        <label for="siteUrl">
+          <span tw="mt-1 font-bold">Site URL</span>
+          <input
+            type="text"
+            name="siteUrl"
+            value={props.siteUrl}
+            onChange={props.handleChange}
+          />
+        </label>
+        <label for="logo">
+          <span tw="mt-1 font-bold">Logo</span>
+          <input type="file" name="logo" onChange={props.handleChange} />
+        </label>
+      </SiteInfoFieldsContainer>
+
+      <SettingsHeader>Design</SettingsHeader>
+      <DesignContainer>
+        <div>
+          <DesignHeader>Typography</DesignHeader>
+          <SingleColumnContainer>
+            <label>
+              <input
+                type="radio"
+                value="styleone"
+                checked={props.theme === 'styleone'}
+                onChange={props.handleChange}
+              />
+              <StyleOneHead tw="p-2 mt-1 font-bold">
+                Libre Franklin is your headline font
+              </StyleOneHead>
+              <br />
+              <StyleOneBody tw="p-2 mt-1">
+                Domine is your body font
+              </StyleOneBody>
+            </label>
+            <label>
+              <input
+                type="radio"
+                value="styletwo"
+                checked={props.theme === 'styletwo'}
+                onChange={props.handleChange}
+              />
+              <StyleTwoHead tw="p-2 mt-1 font-bold">
+                Source Serif Pro is your headline font
+              </StyleTwoHead>
+              <br />
+              <StyleTwoBody tw="p-2 mt-1">
+                Source Sans Pro is your body font
+              </StyleTwoBody>
+            </label>
+            <label>
+              <input
+                type="radio"
+                value="stylethree"
+                checked={props.theme === 'stylethree'}
+                onChange={props.handleChange}
+              />
+              <StyleThreeHead tw="p-2 mt-1 font-bold">
+                Roboto Condensed is your headline font
+              </StyleThreeHead>
+              <br />
+              <StyleThreeBody tw="p-2 mt-1">
+                Roboto is your body font
+              </StyleThreeBody>
+            </label>
+            <label>
+              <input
+                type="radio"
+                value="stylefour"
+                checked={props.theme === 'stylefour'}
+                onChange={props.handleChange}
+              />
+              <StyleFourHead tw="p-2 mt-1 font-bold">
+                Arbutus Slab is your headline font
+              </StyleFourHead>
+              <br />
+              <StyleFourBody tw="p-2 mt-1">
+                Mulish is your body font
+              </StyleFourBody>
+            </label>
+          </SingleColumnContainer>
+        </div>
+        <div>
+          <DesignHeader>Colors</DesignHeader>
+          <SingleColumnContainer>
+            <label>
+              <ColorRadioFloat
+                type="radio"
+                value="colorone"
+                checked={props.color === 'colorone'}
+                onChange={props.handleChange}
+              />
+              <ColorContainer>
+                <ColorOnePrimaryBox></ColorOnePrimaryBox>
+                <ColorLabel>Primary</ColorLabel>
+                <ColorOneSecondaryBox></ColorOneSecondaryBox>
+                <ColorLabel>Secondary</ColorLabel>
+              </ColorContainer>
+            </label>
+            <label>
+              <ColorRadioFloat
+                type="radio"
+                value="colortwo"
+                checked={props.color === 'colortwo'}
+                onChange={props.handleChange}
+              />
+              <ColorContainer>
+                <ColorTwoPrimaryBox></ColorTwoPrimaryBox>
+                <ColorLabel>Primary</ColorLabel>
+                <ColorTwoSecondaryBox></ColorTwoSecondaryBox>
+                <ColorLabel>Secondary</ColorLabel>
+              </ColorContainer>
+            </label>
+            <label>
+              <ColorRadioFloat
+                type="radio"
+                value="colorthree"
+                checked={props.color === 'colorthree'}
+                onChange={props.handleChange}
+              />
+              <ColorContainer>
+                <ColorThreePrimaryBox></ColorThreePrimaryBox>
+                <ColorLabel>Primary</ColorLabel>
+                <ColorThreeSecondaryBox></ColorThreeSecondaryBox>
+                <ColorLabel>Secondary</ColorLabel>
+              </ColorContainer>
+            </label>
+          </SingleColumnContainer>
+        </div>
+      </DesignContainer>
+    </div>
+  );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import tw, { css, styled } from 'twin.macro';
+import NewsletterBlock from '../plugins/NewsletterBlock';
 
 const SettingsHeader = tw.h1`text-4xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
 const DesignContainer = tw.div`grid grid-cols-2 gap-4`;
+const NewsletterContainer = tw.div`grid grid-cols-3 gap-8`;
 const DesignHeader = tw.h1`text-2xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SingleColumnContainer = tw.div`grid grid-cols-1 gap-4`;
 const StyleOneHead = styled.span`
@@ -111,6 +113,34 @@ const ColorThreeSecondaryBox = styled.div(
 );
 
 export default function SiteInfoSettings(props) {
+  const [shortName, setShortName] = useState(props.parsedData['shortName']);
+  const [siteUrl, setSiteUrl] = useState(props.parsedData['siteUrl']);
+  const [color, setColor] = useState(props.parsedData['color']);
+  const [primaryColor, setPrimaryColor] = useState(
+    props.parsedData['primaryColor']
+  );
+  const [secondaryColor, setSecondaryColor] = useState(
+    props.parsedData['secondaryColor']
+  );
+  const [theme, setTheme] = useState(props.parsedData['theme']);
+  const [newsletterHed, setNewsletterHed] = useState(
+    props.parsedData['newsletterHed']
+  );
+  const [newsletterDek, setNewsletterDek] = useState(
+    props.parsedData['newsletterDek']
+  );
+
+  useEffect(() => {
+    setShortName(props.parsedData['shortName']);
+    setSiteUrl(props.parsedData['siteUrl']);
+    setColor(props.parsedData['color']);
+    setTheme(props.parsedData['theme']);
+    setPrimaryColor(props.parsedData['primaryColor']);
+    setSecondaryColor(props.parsedData['secondaryColor']);
+    setNewsletterDek(props.parsedData['newsletterDek']);
+    setNewsletterHed(props.parsedData['newsletterHed']);
+  }, [props.parsedData]);
+
   return (
     <div tw="space-x-4 space-y-4">
       <SettingsHeader>Site Information</SettingsHeader>
@@ -121,7 +151,7 @@ export default function SiteInfoSettings(props) {
           <input
             type="text"
             name="shortName"
-            value={props.shortName}
+            value={shortName}
             onChange={props.handleChange}
           />
         </label>
@@ -130,7 +160,7 @@ export default function SiteInfoSettings(props) {
           <input
             type="text"
             name="siteUrl"
-            value={props.siteUrl}
+            value={siteUrl}
             onChange={props.handleChange}
           />
         </label>
@@ -150,7 +180,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="theme"
                 value="styleone"
-                checked={props.theme === 'styleone'}
+                checked={theme === 'styleone'}
                 onChange={props.handleChange}
               />
               <StyleOneHead tw="p-2 mt-1 font-bold">
@@ -166,7 +196,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="theme"
                 value="styletwo"
-                checked={props.theme === 'styletwo'}
+                checked={theme === 'styletwo'}
                 onChange={props.handleChange}
               />
               <StyleTwoHead tw="p-2 mt-1 font-bold">
@@ -182,7 +212,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 value="stylethree"
                 name="theme"
-                checked={props.theme === 'stylethree'}
+                checked={theme === 'stylethree'}
                 onChange={props.handleChange}
               />
               <StyleThreeHead tw="p-2 mt-1 font-bold">
@@ -198,7 +228,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="theme"
                 value="stylefour"
-                checked={props.theme === 'stylefour'}
+                checked={theme === 'stylefour'}
                 onChange={props.handleChange}
               />
               <StyleFourHead tw="p-2 mt-1 font-bold">
@@ -219,7 +249,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="color"
                 value="colorone"
-                checked={props.color === 'colorone'}
+                checked={color === 'colorone'}
                 onChange={props.handleChange}
               />
               <ColorContainer>
@@ -234,7 +264,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="color"
                 value="colortwo"
-                checked={props.color === 'colortwo'}
+                checked={color === 'colortwo'}
                 onChange={props.handleChange}
               />
               <ColorContainer>
@@ -249,7 +279,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="color"
                 value="colorthree"
-                checked={props.color === 'colorthree'}
+                checked={color === 'colorthree'}
                 onChange={props.handleChange}
               />
               <ColorContainer>
@@ -264,7 +294,7 @@ export default function SiteInfoSettings(props) {
                 type="radio"
                 name="color"
                 value="custom"
-                checked={props.color === 'custom'}
+                checked={color === 'custom'}
                 onChange={props.handleChange}
               />
               <div tw="grid grid-cols-1">
@@ -274,14 +304,14 @@ export default function SiteInfoSettings(props) {
                     type="text"
                     name="primaryColor"
                     placeholder="Primary color (use hex code)"
-                    value={props.primaryColor}
+                    value={primaryColor}
                     onChange={props.handleChange}
                   />
                   <input
                     type="text"
                     name="secondaryColor"
                     placeholder="Secondary color (use hex code)"
-                    value={props.secondaryColor}
+                    value={secondaryColor}
                     onChange={props.handleChange}
                   />
                 </label>
@@ -290,6 +320,40 @@ export default function SiteInfoSettings(props) {
           </SingleColumnContainer>
         </div>
       </DesignContainer>
+
+      <NewsletterContainer>
+        <SettingsHeader tw="col-span-3 mt-5">
+          Newsletter promotion block
+        </SettingsHeader>
+
+        <div tw="col-span-2">
+          <label for="heading">
+            <span tw="w-full mt-1 font-bold">Heading</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="newsletterHed"
+              value={newsletterHed}
+              onChange={props.handleChange}
+            />
+          </label>
+          <label for="description">
+            <span tw="mt-1 font-bold">Description</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="newsletterDek"
+              value={newsletterDek}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="col-span-1">
+          <span tw="mt-1 font-bold">Preview</span>
+
+          <NewsletterBlock metadata={props.parsedData} />
+        </div>
+      </NewsletterContainer>
     </div>
   );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -116,12 +116,12 @@ export default function SiteInfoSettings(props) {
       <SettingsHeader>Site Information</SettingsHeader>
 
       <SiteInfoFieldsContainer>
-        <label for="siteName">
+        <label for="shortName">
           <span tw="mt-1 font-bold">Site name</span>
           <input
             type="text"
-            name="siteName"
-            value={props.siteName}
+            name="shortName"
+            value={props.shortName}
             onChange={props.handleChange}
           />
         </label>

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -176,11 +176,11 @@ export default function SiteInfoSettings(props) {
     setMembershipHed(props.parsedData['membershipHed']);
     setNewsletterDek(props.parsedData['newsletterDek']);
     setNewsletterHed(props.parsedData['newsletterHed']);
-  }, [props.parsedData]);
+  }, [props.parsedData, window.location]);
 
   return (
     <div tw="space-x-4 space-y-4">
-      <SettingsHeader>Site Information</SettingsHeader>
+      <SettingsHeader ref={props.siteInfoRef}>Site Information</SettingsHeader>
 
       <SiteInfoFieldsContainer>
         <label htmlFor="shortName">
@@ -207,7 +207,7 @@ export default function SiteInfoSettings(props) {
         </label>
       </SiteInfoFieldsContainer>
 
-      <SettingsHeader>Design</SettingsHeader>
+      <SettingsHeader ref={props.designRef}>Design</SettingsHeader>
       <DesignContainer>
         <div>
           <DesignHeader>Typography</DesignHeader>
@@ -358,7 +358,7 @@ export default function SiteInfoSettings(props) {
         </div>
       </DesignContainer>
 
-      <NewsletterContainer>
+      <NewsletterContainer ref={props.newsletterRef}>
         <SettingsHeader tw="col-span-3 mt-5">
           Newsletter promotion block
         </SettingsHeader>
@@ -392,7 +392,7 @@ export default function SiteInfoSettings(props) {
         </div>
       </NewsletterContainer>
 
-      <MembershipContainer>
+      <MembershipContainer ref={props.membershipRef}>
         <SettingsHeader tw="col-span-3 mt-5">
           Membership promotion block
         </SettingsHeader>
@@ -425,7 +425,8 @@ export default function SiteInfoSettings(props) {
           <MembershipBlock metadata={props.parsedData} />
         </div>
       </MembershipContainer>
-      <SeoContainer>
+
+      <SeoContainer ref={props.seoRef}>
         <SettingsHeader tw="col-span-3 mt-5">
           SEO and Social Metadata
         </SettingsHeader>

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import tw from 'twin.macro';
+
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
+
+export default function SiteInfoSettings(props) {
+  return <SettingsHeader>Site Information</SettingsHeader>;
+}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -5,6 +5,7 @@ import NewsletterBlock from '../plugins/NewsletterBlock';
 
 const SettingsHeader = tw.h1`text-4xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
+const SeoContainer = tw.div``;
 const DesignContainer = tw.div`grid grid-cols-2 gap-4`;
 const MembershipContainer = tw.div`grid grid-cols-3 gap-8`;
 const NewsletterContainer = tw.div`grid grid-cols-3 gap-8`;
@@ -115,6 +116,25 @@ const ColorThreeSecondaryBox = styled.div(
 );
 
 export default function SiteInfoSettings(props) {
+  const [searchTitle, setSearchTitle] = useState(
+    props.parsedData['searchTitle']
+  );
+  const [searchDescription, setSearchDescription] = useState(
+    props.parsedData['searchDescription']
+  );
+  const [facebookTitle, setFacebookTitle] = useState(
+    props.parsedData['facebookTitle']
+  );
+  const [facebookDescription, setFacebookDescription] = useState(
+    props.parsedData['facebookDescription']
+  );
+  const [twitterTitle, setTwitterTitle] = useState(
+    props.parsedData['twitterTitle']
+  );
+  const [twitterDescription, setTwitterDescription] = useState(
+    props.parsedData['twitterDescription']
+  );
+
   const [shortName, setShortName] = useState(props.parsedData['shortName']);
   const [siteUrl, setSiteUrl] = useState(props.parsedData['siteUrl']);
   const [color, setColor] = useState(props.parsedData['color']);
@@ -139,6 +159,13 @@ export default function SiteInfoSettings(props) {
   );
 
   useEffect(() => {
+    setSearchTitle(props.parsedData['searchTitle']);
+    setSearchDescription(props.parsedData['searchDescription']);
+    setFacebookTitle(props.parsedData['facebookTitle']);
+    setFacebookDescription(props.parsedData['facebookDescription']);
+    setTwitterTitle(props.parsedData['twitterTitle']);
+    setTwitterDescription(props.parsedData['twitterDescription']);
+
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
     setColor(props.parsedData['color']);
@@ -156,7 +183,7 @@ export default function SiteInfoSettings(props) {
       <SettingsHeader>Site Information</SettingsHeader>
 
       <SiteInfoFieldsContainer>
-        <label for="shortName">
+        <label htmlFor="shortName">
           <span tw="mt-1 font-bold">Site name</span>
           <input
             type="text"
@@ -165,7 +192,7 @@ export default function SiteInfoSettings(props) {
             onChange={props.handleChange}
           />
         </label>
-        <label for="siteUrl">
+        <label htmlFor="siteUrl">
           <span tw="mt-1 font-bold">Site URL</span>
           <input
             type="text"
@@ -174,7 +201,7 @@ export default function SiteInfoSettings(props) {
             onChange={props.handleChange}
           />
         </label>
-        <label for="logo">
+        <label htmlFor="logo">
           <span tw="mt-1 font-bold">Logo</span>
           <input type="file" name="logo" onChange={props.handleChange} />
         </label>
@@ -309,7 +336,7 @@ export default function SiteInfoSettings(props) {
               />
               <div tw="grid grid-cols-1">
                 <span>Custom</span>
-                <label for="primaryColor">
+                <label htmlFor="primaryColor">
                   <input
                     type="text"
                     name="primaryColor"
@@ -337,7 +364,7 @@ export default function SiteInfoSettings(props) {
         </SettingsHeader>
 
         <div tw="col-span-2">
-          <label for="heading">
+          <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
             <input
               tw="w-full"
@@ -347,7 +374,7 @@ export default function SiteInfoSettings(props) {
               onChange={props.handleChange}
             />
           </label>
-          <label for="description">
+          <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
             <input
               tw="w-full"
@@ -371,7 +398,7 @@ export default function SiteInfoSettings(props) {
         </SettingsHeader>
 
         <div tw="col-span-2">
-          <label for="heading">
+          <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
             <input
               tw="w-full"
@@ -381,7 +408,7 @@ export default function SiteInfoSettings(props) {
               onChange={props.handleChange}
             />
           </label>
-          <label for="description">
+          <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
             <input
               tw="w-full"
@@ -398,6 +425,84 @@ export default function SiteInfoSettings(props) {
           <MembershipBlock metadata={props.parsedData} />
         </div>
       </MembershipContainer>
+      <SeoContainer>
+        <SettingsHeader tw="col-span-3 mt-5">
+          SEO and Social Metadata
+        </SettingsHeader>
+
+        <div tw="mt-2">
+          <label htmlFor="searchTitle">
+            <span tw="mt-1 font-bold">Search title</span>
+            <input
+              tw="w-full rounded-md border-solid border-gray-300"
+              type="text"
+              name="searchTitle"
+              value={searchTitle}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="mt-2">
+          <label htmlFor="searchDescription">
+            <span tw="mt-1 font-bold">Search description</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="searchDescription"
+              value={searchDescription}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="mt-2">
+          <label htmlFor="facebookTitle">
+            <span tw="mt-1 font-bold">Facebook title</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="facebookTitle"
+              value={facebookTitle}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="mt-2">
+          <label htmlFor="facebookDescription">
+            <span tw="mt-1 font-bold">Facebook description</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="facebookDescription"
+              value={facebookDescription}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="mt-2">
+          <label htmlFor="twitterTitle">
+            <span tw="mt-1 font-bold">Twitter title</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="twitterTitle"
+              value={twitterTitle}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="mt-2">
+          <label htmlFor="twitterDescription">
+            <span tw="mt-1 font-bold">Twitter description</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="twitterDescription"
+              value={twitterDescription}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+      </SeoContainer>
     </div>
   );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import tw, { css, styled } from 'twin.macro';
+import MembershipBlock from '../plugins/MembershipBlock';
 import NewsletterBlock from '../plugins/NewsletterBlock';
 
 const SettingsHeader = tw.h1`text-4xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
 const DesignContainer = tw.div`grid grid-cols-2 gap-4`;
+const MembershipContainer = tw.div`grid grid-cols-3 gap-8`;
 const NewsletterContainer = tw.div`grid grid-cols-3 gap-8`;
 const DesignHeader = tw.h1`text-2xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SingleColumnContainer = tw.div`grid grid-cols-1 gap-4`;
@@ -123,6 +125,12 @@ export default function SiteInfoSettings(props) {
     props.parsedData['secondaryColor']
   );
   const [theme, setTheme] = useState(props.parsedData['theme']);
+  const [membershipHed, setMembershipHed] = useState(
+    props.parsedData['membershipHed']
+  );
+  const [membershipDek, setMembershipDek] = useState(
+    props.parsedData['membershipDek']
+  );
   const [newsletterHed, setNewsletterHed] = useState(
     props.parsedData['newsletterHed']
   );
@@ -137,6 +145,8 @@ export default function SiteInfoSettings(props) {
     setTheme(props.parsedData['theme']);
     setPrimaryColor(props.parsedData['primaryColor']);
     setSecondaryColor(props.parsedData['secondaryColor']);
+    setMembershipDek(props.parsedData['membershipDek']);
+    setMembershipHed(props.parsedData['membershipHed']);
     setNewsletterDek(props.parsedData['newsletterDek']);
     setNewsletterHed(props.parsedData['newsletterHed']);
   }, [props.parsedData]);
@@ -354,6 +364,40 @@ export default function SiteInfoSettings(props) {
           <NewsletterBlock metadata={props.parsedData} />
         </div>
       </NewsletterContainer>
+
+      <MembershipContainer>
+        <SettingsHeader tw="col-span-3 mt-5">
+          Membership promotion block
+        </SettingsHeader>
+
+        <div tw="col-span-2">
+          <label for="heading">
+            <span tw="w-full mt-1 font-bold">Heading</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="membershipHed"
+              value={membershipHed}
+              onChange={props.handleChange}
+            />
+          </label>
+          <label for="description">
+            <span tw="mt-1 font-bold">Description</span>
+            <input
+              tw="w-full"
+              type="text"
+              name="membershipDek"
+              value={membershipDek}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="col-span-1">
+          <span tw="mt-1 font-bold">Preview</span>
+
+          <MembershipBlock metadata={props.parsedData} />
+        </div>
+      </MembershipContainer>
     </div>
   );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -148,6 +148,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <input
                 type="radio"
+                name="theme"
                 value="styleone"
                 checked={props.theme === 'styleone'}
                 onChange={props.handleChange}
@@ -163,6 +164,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <input
                 type="radio"
+                name="theme"
                 value="styletwo"
                 checked={props.theme === 'styletwo'}
                 onChange={props.handleChange}
@@ -179,6 +181,7 @@ export default function SiteInfoSettings(props) {
               <input
                 type="radio"
                 value="stylethree"
+                name="theme"
                 checked={props.theme === 'stylethree'}
                 onChange={props.handleChange}
               />
@@ -193,6 +196,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <input
                 type="radio"
+                name="theme"
                 value="stylefour"
                 checked={props.theme === 'stylefour'}
                 onChange={props.handleChange}
@@ -213,6 +217,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <ColorRadioFloat
                 type="radio"
+                name="color"
                 value="colorone"
                 checked={props.color === 'colorone'}
                 onChange={props.handleChange}
@@ -227,6 +232,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <ColorRadioFloat
                 type="radio"
+                name="color"
                 value="colortwo"
                 checked={props.color === 'colortwo'}
                 onChange={props.handleChange}
@@ -241,6 +247,7 @@ export default function SiteInfoSettings(props) {
             <label>
               <ColorRadioFloat
                 type="radio"
+                name="color"
                 value="colorthree"
                 checked={props.color === 'colorthree'}
                 onChange={props.handleChange}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -115,6 +115,10 @@ const ColorThreeSecondaryBox = styled.div(
   `
 );
 
+const Input = styled.input`
+  ${tw`px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+
 export default function SiteInfoSettings(props) {
   const [searchTitle, setSearchTitle] = useState(
     props.parsedData['searchTitle']
@@ -176,7 +180,7 @@ export default function SiteInfoSettings(props) {
     setMembershipHed(props.parsedData['membershipHed']);
     setNewsletterDek(props.parsedData['newsletterDek']);
     setNewsletterHed(props.parsedData['newsletterHed']);
-  }, [props.parsedData, window.location]);
+  }, [props.parsedData]);
 
   return (
     <div tw="space-x-4 space-y-4">
@@ -185,7 +189,7 @@ export default function SiteInfoSettings(props) {
       <SiteInfoFieldsContainer>
         <label htmlFor="shortName">
           <span tw="mt-1 font-bold">Site name</span>
-          <input
+          <Input
             type="text"
             name="shortName"
             value={shortName}
@@ -194,7 +198,7 @@ export default function SiteInfoSettings(props) {
         </label>
         <label htmlFor="siteUrl">
           <span tw="mt-1 font-bold">Site URL</span>
-          <input
+          <Input
             type="text"
             name="siteUrl"
             value={siteUrl}
@@ -203,7 +207,7 @@ export default function SiteInfoSettings(props) {
         </label>
         <label htmlFor="logo">
           <span tw="mt-1 font-bold">Logo</span>
-          <input type="file" name="logo" onChange={props.handleChange} />
+          <Input type="file" name="logo" onChange={props.handleChange} />
         </label>
       </SiteInfoFieldsContainer>
 
@@ -337,14 +341,14 @@ export default function SiteInfoSettings(props) {
               <div tw="grid grid-cols-1">
                 <span>Custom</span>
                 <label htmlFor="primaryColor">
-                  <input
+                  <Input
                     type="text"
                     name="primaryColor"
                     placeholder="Primary color (use hex code)"
                     value={primaryColor}
                     onChange={props.handleChange}
                   />
-                  <input
+                  <Input
                     type="text"
                     name="secondaryColor"
                     placeholder="Secondary color (use hex code)"
@@ -366,8 +370,7 @@ export default function SiteInfoSettings(props) {
         <div tw="col-span-2">
           <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
-            <input
-              tw="w-full"
+            <Input
               type="text"
               name="newsletterHed"
               value={newsletterHed}
@@ -376,8 +379,7 @@ export default function SiteInfoSettings(props) {
           </label>
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
-            <input
-              tw="w-full"
+            <Input
               type="text"
               name="newsletterDek"
               value={newsletterDek}
@@ -400,8 +402,7 @@ export default function SiteInfoSettings(props) {
         <div tw="col-span-2">
           <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
-            <input
-              tw="w-full"
+            <Input
               type="text"
               name="membershipHed"
               value={membershipHed}
@@ -410,8 +411,7 @@ export default function SiteInfoSettings(props) {
           </label>
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
-            <input
-              tw="w-full"
+            <Input
               type="text"
               name="membershipDek"
               value={membershipDek}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -259,6 +259,34 @@ export default function SiteInfoSettings(props) {
                 <ColorLabel>Secondary</ColorLabel>
               </ColorContainer>
             </label>
+            <label>
+              <ColorRadioFloat
+                type="radio"
+                name="color"
+                value="custom"
+                checked={props.color === 'custom'}
+                onChange={props.handleChange}
+              />
+              <div tw="grid grid-cols-1">
+                <span>Custom</span>
+                <label for="primaryColor">
+                  <input
+                    type="text"
+                    name="primaryColor"
+                    placeholder="Primary color (use hex code)"
+                    value={props.primaryColor}
+                    onChange={props.handleChange}
+                  />
+                  <input
+                    type="text"
+                    name="secondaryColor"
+                    placeholder="Secondary color (use hex code)"
+                    value={props.secondaryColor}
+                    onChange={props.handleChange}
+                  />
+                </label>
+              </div>
+            </label>
           </SingleColumnContainer>
         </div>
       </DesignContainer>

--- a/components/tinycms/Upload.js
+++ b/components/tinycms/Upload.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import S3 from 'react-aws-s3';
+import tw from 'twin.macro';
 
+const UploadButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-700 hover:bg-blue-500 text-white md:rounded`;
 export default function Upload(props) {
   const fileInput = useRef();
   const [imageSrc, setImageSrc] = useState(props.bioImage);
@@ -43,38 +45,11 @@ export default function Upload(props) {
 
   return (
     <>
-      <article className="media">
-        <figure className="media-left">
-          <p
-            className="image is-128x128"
-            style={{ height: '128px', width: '128px' }}
-          >
-            <img src={imageSrc} key={randomKey} />
-          </p>
-        </figure>
-        <div className="media-content">
-          <div className="content">
-            <form className="upload-steps" onSubmit={handleClick}>
-              <div className="file">
-                <label className="file-label">
-                  <input className="file-input" type="file" ref={fileInput} />
-                  <span className="file-cta">
-                    <span className="file-icon">
-                      <i className="fas fa-upload"></i>
-                    </span>
-                    <span className="file-label">Choose a file…</span>
-                  </span>
-                </label>
-              </div>
-              <div className="field">
-                <p className="control">
-                  <button type="submit">Upload</button>
-                </p>
-              </div>
-            </form>
-          </div>
-        </div>
-      </article>
+      <img src={imageSrc} key={randomKey} />
+      <form className="upload-steps" onSubmit={handleClick}>
+        <input className="file-input" type="file" ref={fileInput} />
+        <UploadButton type="submit" value="Upload" />
+      </form>
     </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/runtime": "^7.13.10",
     "@fullhuman/postcss-purgecss": "^3.1.3",
     "@mailchimp/mailchimp_marketing": "^3.0.36",
+    "@tailwindcss/forms": "^0.3.2",
     "bulma": "^0.9.0",
     "chart.js": "^2.9.4",
     "commander": "^7.1.0",

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
+import tw, { css, styled } from 'twin.macro';
 import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraGetAuthorById, hasuraUpdateAuthor } from '../../../lib/authors';
@@ -11,6 +11,15 @@ import {
   slugify,
   validateAuthorName,
 } from '../../../lib/utils.js';
+
+const Input = styled.input`
+  ${tw`px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const TextArea = styled.textarea`
+  ${tw`px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function EditAuthor({
   apiUrl,
@@ -139,13 +148,12 @@ export default function EditAuthor({
         />
       )}
 
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Edit Author"
-          id={author.id}
-        />
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Edit Author
+          </h1>
+        </div>
 
         {displayUpload && (
           <Upload
@@ -160,110 +168,74 @@ export default function EditAuthor({
         )}
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="name">
-              Name
+          <label htmlFor="name">
+            <span tw="block font-medium text-gray-700">Name</span>
+            <Input
+              type="text"
+              value={name}
+              name="name"
+              onChange={(ev) => updateName(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="twitter">
+            <span tw="block font-medium text-gray-700">Twitter</span>
+            <Input
+              type="text"
+              value={twitter}
+              name="twitter"
+              placeholder="@handle"
+              onChange={(ev) => updateTwitter(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="bio">
+            <span tw="block font-medium text-gray-700">Bio</span>
+            <TextArea
+              tw="mt-1 block w-full"
+              rows="3"
+              value={bio}
+              name="bio"
+              onChange={(ev) => setBio(ev.target.value)}
+            />
+          </label>
+
+          <div tw="grid grid-cols-2 mt-4">
+            <label>
+              <input
+                type="radio"
+                name="staff"
+                value="yes"
+                checked={staffYesNo === 'yes'}
+                onChange={handleChange}
+              />{' '}
+              <span tw="font-medium text-gray-700">Staff</span>
             </label>
-            <div className="control">
+            <label>
               <input
-                className="input"
-                type="text"
-                value={name}
-                name="name"
-                onChange={(ev) => updateName(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
+                type="radio"
+                name="staff"
+                value="no"
+                checked={staffYesNo === 'no'}
+                onChange={handleChange}
+              />{' '}
+              <span tw="font-medium text-gray-700">Not Staff</span>
             </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
           </div>
 
-          <div className="field">
-            <label className="label" htmlFor="twitter">
-              Twitter
-            </label>
-            <div className="control has-icons-left">
-              <input
-                className="input"
-                type="text"
-                value={twitter}
-                name="twitter"
-                onChange={(ev) => updateTwitter(ev.target.value)}
-              />
-              <span className="icon is-small is-left">@</span>
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="bio">
-              Bio
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={bio}
-                name="Twitter"
-                onChange={(ev) => setBio(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <div className="control">
-              <label className="radio">
-                <input
-                  type="radio"
-                  name="staff"
-                  value="yes"
-                  checked={staffYesNo === 'yes'}
-                  onChange={handleChange}
-                />{' '}
-                Staff
-              </label>
-              <label className="radio">
-                <input
-                  type="radio"
-                  name="staff"
-                  value="no"
-                  checked={staffYesNo === 'no'}
-                  onChange={handleChange}
-                />{' '}
-                Not Staff
-              </label>
-            </div>
-          </div>
-
-          <div className="field is-grouped">
-            <div className="control">
-              <input
-                className="button is-link"
-                name="submit"
-                type="submit"
-                value="Submit"
-              />
-            </div>
-            <div className="control">
-              <button
-                className="button is-link is-light"
-                name="cancel"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -40,6 +40,11 @@ export default function AddAuthor({
 
   const router = useRouter();
 
+  async function handleCancel(ev) {
+    ev.preventDefault();
+    router.push('/tinycms/authors');
+  }
+
   // removes leading @ from twitter handle before storing
   function updateTwitter(val) {
     let cleanedUpVal = val.replace(/@/, '');
@@ -198,7 +203,7 @@ export default function AddAuthor({
 
           <div tw="grid grid-cols-4 gap-24 mt-4">
             <SubmitButton type="submit" value="Submit" />
-            <CancelButton>Cancel</CancelButton>
+            <CancelButton onClick={handleCancel}>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -1,13 +1,22 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import tw, { css, styled } from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateAuthor } from '../../../lib/authors';
 import { validateAuthorName, slugify } from '../../../lib/utils.js';
+
+const Input = styled.input`
+  ${tw`px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const TextArea = styled.textarea`
+  ${tw`px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function AddAuthor({
   apiUrl,
@@ -103,13 +112,12 @@ export default function AddAuthor({
           notificationType={notificationType}
         />
       )}
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Add an Author"
-        />
-
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Add Author
+          </h1>
+        </div>
         {displayUpload && (
           <Upload
             awsConfig={awsConfig}
@@ -123,99 +131,74 @@ export default function AddAuthor({
         )}
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="name">
-              Name
-            </label>
-            <div className="control">
+          <label htmlFor="name">
+            <span tw="block font-medium text-gray-700">Name</span>
+            <Input
+              type="text"
+              value={name}
+              name="name"
+              onChange={(ev) => updateName(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="twitter">
+            <span tw="block font-medium text-gray-700">Twitter</span>
+            <Input
+              type="text"
+              value={twitter}
+              name="twitter"
+              placeholder="@handle"
+              onChange={(ev) => updateTwitter(ev.target.value)}
+            />
+          </label>
+
+          <label htmlFor="bio">
+            <span tw="block font-medium text-gray-700">Bio</span>
+            <TextArea
+              tw="mt-1 block w-full"
+              rows="3"
+              value={bio}
+              name="bio"
+              onChange={(ev) => setBio(ev.target.value)}
+            />
+          </label>
+
+          <div tw="grid grid-cols-2 mt-4">
+            <label>
               <input
-                className="input"
-                type="text"
-                value={name}
-                name="name"
-                onChange={(ev) => updateName(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
+                type="radio"
+                name="staff"
+                value="yes"
+                checked={staff === 'yes'}
+                onChange={handleChange}
+              />{' '}
+              <span tw="font-medium text-gray-700">Staff</span>
             </label>
-            <div className="control">
+            <label>
               <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <label className="label" htmlFor="twitter">
-              Twitter
+                type="radio"
+                name="staff"
+                value="no"
+                checked={staff === 'no'}
+                onChange={handleChange}
+              />{' '}
+              <span tw="font-medium text-gray-700">Not Staff</span>
             </label>
-            <div className="control has-icons-left">
-              <input
-                className="input"
-                type="text"
-                value={twitter}
-                name="twitter"
-                onChange={(ev) => updateTwitter(ev.target.value)}
-              />
-              <span className="icon is-small is-left">@</span>
-            </div>
           </div>
 
-          <div className="field">
-            <label className="label" htmlFor="bio">
-              Bio
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={bio}
-                name="Twitter"
-                onChange={(ev) => setBio(ev.target.value)}
-              />
-            </div>
-          </div>
-
-          <div className="field">
-            <div className="control">
-              <label className="radio">
-                <input
-                  type="radio"
-                  name="staff"
-                  value="yes"
-                  checked={staff === 'yes'}
-                  onChange={handleChange}
-                />{' '}
-                Staff
-              </label>
-              <label className="radio">
-                <input
-                  type="radio"
-                  name="staff"
-                  value="no"
-                  checked={staff === 'no'}
-                  onChange={handleChange}
-                />{' '}
-                Not Staff
-              </label>
-            </div>
-          </div>
-
-          <div className="field is-grouped">
-            <div className="control">
-              <input type="submit" className="button is-link" value="Submit" />
-            </div>
-            <div className="control">
-              <button className="button is-link is-light">Cancel</button>
-            </div>
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import tw from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout.js';
-import LocaleSwitcher from '../../../components/tinycms/LocaleSwitcher';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraListAllAuthors } from '../../../lib/authors.js';
@@ -64,7 +63,9 @@ export default function Authors({ authors, currentLocale, locales }) {
 
     return (
       <TableRow key={author.id}>
-        <TableCell>{author.name}</TableCell>
+        <TableCell>
+          <Link href={`/tinycms/authors/${author.id}`}>{author.name}</Link>
+        </TableCell>
         <TableCell tw="content-center">{staff}</TableCell>
         <TableCell>{title}</TableCell>
         <TableCell>{author.twitter}</TableCell>
@@ -84,6 +85,12 @@ export default function Authors({ authors, currentLocale, locales }) {
         />
       )}
       <div tw="container mx-auto">
+        <div tw="px-10 pt-5">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Authors
+          </h1>
+        </div>
+
         <div tw="flex pt-8 justify-end">
           <Link href="/tinycms/authors/add">
             <AddAuthorButton>Add Author</AddAuthorButton>

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -1,12 +1,21 @@
 import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import tw from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout.js';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
+import LocaleSwitcher from '../../../components/tinycms/LocaleSwitcher';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraListAllAuthors } from '../../../lib/authors.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
+
+const Table = tw.table`table-auto w-full`;
+const TableHead = tw.thead``;
+const TableBody = tw.tbody``;
+const TableRow = tw.tr``;
+const TableHeader = tw.th`px-4 py-2`;
+const TableCell = tw.td`border px-4 py-2`;
+const AddAuthorButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 
 export default function Authors({ authors, currentLocale, locales }) {
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -31,15 +40,36 @@ export default function Authors({ authors, currentLocale, locales }) {
 
   const listItems = authors.map((author) => {
     let title = hasuraLocaliseText(author.author_translations, 'title');
+    let bio = hasuraLocaliseText(author.author_translations, 'bio');
+    let staff = author.staff ? (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        height="24"
+        width="24"
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+    ) : (
+      ''
+    );
 
     return (
-      <li key={author.id}>
-        <Link key={`${author.id}-link`} href={`/tinycms/authors/${author.id}`}>
-          <a>
-            {author.name}, {title}
-          </a>
-        </Link>
-      </li>
+      <TableRow key={author.id}>
+        <TableCell>{author.name}</TableCell>
+        <TableCell tw="content-center">{staff}</TableCell>
+        <TableCell>{title}</TableCell>
+        <TableCell>{author.twitter}</TableCell>
+        <TableCell>{bio}</TableCell>
+      </TableRow>
     );
   });
 
@@ -53,21 +83,25 @@ export default function Authors({ authors, currentLocale, locales }) {
           notificationType={notificationType}
         />
       )}
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Authors"
-        />
-
-        {/* {message && <div className="success">{message}</div>} */}
-        <ul>{listItems}</ul>
-
-        <section className="section">
+      <div tw="container mx-auto">
+        <div tw="flex pt-8 justify-end">
           <Link href="/tinycms/authors/add">
-            <button className="button">Add an Author</button>
+            <AddAuthorButton>Add Author</AddAuthorButton>
           </Link>
-        </section>
+        </div>
+
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Staff</TableHeader>
+              <TableHeader>Title</TableHeader>
+              <TableHeader>Twitter</TableHeader>
+              <TableHeader>Bio</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>{listItems}</TableBody>
+        </Table>
       </div>
     </AdminLayout>
   );

--- a/pages/tinycms/index.js
+++ b/pages/tinycms/index.js
@@ -93,8 +93,8 @@ export default function TinyCmsHome(props) {
             </CardIcon>
             <CardContentContainer>
               <CardHeader>
-                <Link href="/tinycms/metadata">
-                  <a href="/tinycms/metadata">Settings</a>
+                <Link href="/tinycms/settings">
+                  <a href="/tinycms/settings">Settings</a>
                 </Link>
               </CardHeader>
               <CardContent>

--- a/pages/tinycms/index.js
+++ b/pages/tinycms/index.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { hasuraListLocales } from '../../lib/articles.js';
 import AdminLayout from '../../components/AdminLayout.js';
 import AdminNav from '../../components/nav/AdminNav';
-import AdminHeader from '../../components/tinycms/AdminHeader';
 import tw from 'twin.macro';
 
 const CardsContainer = tw.section`min-h-screen flex items-center justify-center px-4 bg-white grid grid-cols-2 gap-2`;

--- a/pages/tinycms/index.js
+++ b/pages/tinycms/index.js
@@ -18,12 +18,6 @@ export default function TinyCmsHome(props) {
     <AdminLayout>
       <AdminNav homePageEditor={false} showConfigOptions={true} />
       <div id="page">
-        <AdminHeader
-          locales={props.locales}
-          currentLocale={props.currentLocale}
-          title="tinycms site config"
-        />
-
         <CardsContainer>
           <Card>
             <CardIcon>

--- a/pages/tinycms/sections/[id].js
+++ b/pages/tinycms/sections/[id].js
@@ -1,14 +1,20 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import tw, { css, styled } from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout';
 import {
   hasuraGetSectionById,
   hasuraUpdateSection,
 } from '../../../lib/section';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraLocaliseText } from '../../../lib/utils';
+
+const Input = styled.input`
+  ${tw`mb-5 px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function EditSection({
   apiUrl,
@@ -88,82 +94,47 @@ export default function EditSection({
         />
       )}
 
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Edit Section"
-          id={section.id}
-        />
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Edit Section
+          </h1>
+        </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
 
-          <div className="field">
-            <label className="label" htmlFor="slug">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => setSlug(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="slug">
+            <span tw="block font-medium text-gray-700">Slug</span>
+            <Input
+              type="text"
+              value={slug}
+              name="slug"
+              onChange={(ev) => setSlug(ev.target.value)}
+            />
+          </label>
 
-          <div className="field">
-            <label className="checkbox" htmlFor="slug">
-              <input
-                name="published"
-                type="checkbox"
-                checked={published}
-                onChange={handlePublished}
-              />
-              Published
-            </label>
-          </div>
+          <label tw="mt-5" htmlFor="published">
+            <input
+              name="published"
+              type="checkbox"
+              checked={published}
+              onChange={handlePublished}
+            />
+            <span tw="ml-5 font-medium text-gray-700">Published</span>
+          </label>
 
-          <div className="level">
-            <div className="level-left">
-              <div className="level-item">
-                <div className="control">
-                  <input
-                    className="button is-link"
-                    name="submit"
-                    type="submit"
-                    value="Submit"
-                  />
-                </div>
-                <div className="control">
-                  <button
-                    className="button is-link is-light"
-                    name="cancel"
-                    onClick={handleCancel}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div className="level-right">
-              <div className="level-item"></div>
-            </div>
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/sections/add.js
+++ b/pages/tinycms/sections/add.js
@@ -1,11 +1,17 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import tw, { css, styled } from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateSection } from '../../../lib/section';
+
+const Input = styled.input`
+  ${tw`mb-5 px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function AddSection({
   apiUrl,
@@ -18,9 +24,19 @@ export default function AddSection({
   const [showNotification, setShowNotification] = useState(false);
   const [title, setTitle] = useState('');
   const [slug, setSlug] = useState('');
+  const [published, setPublished] = useState(false);
   const [errors, setErrors] = useState([]);
 
   const router = useRouter();
+
+  function handlePublished(event) {
+    const value =
+      event.target.type === 'checkbox'
+        ? event.target.checked
+        : event.target.value;
+
+    setPublished(value);
+  }
 
   async function handleCancel(ev) {
     ev.preventDefault();
@@ -95,57 +111,48 @@ export default function AddSection({
           notificationType={notificationType}
         />
       )}
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Add a Section"
-        />
+
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Add Section
+          </h1>
+        </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
 
-          <div className="field">
-            <label className="label" htmlFor="data">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => setSlug(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="slug">
+            <span tw="block font-medium text-gray-700">Slug</span>
+            <Input
+              type="text"
+              value={slug}
+              name="slug"
+              onChange={(ev) => setSlug(ev.target.value)}
+            />
+          </label>
 
-          <div className="field is-grouped">
-            <div className="control">
-              <input type="submit" className="button is-link" value="Submit" />
-            </div>
-            <div className="control">
-              <button
-                className="button is-link is-light"
-                name="cancel"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
+          <label tw="mt-5" htmlFor="published">
+            <input
+              name="published"
+              type="checkbox"
+              checked={published}
+              onChange={handlePublished}
+            />
+            <span tw="ml-5 font-medium text-gray-700">Published</span>
+          </label>
+
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton onClick={handleCancel}>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/sections/index.js
+++ b/pages/tinycms/sections/index.js
@@ -3,9 +3,17 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
+import tw from 'twin.macro';
 import { hasuraLocaliseText } from '../../../lib/utils';
 import { hasuraListAllSectionsByLocale } from '../../../lib/section.js';
+
+const Table = tw.table`table-auto w-full`;
+const TableHead = tw.thead``;
+const TableBody = tw.tbody``;
+const TableRow = tw.tr``;
+const TableHeader = tw.th`px-4 py-2`;
+const TableCell = tw.td`border px-4 py-2`;
+const AddSectionButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 
 export default function Sections({ sections, currentLocale, locales }) {
   const [message, setMessage] = useState(null);
@@ -25,36 +33,53 @@ export default function Sections({ sections, currentLocale, locales }) {
   const listItems = sections.map((section) => {
     let title = hasuraLocaliseText(section.category_translations, 'title');
     return (
-      <li key={section.id}>
-        <Link
-          key={`${section.id}-link`}
-          href={`/tinycms/sections/${section.id}`}
-        >
-          <a>{title}</a>
-        </Link>{' '}
-        ({section.slug})
-      </li>
+      <TableRow key={section.id}>
+        <TableCell>
+          <Link
+            key={`${section.id}-link`}
+            href={`/tinycms/sections/${section.id}`}
+          >
+            <a>{title}</a>
+          </Link>
+        </TableCell>
+        <TableCell>{section.slug}</TableCell>
+      </TableRow>
     );
   });
 
   return (
     <AdminLayout>
       <AdminNav homePageEditor={false} showConfigOptions={true} />
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Sections"
-        />
+      <div tw="container mx-auto">
+        <div tw="px-10 pt-5">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Sections
+          </h1>
+        </div>
 
         {message && <div className="success">{message}</div>}
-        <ul>{listItems}</ul>
 
-        <section className="section">
-          <Link href="/tinycms/sections/add">
-            <button className="button">Add Section</button>
+        <div tw="flex pt-8 justify-end">
+          <Link href="/tinycms/authors/add">
+            <AddSectionButton>Add Section</AddSectionButton>
           </Link>
-        </section>
+        </div>
+
+        <Table tw="mb-10">
+          <TableHead>
+            <TableRow>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Slug</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>{listItems}</TableBody>
+        </Table>
+
+        <div tw="flex pt-8 justify-end">
+          <Link href="/tinycms/sections/add">
+            <AddSectionButton>Add Section</AddSectionButton>
+          </Link>
+        </div>
       </div>
     </AdminLayout>
   );

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -7,7 +7,7 @@ import AdminHeader from '../../../components/tinycms/AdminHeader';
 import UpdateMetadata from '../../../components/tinycms/UpdateSiteMetadata.js';
 import newsletterStyles from '../../../styles/newsletter.js';
 
-export default function Metadata({
+export default function Settings({
   apiUrl,
   apiToken,
   currentLocale,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -67,27 +67,22 @@ export default function Settings({
   useEffect(() => {
     if (window.location.hash && window.location.hash === '#siteInfo') {
       if (siteInfoRef) {
-        console.log('scrolling to siteInfo');
         siteInfoRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (window.location.hash && window.location.hash === '#design') {
       if (designRef) {
-        console.log('scrolling to design');
         designRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (window.location.hash && window.location.hash === '#newsletter') {
       if (newsletterRef) {
-        console.log('scrolling to newsletter');
         newsletterRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (window.location.hash && window.location.hash === '#membership') {
       if (membershipRef) {
-        console.log('scrolling to membership');
         membershipRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (window.location.hash && window.location.hash === '#seo') {
       if (seoRef) {
-        console.log('scrolling to seo');
         seoRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import tw from 'twin.macro';
 import { hasuraGetMetadataByLocale } from '../../../lib/articles.js';
@@ -8,7 +9,6 @@ import SiteInfoSettings from '../../../components/tinycms/SiteInfoSettings';
 import newsletterStyles from '../../../styles/newsletter.js';
 import { hasuraUpsertMetadata } from '../../../lib/site_metadata';
 import Notification from '../../../components/tinycms/Notification';
-import { SingleDatePicker } from 'react-dates';
 
 const Container = tw.div`flex flex-wrap -mx-2 mb-8`;
 const Sidebar = tw.div`h-full h-screen bg-gray-100 md:w-1/5 lg:w-1/5 px-2 mb-4`;
@@ -26,6 +26,11 @@ export default function Settings({
   siteMetadata,
   locales,
 }) {
+  const siteInfoRef = useRef();
+  const designRef = useRef();
+  const newsletterRef = useRef();
+  const membershipRef = useRef();
+  const seoRef = useRef();
   const [message, setMessage] = useState(null);
   const [metadata, setMetadata] = useState(null);
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -60,6 +65,32 @@ export default function Settings({
     }
   };
   useEffect(() => {
+    if (window.location.hash && window.location.hash === '#siteInfo') {
+      if (siteInfoRef) {
+        console.log('scrolling to siteInfo');
+        siteInfoRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (window.location.hash && window.location.hash === '#design') {
+      if (designRef) {
+        console.log('scrolling to design');
+        designRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (window.location.hash && window.location.hash === '#newsletter') {
+      if (newsletterRef) {
+        console.log('scrolling to newsletter');
+        newsletterRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (window.location.hash && window.location.hash === '#membership') {
+      if (membershipRef) {
+        console.log('scrolling to membership');
+        membershipRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (window.location.hash && window.location.hash === '#seo') {
+      if (seoRef) {
+        console.log('scrolling to seo');
+        seoRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
     if (siteMetadata) {
       let md = siteMetadata.site_metadata_translations[0].data;
       setMetadata(md);
@@ -125,11 +156,31 @@ export default function Settings({
           <LightSidebar>
             <SidebarHeading>Navigation</SidebarHeading>
             <ul>
-              <li>Site Information</li>
-              <li>Design</li>
-              <li>Newsletter Block</li>
-              <li>Membership Block</li>
-              <li>SEO/Social</li>
+              <li>
+                <Link href="/tinycms/settings#siteInfo">
+                  <a href="/tinycms/settings#siteInfo">Site Information</a>
+                </Link>
+              </li>
+              <li>
+                <Link href="/tinycms/settings#design">
+                  <a href="/tinycms/settings#design">Design</a>
+                </Link>
+              </li>
+              <li>
+                <Link href="/tinycms/settings#newsletter">
+                  <a href="/tinycms/settings#newsletter">Newsletter Block</a>
+                </Link>
+              </li>
+              <li>
+                <Link href="/tinycms/settings#membership">
+                  <a href="/tinycms/settings#membership">Membership Block</a>
+                </Link>
+              </li>
+              <li>
+                <Link href="/tinycms/settings#seo">
+                  <a href="/tinycms/settings#seo">SEO/Social</a>
+                </Link>
+              </li>
             </ul>
             <SaveContainer>
               <SaveButton onClick={handleSubmit}>Save</SaveButton>
@@ -147,6 +198,11 @@ export default function Settings({
             )}
             <SettingsContainer>
               <SiteInfoSettings
+                siteInfoRef={siteInfoRef}
+                seoRef={seoRef}
+                newsletterRef={newsletterRef}
+                membershipRef={membershipRef}
+                designRef={designRef}
                 handleChange={handleChange}
                 parsedData={parsedData}
               />

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import tw from 'twin.macro';
 import { hasuraGetMetadataByLocale } from '../../../lib/articles.js';
 import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
 import SiteInfoSettings from '../../../components/tinycms/SiteInfoSettings';
+import newsletterStyles from '../../../styles/newsletter.js';
 import { hasuraUpsertMetadata } from '../../../lib/site_metadata';
 import Notification from '../../../components/tinycms/Notification';
-import tw from 'twin.macro';
+import { SingleDatePicker } from 'react-dates';
 
 const Container = tw.div`flex flex-wrap -mx-2 mb-8`;
 const Sidebar = tw.div`h-full h-screen bg-gray-100 md:w-1/5 lg:w-1/5 px-2 mb-4`;
@@ -39,6 +41,7 @@ export default function Settings({
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
+
     if (type === 'checkbox') {
       setParsedData((prevState) => ({
         ...prevState,
@@ -144,18 +147,16 @@ export default function Settings({
             )}
             <SettingsContainer>
               <SiteInfoSettings
-                shortName={parsedData['shortName']}
-                siteUrl={parsedData['siteUrl']}
-                color={parsedData['color']}
-                primaryColor={parsedData['primaryColor']}
-                secondaryColor={parsedData['secondaryColor']}
-                theme={parsedData['theme']}
                 handleChange={handleChange}
+                parsedData={parsedData}
               />
             </SettingsContainer>
           </form>
         </MainContent>
       </Container>
+      <style jsx global>
+        {newsletterStyles}
+      </style>
     </AdminLayout>
   );
 }

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -5,7 +5,15 @@ import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
 import AdminHeader from '../../../components/tinycms/AdminHeader';
 import UpdateMetadata from '../../../components/tinycms/UpdateSiteMetadata.js';
-import newsletterStyles from '../../../styles/newsletter.js';
+import tw from 'twin.macro';
+
+const Container = tw.div`flex flex-wrap -mx-2 mb-8`;
+const Sidebar = tw.div`w-full md:w-1/5 lg:w-1/5 px-2 mb-4`;
+const SidebarHeading = tw.h1`font-bold`;
+const LightSidebar = tw.div`bg-gray-100 text-black p-2`;
+const MainContent = tw.div`w-full lg:w-1/2 px-2`;
+const SettingsContainer = tw.div`min-w-0 w-full flex-auto lg:static lg:max-h-full lg:overflow-visible p-2`;
+const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
 
 export default function Settings({
   apiUrl,
@@ -35,27 +43,26 @@ export default function Settings({
   return (
     <AdminLayout>
       <AdminNav homePageEditor={false} showConfigOptions={true} />
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Site Metadata"
-        />
-        {message && <div className="success">{message}</div>}
 
-        <section className="section">
-          <UpdateMetadata
-            apiUrl={apiUrl}
-            apiToken={apiToken}
-            currentLocale={currentLocale}
-            metadata={metadata}
-            setMetadata={setMetadata}
-          />
-        </section>
-      </div>
-      <style jsx global>
-        {newsletterStyles}
-      </style>
+      <Container>
+        <Sidebar>
+          <LightSidebar>
+            <SidebarHeading>Navigation</SidebarHeading>
+            <ul>
+              <li>Site Information</li>
+              <li>Design</li>
+              <li>Newsletter Block</li>
+              <li>Membership Block</li>
+              <li>SEO/Social</li>
+            </ul>
+          </LightSidebar>
+        </Sidebar>
+        <MainContent>
+          <SettingsContainer>
+            <SettingsHeader>Site Information</SettingsHeader>
+          </SettingsContainer>
+        </MainContent>
+      </Container>
     </AdminLayout>
   );
 }

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { hasuraGetMetadataByLocale } from '../../../lib/articles.js';
 import AdminLayout from '../../../components/AdminLayout.js';
 import AdminNav from '../../../components/nav/AdminNav';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
+import SiteInfoSettings from '../../../components/tinycms/SiteInfoSettings';
 import UpdateMetadata from '../../../components/tinycms/UpdateSiteMetadata.js';
 import tw from 'twin.macro';
 
@@ -13,7 +13,6 @@ const SidebarHeading = tw.h1`font-bold`;
 const LightSidebar = tw.div`bg-gray-100 text-black p-2`;
 const MainContent = tw.div`w-full lg:w-1/2 px-2`;
 const SettingsContainer = tw.div`min-w-0 w-full flex-auto lg:static lg:max-h-full lg:overflow-visible p-2`;
-const SettingsHeader = tw.h1`text-4xl font-normal leading-normal mt-0 mb-2 text-black`;
 
 export default function Settings({
   apiUrl,
@@ -59,7 +58,7 @@ export default function Settings({
         </Sidebar>
         <MainContent>
           <SettingsContainer>
-            <SettingsHeader>Site Information</SettingsHeader>
+            <SiteInfoSettings />
           </SettingsContainer>
         </MainContent>
       </Container>

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -44,6 +44,11 @@ export default function Settings({
         ...prevState,
         [name]: checked,
       }));
+    } else if (type === 'radio') {
+      setParsedData((prevState) => ({
+        ...prevState,
+        [name]: value,
+      }));
     } else {
       setParsedData((prevState) => ({
         ...prevState,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -147,6 +147,8 @@ export default function Settings({
                 shortName={parsedData['shortName']}
                 siteUrl={parsedData['siteUrl']}
                 color={parsedData['color']}
+                primaryColor={parsedData['primaryColor']}
+                secondaryColor={parsedData['secondaryColor']}
                 theme={parsedData['theme']}
                 handleChange={handleChange}
               />

--- a/pages/tinycms/tags/[id].js
+++ b/pages/tinycms/tags/[id].js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import tw, { css, styled } from 'twin.macro';
 import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminHeader from '../../../components/tinycms/AdminHeader';
@@ -6,6 +7,12 @@ import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraGetTagById, hasuraUpdateTag } from '../../../lib/section.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
+
+const Input = styled.input`
+  ${tw`mb-5 px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function EditTag({
   apiUrl,
@@ -80,63 +87,37 @@ export default function EditTag({
         />
       )}
 
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Edit Tag"
-          id={tag.id}
-        />
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Edit Tag
+          </h1>
+        </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="slug">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => setSlug(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
 
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="slug">
+            <span tw="block font-medium text-gray-700">Slug</span>
+            <Input
+              type="text"
+              value={slug}
+              name="slug"
+              onChange={(ev) => setSlug(ev.target.value)}
+            />
+          </label>
 
-          <div className="field is-grouped">
-            <div className="control">
-              <input
-                className="button is-link"
-                name="submit"
-                type="submit"
-                value="Submit"
-              />
-            </div>
-            <div className="control">
-              <button
-                className="button is-link is-light"
-                name="cancel"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton onClick={handleCancel}>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/tags/add.js
+++ b/pages/tinycms/tags/add.js
@@ -1,11 +1,17 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import tw, { css, styled } from 'twin.macro';
 import AdminLayout from '../../../components/AdminLayout';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateTag } from '../../../lib/section';
+
+const Input = styled.input`
+  ${tw`mb-5 px-3 py-3 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+const SubmitButton = tw.input`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-green-700 hover:bg-green-500 text-white md:rounded`;
+const CancelButton = tw.button`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-gray-600 hover:bg-gray-300 text-white md:rounded`;
 
 export default function AddTag({ apiUrl, apiToken, currentLocale, locales }) {
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -61,56 +67,38 @@ export default function AddTag({ apiUrl, apiToken, currentLocale, locales }) {
           notificationType={notificationType}
         />
       )}
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Add a Tag"
-        />
+
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Add Tag
+          </h1>
+        </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="field">
-            <label className="label" htmlFor="slug">
-              Slug
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={slug}
-                name="slug"
-                onChange={(ev) => setSlug(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="title">
+            <span tw="block font-medium text-gray-700">Title</span>
+            <Input
+              type="text"
+              value={title}
+              name="title"
+              onChange={(ev) => setTitle(ev.target.value)}
+            />
+          </label>
 
-          <div className="field">
-            <label className="label" htmlFor="title">
-              Title
-            </label>
-            <div className="control">
-              <input
-                className="input"
-                type="text"
-                value={title}
-                name="title"
-                onChange={(ev) => setTitle(ev.target.value)}
-              />
-            </div>
-          </div>
+          <label htmlFor="slug">
+            <span tw="block font-medium text-gray-700">Slug</span>
+            <Input
+              type="text"
+              value={slug}
+              name="slug"
+              onChange={(ev) => setSlug(ev.target.value)}
+            />
+          </label>
 
-          <div className="field is-grouped">
-            <div className="control">
-              <input type="submit" className="button is-link" value="Submit" />
-            </div>
-            <div className="control">
-              <button
-                className="button is-link is-light"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
+          <div tw="grid grid-cols-4 gap-24 mt-4">
+            <SubmitButton type="submit" value="Submit" />
+            <CancelButton onClick={handleCancel}>Cancel</CancelButton>
           </div>
         </form>
       </div>

--- a/pages/tinycms/tags/index.js
+++ b/pages/tinycms/tags/index.js
@@ -2,11 +2,19 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from '../../../components/AdminLayout.js';
-import AdminHeader from '../../../components/tinycms/AdminHeader';
 import AdminNav from '../../../components/nav/AdminNav';
+import tw from 'twin.macro';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraListAllTags } from '../../../lib/articles.js';
 import { hasuraLocaliseText } from '../../../lib/utils.js';
+
+const Table = tw.table`table-auto w-full`;
+const TableHead = tw.thead``;
+const TableBody = tw.tbody``;
+const TableRow = tw.tr``;
+const TableHeader = tw.th`px-4 py-2`;
+const TableCell = tw.td`border px-4 py-2`;
+const AddTagButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 
 export default function Tags({ tags, currentLocale, locales }) {
   const [notificationMessage, setNotificationMessage] = useState('');
@@ -33,12 +41,14 @@ export default function Tags({ tags, currentLocale, locales }) {
     let title = hasuraLocaliseText(tag.tag_translations, 'title');
 
     return (
-      <li key={tag.id}>
-        <Link key={`${tag.id}-link`} href={`/tinycms/tags/${tag.id}`}>
-          <a>{title}</a>
-        </Link>{' '}
-        ({tag.slug})
-      </li>
+      <TableRow key={tag.id}>
+        <TableCell>
+          <Link key={`${tag.id}-link`} href={`/tinycms/tags/${tag.id}`}>
+            <a>{title}</a>
+          </Link>
+        </TableCell>
+        <TableCell>{tag.slug}</TableCell>
+      </TableRow>
     );
   });
 
@@ -52,19 +62,34 @@ export default function Tags({ tags, currentLocale, locales }) {
           notificationType={notificationType}
         />
       )}
-      <div id="page">
-        <AdminHeader
-          locales={locales}
-          currentLocale={currentLocale}
-          title="Tags"
-        />
+      <div tw="container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10 pb-24 lg:pb-16">
+        <div tw="pt-5 pb-10">
+          <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+            Tags
+          </h1>
+        </div>
 
-        <ul>{listItems}</ul>
-        <section className="section">
+        <div tw="flex pt-8 justify-end">
           <Link href="/tinycms/tags/add">
-            <button className="button">Add Tag</button>
+            <AddTagButton>Add Tag</AddTagButton>
           </Link>
-        </section>
+        </div>
+
+        <Table tw="mb-10">
+          <TableHead>
+            <TableRow>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Slug</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>{listItems}</TableBody>
+        </Table>
+
+        <div tw="flex pt-8 justify-end">
+          <Link href="/tinycms/tags/add">
+            <AddTagButton>Add Tag</AddTagButton>
+          </Link>
+        </div>
       </div>
     </AdminLayout>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,5 +7,7 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/forms'),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,6 +1315,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tailwindcss/forms@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.3.2.tgz#e28c4514a53e69f725416a5a2a6d0f221683f069"
+  integrity sha512-aj2/rJsGb2whAZ/BQWHWWQRSbhH0r/l1ozOByiv+ZNjBD84GMvb5dhAyfpeasFky+EJrAwX5eaqft8NQMZFWvA==
+  dependencies:
+    mini-svg-data-uri "^1.2.3"
+
 "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz"
@@ -7375,6 +7382,11 @@ mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
+mini-svg-data-uri@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.2.3.tgz#e16baa92ad55ddaa1c2c135759129f41910bc39f"
+  integrity sha512-zd6KCAyXgmq6FV1mR10oKXYtvmA9vRoB6xPSTUJTbFApCtkefDnYueVR1gkof3KcdLZo1Y8mjF2DFmQMIxsHNQ==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Continuing #450 

* sections: list, edit and add
* tags: list, edit and add
* all of tinycms: success and error notifications for tailwind

<img width="962" alt="Screen Shot 2021-04-16 at 11 59 58 am" src="https://user-images.githubusercontent.com/3397/114960961-6ff73400-9eab-11eb-8ad8-3e474f7beb59.png">

I think the remaining to-dos in the tinycms redesign are:

* figure out the best place to put the homepage layout switcher  in the homepage editor
* find a spot for the locale switcher (throughout all of tinycms)
* redesign analytics