### PR TITLE
Line charts for audience analytics - custom dimensions

### DIFF
--- a/pages/api/import/subscribers.js
+++ b/pages/api/import/subscribers.js
@@ -44,7 +44,7 @@ async function getSubscribers(params) {
             ],
             dimensions: [
               {
-                name: 'ga:dimension4',
+                name: 'ga:dimension5',
               },
             ],
           },


### PR DESCRIPTION
Closes #545 

This displays the day-by-day donor & subscriber sessions on the audience analytics page using a line chart.

I had to fix a typo in subscriber import and reload some of that data - I went back to 1-15 April, so to view it you'll need to adjust the date range until it catches up.