### PR TITLE
yarn remove:org -s <slug>

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "populate": "node script/populate.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
+    "remove:org": "node script/remove.js",
     "build": "next build",
     "build:rss": "node script/generate-rss.js",
     "postbuild": "next-sitemap && node script/generate-rss.js",

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,6 +32,7 @@ export async function getStaticProps({ locale }) {
     throw errors;
   }
 
+  console.log('hp data:', data);
   let siteMetadata;
   let metadatas = data.site_metadatas;
   try {

--- a/script/remove.js
+++ b/script/remove.js
@@ -1,0 +1,33 @@
+
+const { program } = require('commander');
+program.version('0.0.1');
+
+const shared = require("./shared");
+require('dotenv').config({ path: '.env.local' })
+
+const apiUrl = process.env.HASURA_API_URL;
+const adminSecret = process.env.HASURA_ADMIN_SECRET;
+
+async function removeOrganization(slug) {
+  const { errors, data } = await shared.hasuraRemoveOrganization({
+    url: apiUrl,
+    adminSecret: adminSecret,
+    slug: slug,
+  })
+
+  if (errors) {
+    console.error("Error deleting organization data: ", errors);
+
+  } else {
+    console.log(`Deleted organization data for ${slug}`, data)
+  }
+}
+
+program
+  .requiredOption('-s, --slug <slug>', 'unique slug identifier of the organization')
+  .description("removes all data for the specified org")
+  .action( (opts) => {
+    removeOrganization(opts.slug);
+  });
+
+program.parse(process.argv);

--- a/script/shared.js
+++ b/script/shared.js
@@ -64,6 +64,36 @@ function hasuraUpsertMetadata(params) {
   });
 }
 
+const HASURA_REMOVE_ORGANIZATION = `mutation MyMutation($slug: String!) {
+  delete_organization_locales(where: {organization: {slug: {_eq: $slug}}}) {
+    affected_rows
+  }
+  delete_category_translations(where: {category: {organization: {slug: {_eq: $slug}}}}) {
+    affected_rows
+  }
+  delete_categories(where: {organization: {slug: {_eq: $slug}}}) {
+    affected_rows
+  }
+	delete_homepage_layout_schemas(where: {organization: {slug: {_eq: $slug}}}) {
+    affected_rows
+  }
+  delete_organizations(where: {slug: {_eq: $slug}}) {
+    affected_rows
+  }
+}`;
+
+function hasuraRemoveOrganization(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    adminSecret: params['adminSecret'],
+    query: HASURA_REMOVE_ORGANIZATION,
+    name: 'MyMutation',
+    variables: {
+      slug: params['slug'],
+    },
+  });
+}
+
 const HASURA_UPSERT_LAYOUT = `mutation MyMutation($organization_id: Int!, $name: String!, $data: jsonb!) {
   insert_homepage_layout_schemas(objects: {name: $name, data: $data, organization_id: $organization_id}, on_conflict: {constraint: homepage_layout_schemas_name_organization_id_key, update_columns: [name, data]}) {
     returning {
@@ -278,5 +308,6 @@ module.exports = {
   hasuraUpsertMetadata,
   hasuraInsertSections,
   hasuraUpsertSection,
+  hasuraRemoveOrganization,
   fetchGraphQL
 }

--- a/script/shared.js
+++ b/script/shared.js
@@ -65,21 +65,27 @@ function hasuraUpsertMetadata(params) {
 }
 
 const HASURA_REMOVE_ORGANIZATION = `mutation MyMutation($slug: String!) {
-  delete_organization_locales(where: {organization: {slug: {_eq: $slug}}}) {
-    affected_rows
-  }
-  delete_category_translations(where: {category: {organization: {slug: {_eq: $slug}}}}) {
-    affected_rows
-  }
-  delete_categories(where: {organization: {slug: {_eq: $slug}}}) {
-    affected_rows
-  }
-	delete_homepage_layout_schemas(where: {organization: {slug: {_eq: $slug}}}) {
-    affected_rows
-  }
-  delete_organizations(where: {slug: {_eq: $slug}}) {
-    affected_rows
-  }
+    delete_organization_locales(where: {organization: {slug: {_eq: $slug}}}) {
+      affected_rows
+    }
+    delete_category_translations(where: {category: {organization: {slug: {_eq: $slug}}}}) {
+      affected_rows
+    }
+    delete_categories(where: {organization: {slug: {_eq: $slug}}}) {
+      affected_rows
+    }
+    delete_site_metadata_translations(where: {site_metadata: {organization: {slug: {_eq: $slug}}}}) {
+      affected_rows
+    }
+    delete_site_metadatas(where: {organization: {slug: {_eq: $slug}}}) {
+      affected_rows
+    }
+    delete_homepage_layout_schemas(where: {organization: {slug: {_eq: $slug}}}) {
+      affected_rows
+    }
+    delete_organizations(where: {slug: {_eq: $slug}}) {
+      affected_rows
+    }  
 }`;
 
 function hasuraRemoveOrganization(params) {


### PR DESCRIPTION
Initial version of a helper script that will remove data for an organization.

right now it will delete:

* organization locales
* categories
* category translations
* homepage layout schemas
* site metadatas
* organization record

I'll likely have to add more tables of data to it, but this was enough to help me run create organization tests.

Also, I probably should add a confirmation step like "ARE YOU REALLY SURE?" before doing something this destructive. It was just a lot of clicking around in the Hasura UI to remove this stuff otherwise.