### PR TITLE
fixes for background & text color setting in newsletter and mailchimp blocks

### DIFF
--- a/components/plugins/MailchimpSubscribe.js
+++ b/components/plugins/MailchimpSubscribe.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import tw, { styled } from 'twin.macro';
 import MailchimpSubscribe from 'react-mailchimp-subscribe';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
@@ -9,22 +9,36 @@ import Colors from '../common/Colors';
 const Group = tw.div`relative`;
 const Input = tw.input`block w-full border-b border-gray-500 bg-black opacity-20`;
 const Bar = tw.div``;
-const Submit = styled.input(({ meta }) => ({
+const Submit = styled.input(({ textColor, backgroundColor }) => ({
   ...tw`block absolute cursor-pointer rounded-full font-bold leading-none w-8 h-8 pl-2 right-2 z-10`,
-  backgroundColor:
-    meta.color === 'custom'
-      ? determineTextColor(meta.primaryColor)
-      : Colors[meta.color].PromoBlockCTABackground,
-  color:
-    meta.color === 'custom'
-      ? meta.primaryColor
-      : Colors[meta.color].PromoBlockCTAText,
+  backgroundColor: backgroundColor,
+  color: textColor,
 }));
 
 // you can get this url from the embed code form action
 const url = process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL;
 
 const CustomForm = ({ status, message, onValidated, metadata }) => {
+  const [textColor, setTextColor] = useState(null);
+  const [backgroundColor, setBackgroundColor] = useState(null);
+
+  useEffect(() => {
+    let bgc;
+    let tc;
+
+    if (metadata.color === 'custom') {
+      bgc = determineTextColor(metadata.primaryColor);
+      tc = metadata.primaryColor;
+    } else if (Colors[metadata.color]) {
+      tc = Colors[metadata.color].PromoBlockCTAText;
+      bgc = Colors[metadata.color].PromoBlockCTABackground;
+      console.log('unknown color', metadata.color);
+    }
+
+    setBackgroundColor(bgc);
+    setTextColor(tc);
+  }, [metadata]);
+
   let email, name;
   const submit = () =>
     email &&
@@ -71,7 +85,8 @@ const CustomForm = ({ status, message, onValidated, metadata }) => {
             fontSize: '18px',
             padding: '10px 10px 10px 5px',
           }}
-          meta={metadata}
+          textColor={textColor}
+          backgroundColor={backgroundColor}
         />
       </Group>
     </div>

--- a/components/plugins/NewsletterBlock.js
+++ b/components/plugins/NewsletterBlock.js
@@ -2,25 +2,37 @@ import tw, { styled } from 'twin.macro';
 import MailchimpSubscribe from './MailchimpSubscribe';
 import Colors from '../common/Colors';
 import { determineTextColor } from '../../lib/utils';
+import { useEffect, useState } from 'react';
 
-const NewsletterWrapper = styled.div(({ meta }) => ({
+const NewsletterWrapper = styled.div(({ textColor, backgroundColor }) => ({
   ...tw`bg-gray-200 mb-8 pt-7 px-4 pb-8 md:sticky md:top-10`,
-  backgroundColor:
-    meta.color === 'custom'
-      ? meta.primaryColor
-      : Colors[meta.color].PromoBlockBackground,
-  color:
-    meta.color === 'custom'
-      ? determineTextColor(meta.primaryColor)
-      : Colors[meta.color].PromoBlockText,
+  backgroundColor: backgroundColor,
+  color: textColor,
 }));
 
 const NewsletterHed = tw.h4`text-2xl font-bold tracking-tight leading-5 mb-2`;
 const NewsletterDek = tw.p`mb-6`;
 
 export default function NewsletterBlock({ metadata, headline }) {
+  const [textColor, setTextColor] = useState(null);
+  const [backgroundColor, setBackgroundColor] = useState(null);
+
+  useEffect(() => {
+    let bgc;
+    let tc;
+    if (metadata.color === 'custom') {
+      bgc = metadata.primaryColor;
+      tc = determineTextColor(metadata.primaryColor);
+    } else if (Colors[metadata.color]) {
+      tc = Colors[metadata.color].PromoBlockText;
+      bgc = Colors[metadata.color].PromoBlockBackground;
+    }
+    setBackgroundColor(bgc);
+    setTextColor(tc);
+  }, [metadata]);
+
   return (
-    <NewsletterWrapper meta={metadata}>
+    <NewsletterWrapper textColor={textColor} backgroundColor={backgroundColor}>
       <NewsletterHed>{metadata.newsletterHed}</NewsletterHed>
       <NewsletterDek>{metadata.newsletterDek}</NewsletterDek>
       <br />


### PR DESCRIPTION
Closes #504 

Now I understand how to pass props to styled components, bonus. 

This was an issue trying to work with `Colors[]` before it was loaded, so I fixed it by moving the text & background colors to explicit props on the styled component, then setting in an `if/else if` wrapped in a useEffect block. That plus using the state for these two values results in the page rendering fine for me either via direct url or navigating from the homepage. The two components are also used in the public-facing site and loaded fine there as well with these changes.