### PR TITLE
Updated bootstrap task for setting up new orgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
     "bootstrap": "node script/bootstrap.js",
+    "status": "node script/status.js",
     "build": "next build",
     "build:rss": "node script/generate-rss.js",
     "postbuild": "next-sitemap && node script/generate-rss.js",

--- a/script/shared.js
+++ b/script/shared.js
@@ -199,6 +199,29 @@ function hasuraListLocales(params) {
   });
 }
 
+const HASURA_LIST_ORGANIZATIONS = `query MyQuery {
+  organizations {
+    created_at
+    id
+    name
+    slug
+    organization_locales {
+      locale {
+        code
+      }
+    }
+  }
+}`;
+
+function hasuraListOrganizations(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    adminSecret: params['adminSecret'],
+    query: HASURA_LIST_ORGANIZATIONS,
+    name: 'MyQuery',
+  });
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -248,6 +271,7 @@ module.exports = {
   hasuraInsertOrgLocales,
   hasuraListAllLocales,
   hasuraListLocales,
+  hasuraListOrganizations,
   hasuraListSections,
   hasuraListTags,
   hasuraUpsertHomepageLayout,

--- a/script/status.js
+++ b/script/status.js
@@ -1,0 +1,36 @@
+const { program } = require('commander');
+program.version('0.0.1');
+
+const shared = require("./shared");
+require('dotenv').config({ path: '.env.local' })
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+const adminSecret = process.env.HASURA_ADMIN_SECRET;
+
+async function listOrganizations() {
+  const { errors, data } = await shared.hasuraListOrganizations({
+    url: apiUrl,
+    adminSecret: adminSecret,
+  })
+
+  if (errors) {
+    console.error("Error listing organizations:", errors);
+  } else {
+    data.organizations.map( (org) => {
+      console.log(`${org.name} (${org.slug}) created at ${org.created_at} with locales:`)
+      org.organization_locales.map( (orgLocale) => {
+        console.log(` * ${orgLocale.locale.code}`);
+      })
+      console.log();
+    })
+  }
+}
+
+program
+  .description("checks the status of the current org")
+  .action( (opts) => {
+    listOrganizations();
+  });
+
+program.parse(process.argv);

--- a/script/vercel.js
+++ b/script/vercel.js
@@ -3,7 +3,6 @@ require('dotenv').config({ path: '.env.local' })
 
 const TOKEN = process.env.VERCEL_TOKEN;
 const BASE_URL = "https://api.vercel.com/v6";
-const ORG_NAME= process.env.ORG_SLUG;
 const GIT_REPO = process.env.GIT_REPO;
 
 async function getProjects() {
@@ -32,11 +31,10 @@ async function getProjects() {
   projectsData.projects.map((project) => console.log(project));
 }
 
-async function createProject() {
+async function createProject(name, slug) {
 
   let projectId;
   let domain;
-
 
   let requestHeaders = {
     "Authorization": `Bearer ${TOKEN}`,
@@ -56,10 +54,10 @@ async function createProject() {
 
   let url = BASE_URL + "/projects?teamId=" + teamId;
 
-  console.log("Creating Vercel project with name:", ORG_NAME)
+  console.log("Creating Vercel project with name:", name)
 
   let requestBody = JSON.stringify({
-    name: ORG_NAME,
+    name: name,
     gitRepository: {
       type: 'github',
       repo: GIT_REPO,
@@ -79,7 +77,7 @@ async function createProject() {
       console.error("[" + data.error.code + "] Unable to create Vercel project because: " + data.error.message);
     } else {
       domain = data.alias[0].domain;
-      console.log("Created Vercel project for " + ORG_NAME);
+      console.log("Created Vercel project for " + name);
 
       projectId = data.id;
 
@@ -99,8 +97,8 @@ async function createProject() {
       }
 
       let envUrl = "https://api.vercel.com/v7/projects/" + projectId + "/env/?teamId=" + teamId;
-
-      const currentEnv = require('dotenv').config({ path: '.env.local' });
+      let envFilename = `.env.local-${slug}`
+      const currentEnv = require('dotenv').config({ path: envFilename });
       let envData = currentEnv.parsed;
 
       let results = [];


### PR DESCRIPTION
You were right - we don't have to clone this repo every time we want to add an org. Not sure why I was doing that!

So, this PR makes the following changes:

* `yarn bootstrap` takes 2 more params: `-n $NAME -s $SLUG`
* it creates a new .env file as `.env.local-$SLUG`
* the env file is based on whatever is set up in `.env.local` so that needs to be correct
* the new env file gets updated values for ORG_NAME, SLUG, bucket name and dir
* `yarn status` is a new script that is for now very simple but could be expanded; i wanted a very easy way to list the orgs and their locales + date created

RIP `~/.tnc/setup` it was brief but you've served your purpose. I'll delete the gist, because otherwise I'll find it in a few weeks and forget that we decided not to do things that way 😂 !