### PR TITLE
Import donation click data

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -170,6 +170,25 @@ export async function hasuraGetReadingFrequency(params) {
   });
 }
 
+const HASURA_GET_DONATION_IMPRESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_donation_impressions(order_by: {date: asc, impressions: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+    impressions
+    action
+    date
+    path
+  }
+}`;
+
+export async function hasuraGetDonationImpressions(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_DONATION_IMPRESSIONS,
+    name: 'MyQuery',
+    variables: { startDate: params['startDate'], endDate: params['endDate'] },
+  });
+}
+
 const HASURA_GET_NEWSLETTER_IMPRESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
   ga_newsletter_impressions(order_by: {date: asc, impressions: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
     impressions
@@ -442,6 +461,34 @@ export async function hasuraInsertNewsletterImpression(params) {
     url: params['url'],
     orgSlug: params['orgSlug'],
     query: HASURA_INSERT_NEWSLETTER_IMPRESSION_DATA,
+    name: 'MyMutation',
+    variables: {
+      action: params['action'],
+      date: params['date'],
+      impressions: params['impressions'],
+      path: params['path'],
+    },
+  });
+}
+
+const HASURA_INSERT_DONATION_IMPRESSION_DATA = `mutation MyMutation($action: String!, $date: date!, $impressions: Int!, $path: String!) {
+  insert_ga_donation_impressions_one(object: {action: $action, date: $date, impressions: $impressions, path: $path}) {
+    action
+    created_at
+    date
+    id
+    impressions
+    organization_id
+    path
+    updated_at
+  }
+}`;
+
+export async function hasuraInsertDonationImpression(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_INSERT_DONATION_IMPRESSION_DATA,
     name: 'MyMutation',
     variables: {
       action: params['action'],

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -177,6 +177,13 @@ const HASURA_GET_DONATION_IMPRESSIONS = `query MyQuery($startDate: date!, $endDa
     date
     path
   }
