### PR TITLE
combine page view stats for urls reported separately with query strings

### DIFF
--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import tw from 'twin.macro';
 import { getMetricsData } from '../../../lib/analytics';
 
@@ -7,11 +7,6 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
-  const INITIAL_STATE = {
-    labels: [],
-    values: [],
-  };
-  const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
 
   let pv = {};
 
@@ -31,33 +26,25 @@ const PageViews = (props) => {
       .then((response) => {
         const queryResult = response.result.reports[0].data.rows;
 
-        let labels = [];
-        let values = [];
-
         if (queryResult) {
           queryResult.forEach((row) => {
             let label = row.dimensions[0];
 
             if (!/tinycms/.test(label)) {
-              console.log('skip tinycms');
-
-              if (label === '/') {
-                label += ' (homepage)';
+              if (/\?/.test(label)) {
+                label = label.split('?')[0];
               }
-              let value = row.metrics[0].values[0];
+              let value = parseInt(row.metrics[0].values[0]);
 
-              labels.push(label);
-              values.push(value);
-              pv[label] = value;
+              if (pv[label]) {
+                pv[label] += value;
+              } else {
+                pv[label] = value;
+              }
             }
           });
         }
 
-        setPageViewReportData({
-          ...pageViewReportData,
-          labels,
-          values,
-        });
         props.setPageViews(pv);
 
         if (window.location.hash && window.location.hash === '#pageviews') {
@@ -87,13 +74,13 @@ const PageViews = (props) => {
           </tr>
         </thead>
         <tbody>
-          {pageViewReportData.labels.map((label, i) => (
+          {Object.keys(props.pageViews).map((label, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
                 {label}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {pageViewReportData.values[i]}
+                {props.pageViews[label]}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
Closes #480

while doing this I also simplified how these stats are being calculated, so no more arrays of labels and values, just the map of page view stats. I'll do this for other analytics components as I edit them for other reasons (charts, bug fixes) so this is more standardized.