### PR TITLE
Bugfix/small navbar fixes

### DIFF
--- a/components/nav/Donate.js
+++ b/components/nav/Donate.js
@@ -18,7 +18,7 @@ const DonateLink = styled.a(({ meta }) => ({
       : Colors[meta.color].CTAText,
 }));
 
-const Donate = ({ label, url, metadata }) => {
+const Donate = ({ label, metadata }) => {
   const { trackEvent } = useAnalytics();
 
   const trackClick = () => {
@@ -30,7 +30,7 @@ const Donate = ({ label, url, metadata }) => {
     });
   };
   return (
-    <Link href={url}>
+    <Link href="/donate">
       <DonateLink
         style={{
           minHeight: '2.375rem',
@@ -38,6 +38,7 @@ const Donate = ({ label, url, metadata }) => {
         className="site__cta button donate"
         onClick={trackClick}
         meta={metadata}
+        href="/donate"
       >
         {label}
       </DonateLink>

--- a/components/nav/GlobalNav.js
+++ b/components/nav/GlobalNav.js
@@ -38,11 +38,7 @@ export default function GlobalNav({ metadata, sections }) {
           </a>
         </Link>
         <RightNav>{sectionLinks}</RightNav>
-        <Donate
-          label={metadata.supportCTA}
-          url={metadata.supportURL}
-          metadata={metadata}
-        />
+        <Donate label={metadata.supportCTA} metadata={metadata} />
       </NavInnerContainer>
     </NavContainer>
   );

--- a/components/nav/GlobalNav.js
+++ b/components/nav/GlobalNav.js
@@ -19,7 +19,9 @@ export default function GlobalNav({ metadata, sections }) {
   if (sections && typeof sections[0].title === 'string') {
     sectionLinks = sections.slice(0, 4).map((section) => (
       <Link key={`navbar-${section.slug}`} href={`/${section.slug}`}>
-        <SectionLink meta={metadata}>{section.title}</SectionLink>
+        <SectionLink href={`/${section.slug}`} meta={metadata}>
+          {section.title}
+        </SectionLink>
       </Link>
     ));
   }

--- a/pages/tinycms/index.js
+++ b/pages/tinycms/index.js
@@ -39,7 +39,7 @@ const cardContent = [
   {
     title: 'Settings',
     description: 'Customize the look, feel and language of your website.',
-    href: '/tinycms/metadata',
+    href: '/tinycms/settings',
     icon: <CogIcon />,
   },
   {


### PR DESCRIPTION
Closes #441 (donate button now goes to the custom donate page at `/donate`)

Also fixes a small issue that's been bugging me with the nav, which is that the mouse pointer doesn't change to a hand on the desktop without an `href` on the anchor tag.

And... I fixed the metadata -> settings link on the tinycms homepage.

