### PR TITLE
log notes and success status of each data import run

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -268,9 +268,10 @@ export function getMetricsData(
   });
 }
 
-const INSERT_DATA_IMPORT = `mutation MyMutation($notes: String, $end_date: date, $start_date: date, $table_name: String) {
-  insert_ga_data_imports_one(object: {end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name}) {
+const INSERT_DATA_IMPORT = `mutation MyMutation($success: Boolean, $notes: String, $end_date: date, $start_date: date, $table_name: String) {
+  insert_ga_data_imports_one(object: {success: $success, end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name}) {
     id
+    success
     notes
     end_date
     created_at
@@ -289,6 +290,7 @@ export async function hasuraInsertDataImport(params) {
     name: 'MyMutation',
     variables: {
       notes: params['notes'],
+      success: params['success'],
       end_date: params['end_date'],
       start_date: params['start_date'],
       table_name: params['table_name'],

--- a/pages/api/import/donors.js
+++ b/pages/api/import/donors.js
@@ -129,8 +129,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -139,14 +146,24 @@ export default async (req, res) => {
     table_name: 'ga_donors',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_donors',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };

--- a/pages/api/import/newsletter-impressions.js
+++ b/pages/api/import/newsletter-impressions.js
@@ -118,8 +118,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -128,14 +135,24 @@ export default async (req, res) => {
     table_name: 'ga_newsletter_impressions',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_newsletter_impressions',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };

--- a/pages/api/import/newsletters.js
+++ b/pages/api/import/newsletters.js
@@ -120,8 +120,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -130,14 +137,24 @@ export default async (req, res) => {
     table_name: 'ga_newsletter_signups',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_newsletter_signups',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };

--- a/pages/api/import/reading-depth.js
+++ b/pages/api/import/reading-depth.js
@@ -145,8 +145,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -155,14 +162,24 @@ export default async (req, res) => {
     table_name: 'ga_reading_depth',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_reading_depth',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };

--- a/pages/api/import/reading-frequency.js
+++ b/pages/api/import/reading-frequency.js
@@ -114,8 +114,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -124,14 +131,24 @@ export default async (req, res) => {
     table_name: 'ga_reading_frequency',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_reading_frequency',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };

--- a/pages/api/import/subscribers.js
+++ b/pages/api/import/subscribers.js
@@ -128,8 +128,15 @@ export default async (req, res) => {
     apiUrl: apiUrl,
   });
 
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
   if (results.errors && results.errors.length > 0) {
-    return res.status(500).json({ status: 'error', errors: results.errors });
+    successFlag = false;
+    resultNotes = results.errors;
   }
 
   const auditResult = await hasuraInsertDataImport({
@@ -138,14 +145,24 @@ export default async (req, res) => {
     table_name: 'ga_subscribers',
     start_date: startDate,
     end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
   });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
 
   res.status(200).json({
     name: 'ga_subscribers',
     startDate: startDate,
     endDate: endDate,
-    status: 'OK',
-    message: JSON.stringify(results),
-    audit: JSON.stringify(auditResult),
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
   });
 };


### PR DESCRIPTION
Closes #560 

each run now:

* has clear errors reported back in the response json (or results if successful)
* logs errors or results in the `ga_data_imports` `notes` text field
* logs true if success, false if errors in the `ga_data_imports` `success` boolean field

goes with https://github.com/news-catalyst/hasura/pull/70 which added the success boolean field to the table & graphql schema.