### PR TITLE
Feature/load sessions from hasura

### DIFF
--- a/components/plugins/NEW_ORG.md
+++ b/components/plugins/NEW_ORG.md
@@ -1,0 +1,14 @@
+# how to setup a new organization
+
+To setup a fake org for the Bellingen Courier-Sun (a real local paper where I live), I did the following:
+
+```
+git clone git@github.com:news-catalyst/next-tinynewsdemo.git bello
+cd bello
+yarn
+cp ~/Projects/newscatalyst/webiny-stack/frontend-site/.env.local-oaklyn .env.local-bello
+cp ~/Projects/newscatalyst/webiny-stack/frontend-site/script/credentials.json script/
+vim .env.local-bello
+./script/switch bello
+yarn bootstrap -l en-US -e jacqui@newscatalyst.org
+```

--- a/docs/howto_setup_ga_api_access.md
+++ b/docs/howto_setup_ga_api_access.md
@@ -9,3 +9,8 @@
   ```
 5. add the overall GA Account ID to the env: `GA_ACCOUNT_ID=XX`
 6. run ` yarn bootstrap -e EMAIL -l en-US -n "The ORG NAME" -s SLUG -u https://DOMAIN.vercel.app` to setup the new org with GA
+
+## setting up for GA data loading into hasura
+
+1. enable the reporting (v4) API in the project: https://console.cloud.google.com/flows/enableapi?apiid=analyticsreporting.googleapis.com&credential=client_key
+2. click through credentials: https://console.cloud.google.com/apis/credentials/wizard?api=analyticsreporting.googleapis.com&project=webiny-sidebar-publishing (choose to use the existing creds)

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,23 @@
 import { format } from 'date-fns';
 import { fetchGraphQL } from './utils';
 
+const HASURA_GET_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    count
+    date
+  }
+}`;
+
+export function hasuraGetSessions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_SESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,4 +1,23 @@
 import { format } from 'date-fns';
+import { fetchGraphQL } from './utils';
+
+const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+    count
+    date
+    path
+  }
+}`;
+
+export function hasuraGetPageViews(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_PAGE_VIEWS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
 
 export function getMetricsData(
   viewID,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
+    "analytics": "node script/analytics.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
     "remove:org": "node script/remove.js",

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -133,6 +133,8 @@ export default function PageViewsPage(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
                 setPageViews={setPageViews}
                 pageViews={pageViews}
               />
@@ -162,9 +164,13 @@ export default function PageViewsPage(props) {
 export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
   return {
     props: {
+      apiUrl,
+      apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
     },

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -96,6 +96,7 @@ export default function SessionsOverview(props) {
   };
 
   useEffect(() => {
+    console.log('props:', props);
     window.gapi.load('auth2', init); //(1)
   });
 
@@ -134,6 +135,8 @@ export default function SessionsOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <GeoSessions
@@ -166,9 +169,13 @@ export default function SessionsOverview(props) {
 export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
   return {
     props: {
+      apiUrl: apiUrl,
+      apiToken: apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
     },

--- a/script/analytics.js
+++ b/script/analytics.js
@@ -1,0 +1,87 @@
+#! /usr/bin/env node
+
+require('dotenv').config({ path: '.env.local' })
+
+const { program } = require('commander');
+program.version('0.0.1');
+
+const { google } = require("googleapis");
+const credentials = require("./credentials.json");
+const scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/analytics", "https://www.googleapis.com/auth/analytics.edit"];
+const auth = new google.auth.JWT(credentials.client_email, null, credentials.private_key, scopes);
+const analyticsreporting = google.analyticsreporting({version: "v4", auth})
+// const googleAnalyticsAccountID = process.env.GA_ACCOUNT_ID;
+const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+
+const shared = require("./shared");
+
+
+// let organizationID;
+
+async function getPageViews(startDate, endDate) {
+  // console.log(analyticsreporting);
+
+  analyticsreporting.reports.batchGet( {
+    requestBody: {
+      reportRequests: [
+      {
+        viewId: googleAnalyticsViewID,
+        dateRanges:[
+          {
+            startDate: startDate,
+            endDate: endDate
+          }],
+        metrics:[
+          {
+            expression: "ga:pageviews"
+          }],
+        dimensions: [
+          {
+            name: "ga:pagePath"
+          }]
+      }]
+    }
+  } )
+  .then((response) => {
+    let reports = response.data.reports;
+
+    console.log("page view data from", startDate, "to", endDate);
+    // console.log(JSON.stringify(reports))
+    let data = reports[0].data;
+
+    if (data && data.rows) {
+      data.rows.map( (row) => {
+        let path = row.dimensions[0];
+        let value = row.metrics[0].values[0];
+
+        shared.hasuraInsertPageView({
+          url: apiUrl,
+          orgSlug: apiToken,
+          count: value,
+          date: endDate,
+          path: path,
+        }).then ( (res) => {
+          console.log(" + ", path, value);
+        })
+        .catch((e) => console.error("[GA] Error inserting page view data into hasura:", e ));
+      });
+    } else {
+      console.error("[GA] no page view data found between", startDate, "and", endDate);
+    }
+  })
+  .catch((e) => console.error("[GA] Error getting page views:", e ));
+}
+
+program
+    // .requiredOption('-v, --view <viewId>', 'view id for the property profile in GA')
+    .requiredOption('-s, --startDate <startDate>', 'start date YYYY-MM-DD')
+    .requiredOption('-e, --endDate <endDate>', 'end date YYYY-MM-DD')
+    .description("loads metrics data from google analytics into hasura")
+    .action( (opts) => {
+      getPageViews(opts.startDate, opts.endDate);
+    });
+
+program.parse(process.argv);

--- a/script/shared.js
+++ b/script/shared.js
@@ -258,6 +258,31 @@ function hasuraListOrganizations(params) {
   });
 }
 
+const HASURA_INSERT_PAGE_VIEW_DATA = `mutation MyMutation($count: Int!, $date: timestamptz!, $path: String!) {
+  insert_ga_page_views_one(object: {count: $count, date: $date, path: $path}) {
+    updated_at
+    id
+    path
+    created_at
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertPageView(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_PAGE_VIEW_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+      path: params['path'],
+    },
+  })
+}
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -284,11 +309,6 @@ async function fetchGraphQL(params) {
   let operationName = params['name'];
   let variables = params['variables'];
 
-  // console.log(JSON.stringify({
-  //   query: operationQuery,
-  //   variables: variables,
-  //   operationName: operationName}))
-
   const result = await fetch(url, {
     method: 'POST',
     headers: requestHeaders,
@@ -305,6 +325,7 @@ async function fetchGraphQL(params) {
 module.exports = {
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
+  hasuraInsertPageView,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -283,6 +283,31 @@ function hasuraInsertPageView(params) {
     },
   })
 }
+
+const HASURA_INSERT_SESSION_DATA = `mutation MyMutation($count: Int!, $date: date!) {
+  insert_ga_sessions_one(object: {count: $count, date: $date}) {
+    updated_at
+    id
+    created_at
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertSession(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_SESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+    },
+  })
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -326,6 +351,7 @@ module.exports = {
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
   hasuraInsertPageView,
+  hasuraInsertSession,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,


### PR DESCRIPTION
continues where PR #536 left off by changing the tinycms sessions (daily) chart to use data from hasura.

I've left this as far as the chart rendering using the same data points as before - it's wonky at the moment though as I need to clear out the test bits of data currently in hasura and properly repopulate all of it from GA (from around 1 April I think). I'd like to wait on doing that until I have all the data points in the `yarn analytics` script.


next: create a lambda function for the data population