### PR TITLE
yarn data:clear will wipe out analytics data for the current org

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
     "data:import": "node script/data-import.js",
+    "data:clear": "node script/clear-analytics.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
     "remove:org": "node script/remove.js",

--- a/script/clear-analytics.js
+++ b/script/clear-analytics.js
@@ -1,0 +1,32 @@
+const { program } = require('commander');
+program.version('0.0.1');
+
+const shared = require("./shared");
+require('dotenv').config({ path: '.env.local' })
+
+const apiUrl = process.env.HASURA_API_URL;
+const orgSlug = process.env.ORG_SLUG;
+
+async function deleteAnalytics(slug) {
+  const { errors, data } = await shared.hasuraDeleteAnalytics({
+    url: apiUrl,
+    orgSlug: orgSlug,
+    slug: slug,
+  })
+
+  if (errors) {
+    console.error(`Error deleting analytics data for organization '${orgSlug}': `, errors);
+
+  } else {
+    console.log(`Deleted analytics data for organization '${orgSlug}'`, data)
+  }
+}
+
+program
+  // .requiredOption('-s, --slug <slug>', 'unique slug identifier of the organization')
+  .description("removes all data for the current (.env.local defined) org")
+  .action( (opts) => {
+    deleteAnalytics();
+  });
+
+program.parse(process.argv);

--- a/script/shared.js
+++ b/script/shared.js
@@ -553,6 +553,51 @@ function hasuraInsertReadingDepth(params) {
   })
 }
 
+const HASURA_DELETE_ANALYTICS = `mutation MyMutation {
+  delete_ga_data_imports(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_custom_dimensions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_donor_reading_frequency(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_geo_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_newsletter_impressions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_page_views(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_reading_depth(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_reading_frequency(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_referral_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_session_duration(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+}`;
+
+function hasuraDeleteAnalytics(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_DELETE_ANALYTICS,
+    name: 'MyMutation',
+  })
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -626,6 +671,7 @@ module.exports = {
   hasuraInsertDataImport,
   hasuraUpsertSection,
   hasuraRemoveOrganization,
+  hasuraDeleteAnalytics,
   fetchGraphQL,
   sanitizePath
 }


### PR DESCRIPTION
closes #581 

`yarn data:clear` will call a mutation that includes all `ga_` tables at time of writing and deletes all data for the current org. it does the org-limitation via Hasura permissions based on the TNC-Organization header. This relies on your .env.local being set to the intended organization.

Do you think we need to add a confirmation to this? Like "are you sure you want to wipe out $org's data?" or something?