### PR TITLE
Bugfix/signups by reading frequency bar chart

### DIFF
--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,6 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
 import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import {
   hasuraGetCustomDimension,
   hasuraGetNewsletterImpressions,
 } from '../../../lib/analytics';
@@ -11,8 +22,8 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const NewsletterSignupFormData = (props) => {
   const signupRef = useRef();
 
+  const [chartData, setChartData] = useState([]);
   const [totalImpressions, setTotalImpressions] = useState({});
-  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
     let params = {
@@ -42,7 +53,18 @@ const NewsletterSignupFormData = (props) => {
         }
         freqSigns[item.label] += parseInt(item.count);
       });
-      setFrequencySignups(freqSigns);
+      setChartData([
+        { name: '0 posts', count: freqSigns['0 posts'] },
+        { name: '1 post', count: freqSigns['1 post'] },
+        { name: '2-3 posts', count: freqSigns['2-3 posts'] },
+        { name: '4-5 posts', count: freqSigns['4-5 posts'] },
+        { name: '6-8 posts', count: freqSigns['6-8 posts'] },
+        { name: '9-13 posts', count: freqSigns['9-13 posts'] },
+        { name: '14-21 posts', count: freqSigns['14-21 posts'] },
+        { name: '22-34 posts', count: freqSigns['22-34 posts'] },
+        { name: '35-55 posts', count: freqSigns['35-55 posts'] },
+        { name: '56+', count: freqSigns['56+'] },
+      ]);
     };
     fetchCustomDimension();
 
@@ -136,26 +158,24 @@ const NewsletterSignupFormData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Articles Read</th>
-            <th tw="px-4">Signups</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.keys(frequencySignups).map((label, i) => (
-            <tr key={`frequency-signup-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {label}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {frequencySignups[label]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
 import tw from 'twin.macro';
-import moment from 'moment';
 // import { parsePageViews } from '../../../lib/utils';
 import { hasuraGetPageViews } from '../../../lib/analytics';
 
@@ -9,7 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
-  const [pageViews, setPageViews] = useState([]);
+  const [sortedPageViews, setSortedPageViews] = useState([]);
   const [totalPageViews, setTotalPageViews] = useState({});
 
   useEffect(() => {
@@ -33,8 +32,17 @@ const PageViews = (props) => {
           totalPV[pv.path] = parseInt(pv.count);
         }
       });
-      setPageViews(data.ga_page_views);
+      var sortable = [];
+      Object.keys(totalPV).forEach((path) => {
+        sortable.push([path, totalPV[path]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
       setTotalPageViews(totalPV);
+      setSortedPageViews(sortable);
     };
     fetchPageViews();
     if (window.location.hash && window.location.hash === '#pageviews') {
@@ -62,13 +70,13 @@ const PageViews = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalPageViews).map((path, i) => (
+          {sortedPageViews.map((item, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {path}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalPageViews[path]}
+                {item[1]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -8,6 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
   const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
+  const [sortedFrequency, setSortedFrequency] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -30,9 +31,19 @@ const ReadingFrequencyData = (props) => {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
+      var sortable = [];
+      Object.keys(totalRF).forEach((key) => {
+        sortable.push([key, totalRF[key]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
       setTotalReadingFrequency(totalRF);
+      setSortedFrequency(sortable);
     };
     fetchReadingFrequency();
+
     if (window.location.hash && window.location.hash === '#frequency') {
       if (frequencyRef) {
         frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -58,13 +69,13 @@ const ReadingFrequencyData = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalReadingFrequency).map((category, i) => (
+          {sortedFrequency.map((item, i) => (
             <tr key={`reading-frequency-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {category}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[category]}
+                {totalReadingFrequency[item[0]]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,5 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
+import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 import { hasuraGetReadingFrequency } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-10 pb-5`;
@@ -7,8 +18,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
-  const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
-  const [sortedFrequency, setSortedFrequency] = useState([]);
+  const [chartData, setChartData] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -25,22 +35,26 @@ const ReadingFrequencyData = (props) => {
       }
       let totalRF = {};
       data.ga_reading_frequency.map((rf) => {
+        console.log(rf.category, rf.count);
         if (totalRF[rf.category]) {
           totalRF[rf.category] += parseInt(rf.count);
         } else {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
-      var sortable = [];
-      Object.keys(totalRF).forEach((key) => {
-        sortable.push([key, totalRF[key]]);
-      });
 
-      sortable.sort(function (a, b) {
-        return b[1] - a[1];
-      });
-      setTotalReadingFrequency(totalRF);
-      setSortedFrequency(sortable);
+      setChartData([
+        { name: '0 posts', count: totalRF['0 posts'] },
+        { name: '1 post', count: totalRF['1 post'] },
+        { name: '2-3 posts', count: totalRF['2-3 posts'] },
+        { name: '4-5 posts', count: totalRF['4-5 posts'] },
+        { name: '6-8 posts', count: totalRF['6-8 posts'] },
+        { name: '9-13 posts', count: totalRF['9-13 posts'] },
+        { name: '14-21 posts', count: totalRF['14-21 posts'] },
+        { name: '22-34 posts', count: totalRF['22-34 posts'] },
+        { name: '35-55 posts', count: totalRF['35-55 posts'] },
+        { name: '56+', count: totalRF['56+'] },
+      ]);
     };
     fetchReadingFrequency();
 
@@ -61,26 +75,24 @@ const ReadingFrequencyData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Number of Articles</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedFrequency.map((item, i) => (
-            <tr key={`reading-frequency-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[item[0]]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };


### PR DESCRIPTION
Number of signups according to number of articles read is a similar data set to the number of page views by articles read; I've made the signups by reading frequency a bar chart as well, so this PR continues PR #593 

The data here is lacking but if you change the date range to 01 March -> today you'll see the chart.