+  ga_page_views(where: {date: {_gte: $startDate, _lte: $endDate}}) {
+    count
+    date
+    id
+    organization_id
+    path
+  }
 }`;
 
 export async function hasuraGetDonationImpressions(params) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -170,9 +170,9 @@ export async function hasuraGetReadingFrequency(params) {
   });
 }
 
-const HASURA_GET_DONATION_IMPRESSIONS = `query MyQuery($startDate: date!, $endDate: date!) {
-  ga_donation_impressions(order_by: {date: asc, impressions: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
-    impressions
+const HASURA_GET_DONATION_CLICKS = `query MyQuery($startDate: date!, $endDate: date!) {
+  ga_donation_clicks(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+    count
     action
     date
     path
@@ -186,11 +186,11 @@ const HASURA_GET_DONATION_IMPRESSIONS = `query MyQuery($startDate: date!, $endDa
   }
 }`;
 
-export async function hasuraGetDonationImpressions(params) {
+export async function hasuraGetDonationClicks(params) {
   return fetchGraphQL({
     url: params['url'],
     orgSlug: params['orgSlug'],
-    query: HASURA_GET_DONATION_IMPRESSIONS,
+    query: HASURA_GET_DONATION_CLICKS,
     name: 'MyQuery',
     variables: { startDate: params['startDate'], endDate: params['endDate'] },
   });

--- a/pages/api/import/donate-impressions.js
+++ b/pages/api/import/donate-impressions.js
@@ -1,0 +1,164 @@
+import {
+  hasuraInsertDataImport,
+  hasuraInsertDonationImpression,
+  sanitizePath,
+} from '../../../lib/analytics';
+
+const { google } = require('googleapis');
+const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+
+const credsEmail = process.env.GOOGLE_CREDENTIALS_EMAIL;
+const credsPrivateKey = process.env.GOOGLE_CREDENTIALS_PRIVATE_KEY;
+const scopes = [
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/analytics',
+  'https://www.googleapis.com/auth/analytics.edit',
+];
+const auth = new google.auth.JWT(credsEmail, null, credsPrivateKey, scopes);
+const analyticsreporting = google.analyticsreporting({ version: 'v4', auth });
+
+async function getDonationImpressions(params) {
+  let startDate = params['startDate'];
+  let endDate = params['endDate'];
+  let googleAnalyticsViewID = params['viewID'];
+  let apiUrl = params['apiUrl'];
+
+  try {
+    const response = await analyticsreporting.reports.batchGet({
+      requestBody: {
+        reportRequests: [
+          {
+            viewId: googleAnalyticsViewID,
+            dateRanges: [
+              {
+                startDate: startDate,
+                endDate: endDate,
+              },
+            ],
+            metrics: [
+              {
+                expression: 'ga:totalEvents',
+              },
+            ],
+            dimensions: [
+              { name: 'ga:eventAction' },
+              { name: 'ga:eventCategory' },
+              { name: 'ga:eventLabel' },
+              { name: 'ga:pagePath' },
+            ],
+            filtersExpression: 'ga:eventCategory==Donate',
+          },
+        ],
+      },
+    });
+    console.log('GA response:', response);
+
+    if (
+      !response ||
+      !response.data ||
+      !response.data.reports ||
+      !response.data.reports[0] ||
+      !response.data.reports[0].data ||
+      !response.data.reports[0].data.rows
+    ) {
+      const error = new Error('No rows returned for ' + startDate);
+      error.code = '404';
+      throw error;
+    }
+
+    let insertPromises = [];
+    response.data.reports[0].data.rows.forEach((row) => {
+      insertPromises.push(
+        hasuraInsertDonationImpression({
+          url: apiUrl,
+          orgSlug: apiToken,
+          impressions: row.metrics[0].values[0],
+          path: sanitizePath(row.dimensions[3]),
+          date: startDate,
+          action: row.dimensions[0],
+        }).then((result) => {
+          console.log('hasura insert result:', result);
+          if (result.errors) {
+            return { status: 'error', errors: result.errors };
+          } else {
+            return { status: 'ok', result: result, errors: [] };
+          }
+        })
+      );
+    });
+
+    let returnResults = { errors: [], results: [] };
+
+    for await (let result of insertPromises) {
+      console.log('for await result:', result);
+      if (result['errors'] && result['errors'].length > 0) {
+        returnResults['errors'].push(result['errors']);
+      }
+      if (result['result']) {
+        returnResults['results'].push(result['result']);
+      }
+    }
+    console.log('returning this:', returnResults);
+    return returnResults;
+  } catch (e) {
+    console.error('caught error:', e);
+    return { errors: [e] };
+  }
+}
+
+export default async (req, res) => {
+  const { startDate, endDate } = req.query;
+
+  console.log('data import donation impression data:', startDate, endDate);
+  const results = await getDonationImpressions({
+    startDate: startDate,
+    endDate: endDate,
+    viewID: googleAnalyticsViewID,
+    apiUrl: apiUrl,
+  });
+
+  let resultNotes =
+    results.results && results.results[0] && results.results[0].data
+      ? results.results[0].data
+      : JSON.stringify(results);
+
+  let successFlag = true;
+  if (results.errors && results.errors.length > 0) {
+    if (results.errors[0].code && results.errors[0].code === '404') {
+      successFlag = true;
+    } else {
+      successFlag = false;
+    }
+    resultNotes = results.errors;
+  }
+
+  const auditResult = await hasuraInsertDataImport({
+    url: apiUrl,
+    orgSlug: apiToken,
+    table_name: 'ga_donation_impressions',
+    start_date: startDate,
+    end_date: endDate,
+    success: successFlag,
+    notes: JSON.stringify(resultNotes),
+  });
+
+  const auditStatus = auditResult.data ? 'ok' : 'error';
+
+  if (results.errors && results.errors.length > 0) {
+    return res
+      .status(500)
+      .json({ status: 'error', errors: resultNotes, audit: auditStatus });
+  }
+
+  res.status(200).json({
+    name: 'ga_donation_impressions',
+    startDate: startDate,
+    endDate: endDate,
+    status: 'ok',
+    message: resultNotes,
+    audit: auditStatus,
+  });
+};

--- a/pages/api/import/subscribers.js
+++ b/pages/api/import/subscribers.js
@@ -44,7 +44,7 @@ async function getSubscribers(params) {
             ],
             dimensions: [
               {
-                name: 'ga:dimension4',
+                name: 'ga:dimension5',
               },
             ],
           },

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -147,7 +147,6 @@ export default function Audience(props) {
               />
 
               <CustomDimensions
-                viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
                 dimension="dimension4"
@@ -157,7 +156,6 @@ export default function Audience(props) {
               />
 
               <CustomDimensions
-                viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
                 dimension="dimension5"

--- a/pages/tinycms/analytics/audience.js
+++ b/pages/tinycms/analytics/audience.js
@@ -24,9 +24,6 @@ const Header = tw.h1`inline-block text-3xl font-extrabold text-gray-900 tracking
 export default function Audience(props) {
   const [isSignedIn, setIsSignedIn] = useState(false);
 
-  const [viewID, setViewID] = useState(
-    process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID
-  );
   const [startDate, setStartDate] = useState(moment().subtract(30, 'days'));
   const [endDate, setEndDate] = useState(moment());
   const [focusedInput, setFocusedInput] = useState(null);
@@ -143,9 +140,10 @@ export default function Audience(props) {
               />
 
               <DonateClicks
-                viewID={viewID}
                 startDate={startDate}
                 endDate={endDate}
+                apiUrl={props.apiUrl}
+                apiToken={props.apiToken}
               />
 
               <CustomDimensions


### PR DESCRIPTION
I missed this data point: custom event data for donation clicks. Previously pulled live from GA (https://github.com/news-catalyst/next-tinynewsdemo/blob/master/components/tinycms/analytics/DonateClicks.js#L54-L72) and then compared with page view data to display the table of article path, clicks, page views and conversion (clicks/page views * 100).

Closes #576 

<img width="983" alt="Screen Shot 2021-05-18 at 11 58 16 am" src="https://user-images.githubusercontent.com/3397/118578898-5873d980-b7d0-11eb-82d7-dad3a43d5da6.png">

~looks like it needs some work still though so I'm switching this to a draft, will finish after lunch:~ (fixed, marking this as ready)

* ~round the conversion %~ done & pushed to this PR
* ~look up each page view for the dates provided by path - the first one for instance isn't finding a match in the screenshot~ actually it is finding all of the page view data for the given date range, it was accurate; I had just changed the article slug several times during that date range while developing another feature, hence the lack of data