### PR TITLE
Better data import script with `ga:date` dimension

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -583,29 +583,29 @@ export async function hasuraInsertNewsletterImpression(params) {
   });
 }
 
-const HASURA_INSERT_DONATION_IMPRESSION_DATA = `mutation MyMutation($action: String!, $date: date!, $impressions: Int!, $path: String!) {
-  insert_ga_donation_impressions_one(object: {action: $action, date: $date, impressions: $impressions, path: $path}) {
+const HASURA_INSERT_DONATION_CLICK_DATA = `mutation MyMutation($action: String!, $date: date!, $count: Int!, $path: String!) {
+  insert_ga_donation_clicks_one(object: {action: $action, date: $date, count: $count, path: $path}) {
     action
     created_at
     date
     id
-    impressions
+    count
     organization_id
     path
     updated_at
   }
 }`;
 
-export async function hasuraInsertDonationImpression(params) {
+export async function hasuraInsertDonationClick(params) {
   return fetchGraphQL({
     url: params['url'],
     orgSlug: params['orgSlug'],
-    query: HASURA_INSERT_DONATION_IMPRESSION_DATA,
+    query: HASURA_INSERT_DONATION_CLICK_DATA,
     name: 'MyMutation',
     variables: {
       action: params['action'],
       date: params['date'],
-      impressions: params['impressions'],
+      count: params['count'],
       path: params['path'],
     },
   });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "clear": "node script/clear.js",
     "populate": "node script/populate.js",
     "data:import": "node script/data-import.js",
+    "data:clear": "node script/clear-analytics.js",
     "bootstrap": "node script/bootstrap.js",
     "status": "node script/status.js",
     "remove:org": "node script/remove.js",

--- a/pages/api/import/donate-clicks.js
+++ b/pages/api/import/donate-clicks.js
@@ -1,6 +1,6 @@
 import {
   hasuraInsertDataImport,
-  hasuraInsertDonationImpression,
+  hasuraInsertDonationClick,
   sanitizePath,
 } from '../../../lib/analytics';
 
@@ -20,7 +20,7 @@ const scopes = [
 const auth = new google.auth.JWT(credsEmail, null, credsPrivateKey, scopes);
 const analyticsreporting = google.analyticsreporting({ version: 'v4', auth });
 
-async function getDonationImpressions(params) {
+async function getDonationClicks(params) {
   let startDate = params['startDate'];
   let endDate = params['endDate'];
   let googleAnalyticsViewID = params['viewID'];
@@ -72,10 +72,10 @@ async function getDonationImpressions(params) {
     let insertPromises = [];
     response.data.reports[0].data.rows.forEach((row) => {
       insertPromises.push(
-        hasuraInsertDonationImpression({
+        hasuraInsertDonationClick({
           url: apiUrl,
           orgSlug: apiToken,
-          impressions: row.metrics[0].values[0],
+          count: row.metrics[0].values[0],
           path: sanitizePath(row.dimensions[3]),
           date: startDate,
           action: row.dimensions[0],
@@ -112,8 +112,8 @@ async function getDonationImpressions(params) {
 export default async (req, res) => {
   const { startDate, endDate } = req.query;
 
-  console.log('data import donation impression data:', startDate, endDate);
-  const results = await getDonationImpressions({
+  console.log('data import donation click data:', startDate, endDate);
+  const results = await getDonationClicks({
     startDate: startDate,
     endDate: endDate,
     viewID: googleAnalyticsViewID,
@@ -138,7 +138,7 @@ export default async (req, res) => {
   const auditResult = await hasuraInsertDataImport({
     url: apiUrl,
     orgSlug: apiToken,
-    table_name: 'ga_donation_impressions',
+    table_name: 'ga_donation_clicks',
     start_date: startDate,
     end_date: endDate,
     success: successFlag,
@@ -154,7 +154,7 @@ export default async (req, res) => {
   }
 
   res.status(200).json({
-    name: 'ga_donation_impressions',
+    name: 'ga_donation_clicks',
     startDate: startDate,
     endDate: endDate,
     status: 'ok',

--- a/pages/api/import/session-duration.js
+++ b/pages/api/import/session-duration.js
@@ -138,7 +138,7 @@ export default async (req, res) => {
   });
 
   res.status(200).json({
-    name: tableName,
+    name: 'ga_session_duration',
     startDate: startDate,
     endDate: endDate,
     status: 'OK',

--- a/script/clear-analytics.js
+++ b/script/clear-analytics.js
@@ -1,0 +1,32 @@
+const { program } = require('commander');
+program.version('0.0.1');
+
+const shared = require("./shared");
+require('dotenv').config({ path: '.env.local' })
+
+const apiUrl = process.env.HASURA_API_URL;
+const orgSlug = process.env.ORG_SLUG;
+
+async function deleteAnalytics(slug) {
+  const { errors, data } = await shared.hasuraDeleteAnalytics({
+    url: apiUrl,
+    orgSlug: orgSlug,
+    slug: slug,
+  })
+
+  if (errors) {
+    console.error(`Error deleting analytics data for organization '${orgSlug}': `, errors);
+
+  } else {
+    console.log(`Deleted analytics data for organization '${orgSlug}'`, data)
+  }
+}
+
+program
+  // .requiredOption('-s, --slug <slug>', 'unique slug identifier of the organization')
+  .description("removes all data for the current (.env.local defined) org")
+  .action( (opts) => {
+    deleteAnalytics();
+  });
+
+program.parse(process.argv);

--- a/script/data-import.js
+++ b/script/data-import.js
@@ -1,17 +1,34 @@
+const { program } = require('commander');
+program.version('0.0.1');
+
 const fetch = require("node-fetch");
 require('dotenv').config({ path: '.env.local' })
 
 const {format} = require('date-fns');
 
 const baseURL = process.env.SITE_URL + "/api/import/";
-const endpoints = ["donors", "geo-sessions", "newsletter-impressions", "newsletters", "page-views", "reading-depth", "reading-frequency", "referral-sessions", "session-duration", "sessions", "subscribers"];
+const endpoints = [
+  "donate-clicks", 
+  "donor-reading-frequency", 
+  "donors", 
+  "geo-sessions", 
+  "newsletter-impressions", 
+  "newsletters", 
+  "page-views", 
+  "reading-depth", 
+  "reading-frequency", 
+  "referral-sessions", 
+  "session-duration", 
+  "sessions", 
+  "subscribers"
+];
 
 async function runDataImport(startDate, endDate) {
   console.log("running data import:", startDate, endDate);
 
   for await (let endpoint of endpoints) {
     let endpointURL = baseURL + endpoint;
-    endpointURL += `?startDate=${startDate}&endDate=${endDate}`;
+    endpointURL += `?startDate=${format(startDate, 'yyyy-MM-dd')}&endDate=${format(endDate, 'yyyy-MM-dd')}`;
 
     console.log(endpointURL);
 
@@ -30,12 +47,34 @@ async function runDataImport(startDate, endDate) {
   };
 }
 
-let twoDaysAgo = new Date(); 
-twoDaysAgo.setDate(twoDaysAgo.getDate() - 2); 
-let startDate = format(twoDaysAgo, "yyyy-MM-dd")
+program
+  .option('-s, --start-date <startDate>', 'start of the date range')
+  .option('-e, --end-date <endDate>', 'end of the date range')
+  .description("imports daily GA data for each date in the specified range")
+  .action( (opts) => {
+    let startDate;
+    if (opts.startDate === undefined) {
+      let yesterday = new Date(); 
+      startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    } else {
+      startDate = new Date(opts.startDate);
+    }
 
-let yesterday = new Date(); // Today!
-yesterday.setDate(yesterday.getDate() - 1); 
-let endDate = format(yesterday, "yyyy-MM-dd")
+    let endDate;
+    if (opts.endDate === undefined) {
+      let today = new Date(); 
+      endDate = new Date(today.setDate(today.getDate() - 1));
+    } else {
+      endDate = new Date(opts.endDate);
+    }
 
-runDataImport(startDate, endDate);
+    for (var d = startDate; d <= endDate; d.setDate(d.getDate() + 1)) {
+      let sd = new Date(d);
+      let ed = new Date(d.setDate(d.getDate() + 1));
+      // console.log("running data import for", sd, ed);
+      runDataImport(sd, ed);
+    }
+
+  });
+
+program.parse(process.argv);

--- a/script/shared.js
+++ b/script/shared.js
@@ -553,6 +553,51 @@ function hasuraInsertReadingDepth(params) {
   })
 }
 
+const HASURA_DELETE_ANALYTICS = `mutation MyMutation {
+  delete_ga_data_imports(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_custom_dimensions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_donor_reading_frequency(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_geo_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_newsletter_impressions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_page_views(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_reading_depth(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_reading_frequency(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_referral_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_session_duration(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_ga_sessions(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+}`;
+
+function hasuraDeleteAnalytics(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_DELETE_ANALYTICS,
+    name: 'MyMutation',
+  })
+}
+
 async function fetchGraphQL(params) {
   let url;
   let orgSlug;
@@ -626,6 +671,7 @@ module.exports = {
   hasuraInsertDataImport,
   hasuraUpsertSection,
   hasuraRemoveOrganization,
+  hasuraDeleteAnalytics,
   fetchGraphQL,
   sanitizePath
 }


### PR DESCRIPTION
I've updated the data import script (used by me locally and the github action remotely) to:

* default start and end dates to yesterday -> today
* optionally accept params for start and end date
* pass the start and end dates directly to GA API
* along with a `ga:date` dimension to return daily figures for each endpoint
* do this for each defined data import API endpoint

I just ran it locally and it all seemed to work fine, so next I'll be reviewing the analytics data to see it if now makes more sense.

While I was doing this, I noticed the endpoint "donate-impressions" was misnamed and changed it to "donate-clicks" to match the table / reality :)