### PR TITLE
Label the 'published' flag as 'show in nav' for sections in the tinycms

### DIFF
--- a/pages/tinycms/sections/[id].js
+++ b/pages/tinycms/sections/[id].js
@@ -65,9 +65,9 @@ export default function EditSection({
       // display success message
       let message = 'The section is updated.';
       if (published) {
-        message += ' (section is live)';
+        message += ' (section appears in nav)';
       } else {
-        message += ' (section is unpublished)';
+        message += ' (section is hidden in nav)';
       }
       setNotificationMessage(message);
       setNotificationType('success');
@@ -112,7 +112,7 @@ export default function EditSection({
             name="published"
             checked={published}
             onChange={handlePublished}
-            label="Published"
+            label="Show in nav"
           />
 
           <TinySubmitCancelButtons destURL="/tinycms/sections" />

--- a/pages/tinycms/sections/add.js
+++ b/pages/tinycms/sections/add.js
@@ -130,7 +130,7 @@ export default function AddSection({
             name="published"
             checked={published}
             onChange={handlePublished}
-            label="Published"
+            label="Show in nav"
           />
 
           <TinySubmitCancelButtons destURL="/tinycms/sections" />

--- a/pages/tinycms/sections/index.js
+++ b/pages/tinycms/sections/index.js
@@ -80,7 +80,7 @@ export default function Sections({ sections, currentLocale, locales }) {
             <TableRow>
               <TableHeader>Name</TableHeader>
               <TableHeader>Slug</TableHeader>
-              <TableHeader>Published?</TableHeader>
+              <TableHeader>Show in nav?</TableHeader>
             </TableRow>
           </TableHead>
           <TableBody>{listItems}</TableBody>


### PR DESCRIPTION
This goes with https://github.com/news-catalyst/google-app-scripts/pull/266 and changes the way we refer to a section's visibility.

<img width="1312" alt="Screen Shot 2021-05-06 at 8 18 57 am" src="https://user-images.githubusercontent.com/3397/117217597-f799e800-ae44-11eb-9829-b5de669e97f8.png">
