### PR TITLE
combine page view status for urls with default locale prefix

### DIFF
--- a/components/AdminLayout.js
+++ b/components/AdminLayout.js
@@ -6,7 +6,6 @@ const SignInButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right b
 
 export default function AdminLayout({ children }) {
   const [session, loading] = useSession();
-  console.log('AdminLayout session:', session);
 
   return (
     <>

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import tw from 'twin.macro';
 import { getMetricsData } from '../../../lib/analytics';
 
@@ -7,11 +7,6 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
-  const INITIAL_STATE = {
-    labels: [],
-    values: [],
-  };
-  const [pageViewReportData, setPageViewReportData] = useState(INITIAL_STATE);
 
   let pv = {};
 
@@ -31,33 +26,25 @@ const PageViews = (props) => {
       .then((response) => {
         const queryResult = response.result.reports[0].data.rows;
 
-        let labels = [];
-        let values = [];
-
         if (queryResult) {
           queryResult.forEach((row) => {
             let label = row.dimensions[0];
 
             if (!/tinycms/.test(label)) {
-              console.log('skip tinycms');
-
-              if (label === '/') {
-                label += ' (homepage)';
+              if (/\?/.test(label)) {
+                label = label.split('?')[0];
               }
-              let value = row.metrics[0].values[0];
+              let value = parseInt(row.metrics[0].values[0]);
 
-              labels.push(label);
-              values.push(value);
-              pv[label] = value;
+              if (pv[label]) {
+                pv[label] += value;
+              } else {
+                pv[label] = value;
+              }
             }
           });
         }
 
-        setPageViewReportData({
-          ...pageViewReportData,
-          labels,
-          values,
-        });
         props.setPageViews(pv);
 
         if (window.location.hash && window.location.hash === '#pageviews') {
@@ -87,13 +74,13 @@ const PageViews = (props) => {
           </tr>
         </thead>
         <tbody>
-          {pageViewReportData.labels.map((label, i) => (
+          {Object.keys(props.pageViews).map((label, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
                 {label}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {pageViewReportData.values[i]}
+                {props.pageViews[label]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -34,6 +34,9 @@ const PageViews = (props) => {
               if (/\?/.test(label)) {
                 label = label.split('?')[0];
               }
+              if (/\/en-US\//.test(label)) {
+                label = label.replace('/en-US', '');
+              }
               let value = parseInt(row.metrics[0].values[0]);
 
               if (pv[label]) {


### PR DESCRIPTION
Closes #481 

I decided to hard code the default locale as `en-US` as I think it'll be pretty unusual for any of our tiny news orgs to use a different one. Figuring out which of the locales on a given site is the default would require additional work requesting that info, which we could do if necessary in the future.