### PR TITLE
load page view data into hasura

### DIFF
--- a/docs/howto_setup_ga_api_access.md
+++ b/docs/howto_setup_ga_api_access.md
@@ -9,3 +9,8 @@
   ```
 5. add the overall GA Account ID to the env: `GA_ACCOUNT_ID=XX`
 6. run ` yarn bootstrap -e EMAIL -l en-US -n "The ORG NAME" -s SLUG -u https://DOMAIN.vercel.app` to setup the new org with GA
+
+## setting up for GA data loading into hasura
+
+1. enable the reporting (v4) API in the project: https://console.cloud.google.com/flows/enableapi?apiid=analyticsreporting.googleapis.com&credential=client_key
+2. click through credentials: https://console.cloud.google.com/apis/credentials/wizard?api=analyticsreporting.googleapis.com&project=webiny-sidebar-publishing (choose to use the existing creds)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
+    "analytics": "node script/analytics.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
     "remove:org": "node script/remove.js",

--- a/script/analytics.js
+++ b/script/analytics.js
@@ -1,0 +1,87 @@
+#! /usr/bin/env node
+
+require('dotenv').config({ path: '.env.local' })
+
+const { program } = require('commander');
+program.version('0.0.1');
+
+const { google } = require("googleapis");
+const credentials = require("./credentials.json");
+const scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/analytics", "https://www.googleapis.com/auth/analytics.edit"];
+const auth = new google.auth.JWT(credentials.client_email, null, credentials.private_key, scopes);
+const analyticsreporting = google.analyticsreporting({version: "v4", auth})
+// const googleAnalyticsAccountID = process.env.GA_ACCOUNT_ID;
+const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+
+const shared = require("./shared");
+
+
+// let organizationID;
+
+async function getPageViews(startDate, endDate) {
+  // console.log(analyticsreporting);
+
+  analyticsreporting.reports.batchGet( {
+    requestBody: {
+      reportRequests: [
+      {
+        viewId: googleAnalyticsViewID,
+        dateRanges:[
+          {
+            startDate: startDate,
+            endDate: endDate
+          }],
+        metrics:[
+          {
+            expression: "ga:pageviews"
+          }],
+        dimensions: [
+          {
+            name: "ga:pagePath"
+          }]
+      }]
+    }
+  } )
+  .then((response) => {
+    let reports = response.data.reports;
+
+    console.log("page view data from", startDate, "to", endDate);
+    // console.log(JSON.stringify(reports))
+    let data = reports[0].data;
+
+    if (data && data.rows) {
+      data.rows.map( (row) => {
+        let path = row.dimensions[0];
+        let value = row.metrics[0].values[0];
+
+        shared.hasuraInsertPageView({
+          url: apiUrl,
+          orgSlug: apiToken,
+          count: value,
+          date: endDate,
+          path: path,
+        }).then ( (res) => {
+          console.log(" + ", path, value);
+        })
+        .catch((e) => console.error("[GA] Error inserting page view data into hasura:", e ));
+      });
+    } else {
+      console.error("[GA] no page view data found between", startDate, "and", endDate);
+    }
+  })
+  .catch((e) => console.error("[GA] Error getting page views:", e ));
+}
+
+program
+    // .requiredOption('-v, --view <viewId>', 'view id for the property profile in GA')
+    .requiredOption('-s, --startDate <startDate>', 'start date YYYY-MM-DD')
+    .requiredOption('-e, --endDate <endDate>', 'end date YYYY-MM-DD')
+    .description("loads metrics data from google analytics into hasura")
+    .action( (opts) => {
+      getPageViews(opts.startDate, opts.endDate);
+    });
+
+program.parse(process.argv);

--- a/script/shared.js
+++ b/script/shared.js
@@ -258,6 +258,31 @@ function hasuraListOrganizations(params) {
   });
 }
 
+const HASURA_INSERT_PAGE_VIEW_DATA = `mutation MyMutation($count: Int!, $date: timestamptz!, $path: String!) {
+  insert_ga_page_views_one(object: {count: $count, date: $date, path: $path}) {
+    updated_at
+    id
+    path
+    created_at
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertPageView(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_PAGE_VIEW_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+      path: params['path'],
+    },
+  })
+}
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -284,11 +309,6 @@ async function fetchGraphQL(params) {
   let operationName = params['name'];
   let variables = params['variables'];
 
-  // console.log(JSON.stringify({
-  //   query: operationQuery,
-  //   variables: variables,
-  //   operationName: operationName}))
-
   const result = await fetch(url, {
     method: 'POST',
     headers: requestHeaders,
@@ -305,6 +325,7 @@ async function fetchGraphQL(params) {
 module.exports = {
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
+  hasuraInsertPageView,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,


### PR DESCRIPTION
I decided to break this up into smaller PRs - this introduces a new script `yarn analytics -s start -e end` that for now requests page view data from GA and inserts it into Hasura in a table called `ga_page_views`

I'm going through the list of remaining data points now, starting with sessions.