### PR TITLE
Bugfix: adds missing newsletter signup stats

### DIFF
--- a/components/plugins/NEW_ORG.md
+++ b/components/plugins/NEW_ORG.md
@@ -1,0 +1,14 @@
+# how to setup a new organization
+
+To setup a fake org for the Bellingen Courier-Sun (a real local paper where I live), I did the following:
+
+```
+git clone git@github.com:news-catalyst/next-tinynewsdemo.git bello
+cd bello
+yarn
+cp ~/Projects/newscatalyst/webiny-stack/frontend-site/.env.local-oaklyn .env.local-bello
+cp ~/Projects/newscatalyst/webiny-stack/frontend-site/script/credentials.json script/
+vim .env.local-bello
+./script/switch bello
+yarn bootstrap -l en-US -e jacqui@newscatalyst.org
+```

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
-import { getMetricsData } from '../../../lib/analytics';
+import {
+  hasuraGetCustomDimension,
+  hasuraGetNewsletterImpressions,
+} from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-3 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
@@ -8,128 +11,81 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const NewsletterSignupFormData = (props) => {
   const signupRef = useRef();
 
-  const [sortedNewsletterRows, setSortedNewsletterRows] = useState([]);
-  const [frequencySignups, setFrequencySignups] = useState([]);
+  const [totalImpressions, setTotalImpressions] = useState({});
+  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
-    let eventMetrics = ['ga:totalEvents'];
-    let eventDimensions = [
-      'ga:eventCategory',
-      'ga:eventAction',
-      'ga:eventLabel',
-      'ga:pagePath',
-    ];
-    getMetricsData(
-      props.viewID,
-      props.startDate,
-      props.endDate,
-      eventMetrics,
-      ['ga:eventCategory', 'ga:eventAction', 'ga:eventLabel', 'ga:dimension2'],
-      {
-        filters:
-          'ga:eventCategory==NTG Newsletter;ga:eventAction==Newsletter Signup',
+    let params = {
+      url: props.apiUrl,
+      orgSlug: props.apiToken,
+      startDate: props.startDate.format('YYYY-MM-DD'),
+      endDate: props.endDate.format('YYYY-MM-DD'),
+    };
+    let customParams = {
+      url: props.apiUrl,
+      orgSlug: props.apiToken,
+      startDate: props.startDate.format('YYYY-MM-DD'),
+      endDate: props.endDate.format('YYYY-MM-DD'),
+      dimension: props.dimension,
+    };
+    const fetchCustomDimension = async () => {
+      const { errors, data } = await hasuraGetCustomDimension(customParams);
+
+      if (errors && !data) {
+        console.error(errors);
       }
-    ).then((resp) => {
-      const queryResult = resp.result.reports[0].data.rows;
-      console.log('dimension2 results:', queryResult);
-      let collectedData = {};
-      queryResult.forEach((row) => {
-        let frequency = row.dimensions[3];
-        let signupCount = row.metrics[0].values[0];
-        collectedData[frequency] = signupCount;
-      });
-      var sortable = [];
-      Object.keys(collectedData).forEach((key) => {
-        let signups = collectedData[key];
-        sortable.push([key, signups]);
-      });
 
-      sortable.sort(function (a, b) {
-        return b[1] - a[1];
-      });
-
-      setFrequencySignups(sortable);
-    });
-
-    getMetricsData(
-      props.viewID,
-      props.startDate,
-      props.endDate,
-      eventMetrics,
-      eventDimensions,
-      {
-        filters: 'ga:eventCategory==NTG Newsletter',
-      }
-    )
-      .then((resp) => {
-        const queryResult = resp.result.reports[0].data.rows;
-
-        let collectedData = {};
-        queryResult.forEach((row) => {
-          console.log('row:', row);
-
-          let articlePath = row.dimensions[3];
-          let eventAction = row.dimensions[1];
-          let value = row.metrics[0].values[0];
-
-          if (collectedData[articlePath]) {
-            collectedData[articlePath][eventAction] = value;
-          } else {
-            collectedData[articlePath] = {};
-            collectedData[articlePath][eventAction] = value;
-          }
-        });
-
-        var sortable = [];
-        Object.keys(collectedData).forEach((key) => {
-          let views = collectedData[key]['Newsletter Modal Impression 1'];
-          let signups = collectedData[key]['Newsletter Signup'];
-          let conversion = 0;
-
-          if (views && signups) {
-            conversion = (signups / views) * 100;
-          }
-          collectedData[key]['conversion'] = Math.round(conversion);
-          sortable.push([key, conversion]);
-        });
-
-        sortable.sort(function (a, b) {
-          return b[1] - a[1];
-        });
-
-        let sortedRows = [];
-        sortable.map((item, i) => {
-          // console.log("item:", item)
-          if (item && item[0]) {
-            // console.log("item:", item, collectedData[item[0]])
-            sortedRows.push(
-              <tr key={`newsletter-signup-row-${i}`}>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {item[0]}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['Newsletter Modal Impression 1']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['Newsletter Signup']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['conversion']}
-                </td>
-              </tr>
-            );
-          } else {
-            console.error('NEWSLETTER MISSING ITEM', sortedNewsletter);
-          }
-        });
-        setSortedNewsletterRows(sortedRows);
-        if (window.location.hash && window.location.hash === '#signups') {
-          if (signupRef) {
-            signupRef.current.scrollIntoView({ behavior: 'smooth' });
-          }
+      let freqSigns = {};
+      data.ga_custom_dimensions.map((item, i) => {
+        if (!freqSigns[item.label]) {
+          freqSigns[item.label] = 0;
         }
-      })
-      .catch((error) => console.error(error));
+        freqSigns[item.label] += parseInt(item.count);
+      });
+      setFrequencySignups(freqSigns);
+    };
+    fetchCustomDimension();
+
+    const fetchNewsletterImpressions = async () => {
+      const { errors, data } = await hasuraGetNewsletterImpressions(params);
+
+      if (errors && !data) {
+        console.error(errors);
+      }
+
+      let totalImps = {};
+      data.ga_newsletter_impressions.map((row) => {
+        if (!totalImps[row.path]) {
+          totalImps[row.path] = { impressions: 0, signups: 0 };
+        }
+
+        if (row.action === 'Newsletter Modal Impression 1') {
+          totalImps[row.path]['impressions'] += parseInt(row.impressions);
+        } else if (row.action === 'Newsletter Signup') {
+          totalImps[row.path]['signups'] += parseInt(row.impressions);
+        }
+      });
+      Object.keys(totalImps).map((path) => {
+        let conversion = 0;
+        let signups = totalImps[path]['signups'];
+        let impressions = totalImps[path]['impressions'];
+        if (signups && impressions) {
+          conversion = (signups / impressions) * 100;
+          totalImps[path]['conversion'] = conversion.toFixed(2);
+        } else {
+          totalImps[path]['conversion'] = 0;
+        }
+      });
+      setTotalImpressions(totalImps);
+      // setNewsletterImpressions(data.ga_newsletter_impressions);
+    };
+    fetchNewsletterImpressions();
+
+    if (window.location.hash && window.location.hash === '#signups') {
+      if (signupRef) {
+        signupRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
   }, [props.startDate, props.endDate]);
 
   return (
@@ -151,7 +107,24 @@ const NewsletterSignupFormData = (props) => {
             <th tw="p-4">Conversion Rate</th>
           </tr>
         </thead>
-        <tbody>{sortedNewsletterRows}</tbody>
+        <tbody>
+          {Object.keys(totalImpressions).map((path, i) => (
+            <tr key={`newsletter-signup-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {path}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalImpressions[path]['impressions']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalImpressions[path]['signups']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalImpressions[path]['conversion']}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
       </table>
 
       <SubHeaderContainer>
@@ -171,13 +144,13 @@ const NewsletterSignupFormData = (props) => {
           </tr>
         </thead>
         <tbody>
-          {frequencySignups.map((item, i) => (
+          {Object.keys(frequencySignups).map((label, i) => (
             <tr key={`frequency-signup-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
+                {label}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
+                {frequencySignups[label]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -1,125 +1,77 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
-import { getMetricsData } from '../../../lib/analytics';
+import { hasuraGetReadingDepth } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-10 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
 
 const ReadingDepthData = (props) => {
   const depthRef = useRef();
-  const [readingDepthTableRows, setReadingDepthTableRows] = useState([]);
+  const [totalReadingDepth, setTotalReadingDepth] = useState({});
 
   useEffect(() => {
-    let eventMetrics = ['ga:totalEvents'];
-    let eventDimensions = [
-      'ga:eventCategory',
-      'ga:eventAction',
-      'ga:eventLabel',
-      'ga:pagePath',
-    ];
+    let rdParams = {
+      url: props.apiUrl,
+      orgSlug: props.apiToken,
+      startDate: props.startDate.format('YYYY-MM-DD'),
+      endDate: props.endDate.format('YYYY-MM-DD'),
+    };
+    const fetchReadingDepthData = async () => {
+      const { errors, data } = await hasuraGetReadingDepth(rdParams);
 
-    let readingDepthRows = [];
-    getMetricsData(
-      props.viewID,
-      props.startDate,
-      props.endDate,
-      eventMetrics,
-      eventDimensions,
-      {
-        filters: 'ga:eventCategory==NTG Article Milestone',
+      if (errors && !data) {
+        console.error(errors);
+        return errors;
       }
-    )
-      .then((response) => {
-        const queryResult = response.result.reports[0].data.rows;
-        // console.log('reading depth: ', queryResult);
+      let totalRD = {};
+      data.ga_reading_depth.map((rd) => {
+        if (!totalRD[rd.path]) {
+          totalRD[rd.path] = {
+            read_25: 0,
+            read_50: 0,
+            read_75: 0,
+            read_100: 0,
+            pageviews: 0,
+            conversion: 0,
+          };
+        }
+        totalRD[rd.path]['read_25'] += parseInt(rd.read_25);
+        totalRD[rd.path]['read_50'] += parseInt(rd.read_50);
+        totalRD[rd.path]['read_75'] += parseInt(rd.read_75);
+        totalRD[rd.path]['read_100'] += parseInt(rd.read_100);
+      });
 
-        let collectedData = {};
-        queryResult.forEach((row) => {
-          let articlePath = row.dimensions[3];
-
-          if (articlePath !== '/') {
-            let percentage = row.dimensions[1];
-            let count = row.metrics[0].values[0];
-            if (collectedData[articlePath]) {
-              collectedData[articlePath][percentage] = count;
-            } else {
-              collectedData[articlePath] = {};
-              collectedData[articlePath][percentage] = count;
-            }
-          }
-        });
-
-        var sortable = [];
-        Object.keys(collectedData).forEach((path) => {
-          let read25 = 0;
-          let readFullArticleCount = 0;
-          Object.keys(collectedData[path]).forEach((pct) => {
-            if (pct === '25%') {
-              read25 = collectedData[path][pct];
-            }
-            if (pct === '100%') {
-              readFullArticleCount = collectedData[path][pct];
-            }
-          });
-
-          let conversion = 0;
-          let pageViews = 0;
-          if (
-            props.pageViews &&
-            props.pageViews[path] &&
-            props.pageViews[path] > 0
-          ) {
-            conversion = (readFullArticleCount / props.pageViews[path]) * 100;
-            pageViews = props.pageViews[path];
-          }
-          collectedData[path]['pageViews'] = pageViews;
-          collectedData[path]['conversion'] = Math.round(conversion);
-          sortable.push([path, conversion]);
-        });
-
-        sortable.sort(function (a, b) {
-          return b[1] - a[1];
-        });
-
-        sortable.map((item, i) => {
-          if (item && item[0] && collectedData[item[0]]) {
-            readingDepthRows.push(
-              <tr key={`reading-depth-row-${i}`}>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {item[0]}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['25%']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['50%']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['75%']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['100%']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['pageViews']}
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {collectedData[item[0]]['conversion']}%
-                </td>
-              </tr>
-            );
-          }
-        });
-        setReadingDepthTableRows(readingDepthRows);
-
-        if (window.location.hash && window.location.hash === '#depth') {
-          if (depthRef) {
-            depthRef.current.scrollIntoView({ behavior: 'smooth' });
+      data.ga_page_views.map((pv) => {
+        if (totalRD[pv.path]) {
+          console.log(
+            'found matching article for page views:',
+            totalRD[pv.path]
+          );
+          if (totalRD[pv.path]['pageviews']) {
+            totalRD[pv.path]['pageviews'] += parseInt(pv.count);
+          } else {
+            totalRD[pv.path]['pageviews'] = parseInt(pv.count);
           }
         }
-      })
-      .catch((error) => console.error(error));
-  }, [props.pageViews, props.startDate, props.endDate]);
+      });
+      Object.keys(totalRD).map((path) => {
+        if (totalRD[path]['pageviews'] > 0) {
+          let conversion =
+            (totalRD[path]['read_100'] / totalRD[path]['pageviews']) * 100;
+          totalRD[path]['conversion'] = conversion;
+          console.log(path, conversion, totalRD[path]);
+        }
+      });
+      setTotalReadingDepth(totalRD);
+    };
+    fetchReadingDepthData();
+
+    if (window.location.hash && window.location.hash === '#depth') {
+      if (depthRef) {
+        depthRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [props.startDate, props.endDate]);
 
   return (
     <>
@@ -147,7 +99,33 @@ const ReadingDepthData = (props) => {
             <th tw="px-4">Read Entire Article</th>
           </tr>
         </thead>
-        <tbody>{readingDepthTableRows}</tbody>
+        <tbody>
+          {Object.keys(totalReadingDepth).map((path, i) => (
+            <tr key={`reading-depth-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {path}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['read_25']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['read_50']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['read_75']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['read_100']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['pageviews']}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingDepth[path]['conversion']}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
       </table>
     </>
   );

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,76 +1,43 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
-import { getMetricsData } from '../../../lib/analytics';
+import { hasuraGetReadingFrequency } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-10 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
 
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
-  const INITIAL_STATE = {
-    labels: [],
-    values: [],
-  };
-  const [frequencyData, setFrequencyData] = useState(INITIAL_STATE);
-  const [readingFrequencyTableRows, setReadingFrequencyTableRows] = useState(
-    []
-  );
+  const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
 
   useEffect(() => {
-    const pageViewsMetric = 'ga:pageviews';
-    let readingFrequencyRows = [];
+    let params = {
+      url: props.apiUrl,
+      orgSlug: props.apiToken,
+      startDate: props.startDate.format('YYYY-MM-DD'),
+      endDate: props.endDate.format('YYYY-MM-DD'),
+    };
+    const fetchReadingFrequency = async () => {
+      const { errors, data } = await hasuraGetReadingFrequency(params);
 
-    const customDimensionFrequency = ['ga:dimension2'];
-    getMetricsData(
-      props.viewID,
-      props.startDate,
-      props.endDate,
-      [pageViewsMetric],
-      customDimensionFrequency
-    )
-      .then((response) => {
-        const queryResult = response.result.reports[0].data.rows;
-
-        let labels = [];
-        let values = [];
-
-        var sortable = [];
-        queryResult.forEach((row) => {
-          let postsRange = row.dimensions[0].split(' ')[0];
-          let label = row.dimensions.join(' - ');
-          let value = row.metrics[0].values[0];
-
-          labels.push(label);
-          values.push(value);
-          sortable.push([value, label, parseInt(postsRange)]);
-        });
-        setFrequencyData({ ...frequencyData, labels, values });
-
-        sortable.sort(function (a, b) {
-          return a[2] - b[2];
-        });
-
-        sortable.map((item, i) => {
-          readingFrequencyRows.push(
-            <tr key={`reading-frequency-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-            </tr>
-          );
-        });
-        setReadingFrequencyTableRows(readingFrequencyRows);
-
-        if (window.location.hash && window.location.hash === '#frequency') {
-          if (frequencyRef) {
-            frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
-          }
+      if (errors && !data) {
+        console.error(errors);
+      }
+      let totalRF = {};
+      data.ga_reading_frequency.map((rf) => {
+        if (totalRF[rf.category]) {
+          totalRF[rf.category] += parseInt(rf.count);
+        } else {
+          totalRF[rf.category] = parseInt(rf.count);
         }
-      })
-      .catch((error) => console.error(error));
+      });
+      setTotalReadingFrequency(totalRF);
+    };
+    fetchReadingFrequency();
+    if (window.location.hash && window.location.hash === '#frequency') {
+      if (frequencyRef) {
+        frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
   }, [props.startDate, props.endDate]);
 
   return (
@@ -90,7 +57,18 @@ const ReadingFrequencyData = (props) => {
             <th tw="px-4">Views</th>
           </tr>
         </thead>
-        <tbody>{readingFrequencyTableRows}</tbody>
+        <tbody>
+          {Object.keys(totalReadingFrequency).map((category, i) => (
+            <tr key={`reading-frequency-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {category}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {totalReadingFrequency[category]}
+              </td>
+            </tr>
+          ))}
+        </tbody>
       </table>
     </>
   );

--- a/docs/howto_setup_ga_api_access.md
+++ b/docs/howto_setup_ga_api_access.md
@@ -9,3 +9,8 @@
   ```
 5. add the overall GA Account ID to the env: `GA_ACCOUNT_ID=XX`
 6. run ` yarn bootstrap -e EMAIL -l en-US -n "The ORG NAME" -s SLUG -u https://DOMAIN.vercel.app` to setup the new org with GA
+
+## setting up for GA data loading into hasura
+
+1. enable the reporting (v4) API in the project: https://console.cloud.google.com/flows/enableapi?apiid=analyticsreporting.googleapis.com&credential=client_key
+2. click through credentials: https://console.cloud.google.com/apis/credentials/wizard?api=analyticsreporting.googleapis.com&project=webiny-sidebar-publishing (choose to use the existing creds)

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -101,6 +101,33 @@ export function hasuraGetReadingDepth(params) {
   });
 }
 
+const HASURA_GET_CUSTOM_DIMENSION = `query MyQuery($startDate: date!, $endDate: date!, $dimension: String) {
+  ga_custom_dimensions(where: {date: {_gte: $startDate, _lte: $endDate}, dimension: {_eq: $dimension}}) {
+    count
+    created_at
+    date
+    dimension
+    id
+    label
+    organization_id
+    updated_at
+  }
+}`;
+
+export function hasuraGetCustomDimension(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_CUSTOM_DIMENSION,
+    name: 'MyQuery',
+    variables: {
+      startDate: params['startDate'],
+      endDate: params['endDate'],
+      dimension: params['dimension'],
+    },
+  });
+}
+
 const HASURA_GET_READING_FREQUENCY = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_reading_frequency(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
     id

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,24 @@
 import { format } from 'date-fns';
 import { fetchGraphQL } from './utils';
 
+const HASURA_GET_GEO_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_geo_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    count
+    date
+    region
+  }
+}`;
+
+export function hasuraGetGeoSessions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_GEO_SESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -54,6 +54,23 @@ export function hasuraGetSessions(params) {
   });
 }
 
+const HASURA_GET_SESSION_DURATION = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_session_duration(order_by: {date: asc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    seconds
+    date
+  }
+}`;
+
+export function hasuraGetSessionDuration(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_SESSION_DURATION,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -71,6 +71,36 @@ export function hasuraGetSessionDuration(params) {
   });
 }
 
+const HASURA_GET_READING_DEPTH_PAGE_VIEWS = `query MyQuery($date: date_comparison_exp) {
+  ga_reading_depth(where: {date: $date}) {
+    date
+    id
+    organization_id
+    path
+    read_100
+    read_25
+    read_50
+    read_75
+  }
+  ga_page_views(where: {date: $date}) {
+    count
+    date
+    id
+    organization_id
+    path
+  }
+}`;
+
+export function hasuraGetReadingDepth(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_READING_DEPTH_PAGE_VIEWS,
+    name: 'MyQuery',
+    variables: { date: { _gte: params['startDate'], _lte: params['endDate'] } },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,23 @@
 import { format } from 'date-fns';
 import { fetchGraphQL } from './utils';
 
+const HASURA_GET_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    count
+    date
+  }
+}`;
+
+export function hasuraGetSessions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_SESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -147,6 +147,25 @@ export function hasuraGetReadingFrequency(params) {
   });
 }
 
+const HASURA_GET_NEWSLETTER_IMPRESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_newsletter_impressions(order_by: {date: asc, impressions: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+    impressions
+    action
+    date
+    path
+  }
+}`;
+
+export function hasuraGetNewsletterImpressions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_NEWSLETTER_IMPRESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -101,6 +101,25 @@ export function hasuraGetReadingDepth(params) {
   });
 }
 
+const HASURA_GET_READING_FREQUENCY = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_reading_frequency(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    id
+    date
+    count
+    category
+  }
+}`;
+
+export function hasuraGetReadingFrequency(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_READING_FREQUENCY,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     count

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,4 +1,23 @@
 import { format } from 'date-fns';
+import { fetchGraphQL } from './utils';
+
+const HASURA_GET_PAGE_VIEWS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+    count
+    date
+    path
+  }
+}`;
+
+export function hasuraGetPageViews(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_PAGE_VIEWS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
 
 export function getMetricsData(
   viewID,

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,6 +1,24 @@
 import { format } from 'date-fns';
 import { fetchGraphQL } from './utils';
 
+const HASURA_GET_REFERRAL_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_referral_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    count
+    date
+    source
+  }
+}`;
+
+export function hasuraGetReferralSessions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_REFERRAL_SESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_GEO_SESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_geo_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
     count

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
+    "analytics": "node script/analytics.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
     "remove:org": "node script/remove.js",

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -152,18 +152,20 @@ export default function Audience(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
-                metrics={['ga:sessions']}
-                dimensions={['ga:dimension4']}
+                dimension="dimension4"
                 label="Donor"
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <CustomDimensions
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
-                metrics={['ga:sessions']}
-                dimensions={['ga:dimension5']}
+                dimension="dimension5"
                 label="Subscriber"
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
             </SettingsContainer>
           )}
@@ -178,6 +180,8 @@ export default function Audience(props) {
 export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
   mailchimp.setConfig({
     apiKey: process.env.MAILCHIMP_API_KEY,
@@ -196,6 +200,8 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
+      apiUrl,
+      apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
       mailchimpKey: process.env.MAILCHIMP_API_KEY,

--- a/pages/tinycms/analytics/newsletter.js
+++ b/pages/tinycms/analytics/newsletter.js
@@ -133,6 +133,9 @@ export default function NewsletterOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
+                dimension="dimension2"
               />
 
               <MailchimpReport
@@ -151,6 +154,8 @@ export default function NewsletterOverview(props) {
   );
 }
 export async function getServerSideProps(context) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
 
@@ -171,6 +176,8 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
+      apiUrl,
+      apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
       mailchimpKey: process.env.MAILCHIMP_API_KEY,

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -152,6 +152,8 @@ export default function PageViewsPage(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
             </SettingsContainer>
           )}

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -133,6 +133,8 @@ export default function PageViewsPage(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
                 setPageViews={setPageViews}
                 pageViews={pageViews}
               />
@@ -162,9 +164,13 @@ export default function PageViewsPage(props) {
 export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
   return {
     props: {
+      apiUrl,
+      apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
     },

--- a/pages/tinycms/analytics/pageviews.js
+++ b/pages/tinycms/analytics/pageviews.js
@@ -144,6 +144,8 @@ export default function PageViewsPage(props) {
                 startDate={startDate}
                 endDate={endDate}
                 pageViews={pageViews}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <ReadingFrequencyData

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -157,6 +157,8 @@ export default function SessionsOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
             </SettingsContainer>
           )}

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -143,6 +143,8 @@ export default function SessionsOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <AverageSessionDuration

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -96,6 +96,7 @@ export default function SessionsOverview(props) {
   };
 
   useEffect(() => {
+    console.log('props:', props);
     window.gapi.load('auth2', init); //(1)
   });
 
@@ -134,6 +135,8 @@ export default function SessionsOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <GeoSessions
@@ -166,9 +169,13 @@ export default function SessionsOverview(props) {
 export async function getServerSideProps(context) {
   const clientID = process.env.ANALYTICS_CLIENT_ID;
   const clientSecret = process.env.ANALYTICS_CLIENT_SECRET;
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
 
   return {
     props: {
+      apiUrl: apiUrl,
+      apiToken: apiToken,
       clientID: clientID,
       clientSecret: clientSecret,
     },

--- a/pages/tinycms/analytics/sessions.js
+++ b/pages/tinycms/analytics/sessions.js
@@ -151,6 +151,8 @@ export default function SessionsOverview(props) {
                 viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <ReferralSource

--- a/script/analytics.js
+++ b/script/analytics.js
@@ -457,12 +457,12 @@ program
     .description("loads metrics data from google analytics into hasura")
     .action( (opts) => {
       getReadingFrequency(opts.startDate, opts.endDate);
-      // getReadingDepth(opts.startDate, opts.endDate);
-      // getPageViews(opts.startDate, opts.endDate);
-      // getSessions(opts.startDate, opts.endDate);
-      // getGeoSessions(opts.startDate, opts.endDate);
-      // getReferralSessions(opts.startDate, opts.endDate);
-      // getSessionDuration(opts.startDate, opts.endDate);
+      getReadingDepth(opts.startDate, opts.endDate);
+      getPageViews(opts.startDate, opts.endDate);
+      getSessions(opts.startDate, opts.endDate);
+      getGeoSessions(opts.startDate, opts.endDate);
+      getReferralSessions(opts.startDate, opts.endDate);
+      getSessionDuration(opts.startDate, opts.endDate);
     });
 
 program.parse(process.argv);

--- a/script/analytics.js
+++ b/script/analytics.js
@@ -1,0 +1,87 @@
+#! /usr/bin/env node
+
+require('dotenv').config({ path: '.env.local' })
+
+const { program } = require('commander');
+program.version('0.0.1');
+
+const { google } = require("googleapis");
+const credentials = require("./credentials.json");
+const scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/analytics", "https://www.googleapis.com/auth/analytics.edit"];
+const auth = new google.auth.JWT(credentials.client_email, null, credentials.private_key, scopes);
+const analyticsreporting = google.analyticsreporting({version: "v4", auth})
+// const googleAnalyticsAccountID = process.env.GA_ACCOUNT_ID;
+const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+
+const shared = require("./shared");
+
+
+// let organizationID;
+
+async function getPageViews(startDate, endDate) {
+  // console.log(analyticsreporting);
+
+  analyticsreporting.reports.batchGet( {
+    requestBody: {
+      reportRequests: [
+      {
+        viewId: googleAnalyticsViewID,
+        dateRanges:[
+          {
+            startDate: startDate,
+            endDate: endDate
+          }],
+        metrics:[
+          {
+            expression: "ga:pageviews"
+          }],
+        dimensions: [
+          {
+            name: "ga:pagePath"
+          }]
+      }]
+    }
+  } )
+  .then((response) => {
+    let reports = response.data.reports;
+
+    console.log("page view data from", startDate, "to", endDate);
+    // console.log(JSON.stringify(reports))
+    let data = reports[0].data;
+
+    if (data && data.rows) {
+      data.rows.map( (row) => {
+        let path = row.dimensions[0];
+        let value = row.metrics[0].values[0];
+
+        shared.hasuraInsertPageView({
+          url: apiUrl,
+          orgSlug: apiToken,
+          count: value,
+          date: endDate,
+          path: path,
+        }).then ( (res) => {
+          console.log(" + ", path, value);
+        })
+        .catch((e) => console.error("[GA] Error inserting page view data into hasura:", e ));
+      });
+    } else {
+      console.error("[GA] no page view data found between", startDate, "and", endDate);
+    }
+  })
+  .catch((e) => console.error("[GA] Error getting page views:", e ));
+}
+
+program
+    // .requiredOption('-v, --view <viewId>', 'view id for the property profile in GA')
+    .requiredOption('-s, --startDate <startDate>', 'start date YYYY-MM-DD')
+    .requiredOption('-e, --endDate <endDate>', 'end date YYYY-MM-DD')
+    .description("loads metrics data from google analytics into hasura")
+    .action( (opts) => {
+      getPageViews(opts.startDate, opts.endDate);
+    });
+
+program.parse(process.argv);

--- a/script/analytics.js
+++ b/script/analytics.js
@@ -64,7 +64,11 @@ async function getGeoSessions(startDate, endDate) {
           region: region,
           date: endDate,
         }).then ( (res) => {
-          console.log(" + geo session ", region, value, endDate);
+          if (res.errors) {
+            console.error("[GA] error inserting geo session data: ", res.errors);
+          } else {
+            console.log(" + geo session ", region, value, endDate);
+          }
         })
         .catch((e) => console.error("[GA] Error inserting geo session data into hasura:", e ));
       });

--- a/script/shared.js
+++ b/script/shared.js
@@ -360,6 +360,30 @@ function hasuraInsertSession(params) {
   })
 }
 
+const HASURA_INSERT_SESSION_DURATION_DATA = `mutation MyMutation($seconds: float8!, $date: date!) {
+  insert_ga_session_duration_one(object: {seconds: $seconds, date: $date}) {
+    updated_at
+    id
+    created_at
+    seconds
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertSessionDuration(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_SESSION_DURATION_DATA,
+    name: 'MyMutation',
+    variables: {
+      seconds: params['seconds'],
+      date: params['date'],
+    },
+  })
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -404,6 +428,7 @@ module.exports = {
   hasuraInsertOrgLocales,
   hasuraInsertPageView,
   hasuraInsertSession,
+  hasuraInsertSessionDuration,
   hasuraInsertGeoSession,
   hasuraInsertReferralSession,
   hasuraListAllLocales,

--- a/script/shared.js
+++ b/script/shared.js
@@ -258,6 +258,31 @@ function hasuraListOrganizations(params) {
   });
 }
 
+const HASURA_INSERT_PAGE_VIEW_DATA = `mutation MyMutation($count: Int!, $date: timestamptz!, $path: String!) {
+  insert_ga_page_views_one(object: {count: $count, date: $date, path: $path}) {
+    updated_at
+    id
+    path
+    created_at
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertPageView(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_PAGE_VIEW_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+      path: params['path'],
+    },
+  })
+}
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -284,11 +309,6 @@ async function fetchGraphQL(params) {
   let operationName = params['name'];
   let variables = params['variables'];
 
-  // console.log(JSON.stringify({
-  //   query: operationQuery,
-  //   variables: variables,
-  //   operationName: operationName}))
-
   const result = await fetch(url, {
     method: 'POST',
     headers: requestHeaders,
@@ -305,6 +325,7 @@ async function fetchGraphQL(params) {
 module.exports = {
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
+  hasuraInsertPageView,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -258,7 +258,7 @@ function hasuraListOrganizations(params) {
   });
 }
 
-const HASURA_INSERT_PAGE_VIEW_DATA = `mutation MyMutation($count: Int!, $date: timestamptz!, $path: String!) {
+const HASURA_INSERT_PAGE_VIEW_DATA = `mutation MyMutation($count: Int!, $date: date!, $path: String!) {
   insert_ga_page_views_one(object: {count: $count, date: $date, path: $path}) {
     updated_at
     id
@@ -280,6 +280,32 @@ function hasuraInsertPageView(params) {
       count: params['count'],
       date: params['date'],
       path: params['path'],
+    },
+  })
+}
+
+const HASURA_INSERT_REFERRAL_SESSION_DATA = `mutation MyMutation($count: Int!, $date: date!, $source: String!) {
+  insert_ga_referral_sessions_one(object: {source: $source, count: $count, date: $date}) {
+    updated_at
+    id
+    created_at
+    source
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertReferralSession(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_REFERRAL_SESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      source: params['source'],
+      date: params['date'],
     },
   })
 }
@@ -379,6 +405,7 @@ module.exports = {
   hasuraInsertPageView,
   hasuraInsertSession,
   hasuraInsertGeoSession,
+  hasuraInsertReferralSession,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -284,6 +284,32 @@ function hasuraInsertPageView(params) {
   })
 }
 
+const HASURA_INSERT_GEO_SESSION_DATA = `mutation MyMutation($count: Int!, $date: date!, $region: String!) {
+  insert_ga_geo_sessions_one(object: {region: $region, count: $count, date: $date}) {
+    updated_at
+    id
+    created_at
+    region
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertGeoSession(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_GEO_SESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      region: params['region'],
+      date: params['date'],
+    },
+  })
+}
+
 const HASURA_INSERT_SESSION_DATA = `mutation MyMutation($count: Int!, $date: date!) {
   insert_ga_sessions_one(object: {count: $count, date: $date}) {
     updated_at
@@ -352,6 +378,7 @@ module.exports = {
   hasuraInsertOrgLocales,
   hasuraInsertPageView,
   hasuraInsertSession,
+  hasuraInsertGeoSession,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -385,6 +385,32 @@ function hasuraInsertSessionDuration(params) {
   })
 }
 
+const HASURA_INSERT_READING_FREQUENCY_DATA = `mutation MyMutation($category: String!, $count: Int!, $date: date!) {
+  insert_ga_reading_frequency_one(object: {count: $count, category: $category, date: $date}) {
+    id
+    updated_at
+    organization_id
+    date
+    created_at
+    category
+    count
+  }
+}`;
+
+function hasuraInsertReadingFrequency(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_READING_FREQUENCY_DATA,
+    name: 'MyMutation',
+    variables: {
+      category: params['category'],
+      count: params['count'],
+      date: params['date'],
+    },
+  })
+}
+
 const HASURA_INSERT_READING_DEPTH_DATA = `mutation MyMutation($date: date!, $path: String!, $read_100: float8!, $read_25: float8!, $read_50: float8!, $read_75: float8!) {
   insert_ga_reading_depth_one(object: {path: $path, date: $date, read_25: $read_25, read_50: $read_50, read_75: $read_75, read_100: $read_100}) {
     id
@@ -502,6 +528,7 @@ module.exports = {
   hasuraInsertReferralSession,
   hasuraGetReadingDepth,
   hasuraInsertReadingDepth,
+  hasuraInsertReadingFrequency,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -283,6 +283,31 @@ function hasuraInsertPageView(params) {
     },
   })
 }
+
+const HASURA_INSERT_SESSION_DATA = `mutation MyMutation($count: Int!, $date: date!) {
+  insert_ga_sessions_one(object: {count: $count, date: $date}) {
+    updated_at
+    id
+    created_at
+    count
+    date
+    organization_id
+  }
+}`;
+
+function hasuraInsertSession(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_SESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+    },
+  })
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -326,6 +351,7 @@ module.exports = {
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
   hasuraInsertPageView,
+  hasuraInsertSession,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -385,6 +385,34 @@ function hasuraInsertSessionDuration(params) {
   })
 }
 
+const HASURA_INSERT_CUSTOM_DIMENSION_DATA = `mutation MyMutation($count: Int!, $date: date!, $dimension: String!, $label: String!) {
+  insert_ga_custom_dimensions_one(object: {count: $count, date: $date, dimension: $dimension, label: $label}) {
+    count
+    created_at
+    date
+    dimension
+    id
+    label
+    organization_id
+    updated_at
+  }
+}`
+
+function hasuraInsertCustomDimension(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_CUSTOM_DIMENSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      count: params['count'],
+      date: params['date'],
+      dimension: params['dimension'],
+      label: params['label'],
+    },
+  })
+}
+
 const HASURA_INSERT_READING_FREQUENCY_DATA = `mutation MyMutation($category: String!, $count: Int!, $date: date!) {
   insert_ga_reading_frequency_one(object: {count: $count, category: $category, date: $date}) {
     id
@@ -529,6 +557,7 @@ module.exports = {
   hasuraGetReadingDepth,
   hasuraInsertReadingDepth,
   hasuraInsertReadingFrequency,
+  hasuraInsertCustomDimension,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,

--- a/script/shared.js
+++ b/script/shared.js
@@ -385,6 +385,34 @@ function hasuraInsertSessionDuration(params) {
   })
 }
 
+const HASURA_INSERT_NEWSLETTER_IMPRESSION_DATA = `mutation MyMutation($action: String!, $date: date!, $impressions: Int!, $path: String!) {
+  insert_ga_newsletter_impressions_one(object: {action: $action, date: $date, impressions: $impressions, path: $path}) {
+    action
+    created_at
+    date
+    id
+    impressions
+    organization_id
+    path
+    updated_at
+  }
+}`;
+
+function hasuraInsertNewsletterImpression(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_NEWSLETTER_IMPRESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      action: params['action'],
+      date: params['date'],
+      impressions: params['impressions'],
+      path: params['path'],
+    },
+  })
+}
+
 const HASURA_INSERT_CUSTOM_DIMENSION_DATA = `mutation MyMutation($count: Int!, $date: date!, $dimension: String!, $label: String!) {
   insert_ga_custom_dimensions_one(object: {count: $count, date: $date, dimension: $dimension, label: $label}) {
     count
@@ -558,6 +586,7 @@ module.exports = {
   hasuraInsertReadingDepth,
   hasuraInsertReadingFrequency,
   hasuraInsertCustomDimension,
+  hasuraInsertNewsletterImpression,
   hasuraListAllLocales,
   hasuraListLocales,
   hasuraListOrganizations,


### PR DESCRIPTION
Fixes #546 

* load dimension2 data from GA into custom dimensions table (this is reading frequency x newsletter signups)
* load newsletter impressions and signups (GA events) into newsletter_impressions
* update tinycms newsletter page to display this

Note: the data around these metrics is really sparse. In order to see anything, you'll need to change the date range to 1 March 2021 -> today.

Related note: should I setup some kind of automated script to click through one or a few of our sites to have better fake metrics data? Just an idea, not sure if there's an easier way to do this. I just don't want the analytics dashboards to break once in use with real data.