### PR TITLE
Bugfix: sort the donor reading frequency table

### DIFF
--- a/components/tinycms/analytics/DonateClicks.js
+++ b/components/tinycms/analytics/DonateClicks.js
@@ -1,9 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
-import {
-  getMetricsData,
-  hasuraGetDonationClicks,
-} from '../../../lib/analytics';
+import { hasuraGetDonationClicks } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-3 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
@@ -13,7 +10,6 @@ const DonateClicks = (props) => {
   const [donateTableRows, setDonateTableRows] = useState([]);
   const [donorFrequencyRows, setDonorFrequencyRows] = useState([]);
   const [totalClickDatas, setTotalClickDatas] = useState({});
-  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
     const fetchDonationClicks = async () => {
@@ -123,43 +119,45 @@ const DonateClicks = (props) => {
       setTotalClickDatas(totalClicks);
 
       let donorFreqRows = [];
-      Object.keys(donorFrequency).map((date, i) => {
-        let uniqueRowKey = `frequency-table-row-${i}`;
-        donorFreqRows.push(
-          <tr key={uniqueRowKey}>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {date}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['1 post'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['2-3 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['4-5 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['6-8 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['9-13 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['14-21 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['22-34 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['35-55 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['56+']}
-            </td>
-          </tr>
-        );
-      });
+      Object.keys(donorFrequency)
+        .sort()
+        .map((date, i) => {
+          let uniqueRowKey = `frequency-table-row-${i}`;
+          donorFreqRows.push(
+            <tr key={uniqueRowKey}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {date}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['1 post'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['2-3 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['4-5 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['6-8 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['9-13 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['14-21 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['22-34 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['35-55 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['56+'] || 0}
+              </td>
+            </tr>
+          );
+        });
       setDonorFrequencyRows(donorFreqRows);
     };
     fetchDonationClicks();
@@ -174,8 +172,9 @@ const DonateClicks = (props) => {
   return (
     <>
       <SubHeaderContainer>
-        <SubHeader>Donate Button Clicks</SubHeader>
+        <SubHeader>Donate Button Clicks with Page Views</SubHeader>
       </SubHeaderContainer>
+
       <p tw="p-2">
         {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
         {props.endDate.format('dddd, MMMM Do YYYY')}
@@ -193,6 +192,9 @@ const DonateClicks = (props) => {
         <tbody>{donateTableRows}</tbody>
       </table>
 
+      <SubHeaderContainer>
+        <SubHeader>Donate Button Clicks by Reading Frequency</SubHeader>
+      </SubHeaderContainer>
       <table tw="pt-10 mt-10 w-full table-auto">
         <thead>
           <tr>

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,6 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
 import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import {
   hasuraGetCustomDimension,
   hasuraGetNewsletterImpressions,
 } from '../../../lib/analytics';
@@ -11,8 +22,8 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const NewsletterSignupFormData = (props) => {
   const signupRef = useRef();
 
+  const [chartData, setChartData] = useState([]);
   const [totalImpressions, setTotalImpressions] = useState({});
-  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
     let params = {
@@ -42,7 +53,18 @@ const NewsletterSignupFormData = (props) => {
         }
         freqSigns[item.label] += parseInt(item.count);
       });
-      setFrequencySignups(freqSigns);
+      setChartData([
+        { name: '0 posts', count: freqSigns['0 posts'] },
+        { name: '1 post', count: freqSigns['1 post'] },
+        { name: '2-3 posts', count: freqSigns['2-3 posts'] },
+        { name: '4-5 posts', count: freqSigns['4-5 posts'] },
+        { name: '6-8 posts', count: freqSigns['6-8 posts'] },
+        { name: '9-13 posts', count: freqSigns['9-13 posts'] },
+        { name: '14-21 posts', count: freqSigns['14-21 posts'] },
+        { name: '22-34 posts', count: freqSigns['22-34 posts'] },
+        { name: '35-55 posts', count: freqSigns['35-55 posts'] },
+        { name: '56+', count: freqSigns['56+'] },
+      ]);
     };
     fetchCustomDimension();
 
@@ -136,26 +158,24 @@ const NewsletterSignupFormData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Articles Read</th>
-            <th tw="px-4">Signups</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.keys(frequencySignups).map((label, i) => (
-            <tr key={`frequency-signup-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {label}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {frequencySignups[label]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
 import tw from 'twin.macro';
-import moment from 'moment';
 // import { parsePageViews } from '../../../lib/utils';
 import { hasuraGetPageViews } from '../../../lib/analytics';
 
@@ -9,7 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
-  const [pageViews, setPageViews] = useState([]);
+  const [sortedPageViews, setSortedPageViews] = useState([]);
   const [totalPageViews, setTotalPageViews] = useState({});
 
   useEffect(() => {
@@ -33,8 +32,17 @@ const PageViews = (props) => {
           totalPV[pv.path] = parseInt(pv.count);
         }
       });
-      setPageViews(data.ga_page_views);
+      var sortable = [];
+      Object.keys(totalPV).forEach((path) => {
+        sortable.push([path, totalPV[path]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
       setTotalPageViews(totalPV);
+      setSortedPageViews(sortable);
     };
     fetchPageViews();
     if (window.location.hash && window.location.hash === '#pageviews') {
@@ -62,13 +70,13 @@ const PageViews = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalPageViews).map((path, i) => (
+          {sortedPageViews.map((item, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {path}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalPageViews[path]}
+                {item[1]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -8,6 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
   const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
+  const [sortedFrequency, setSortedFrequency] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -30,9 +31,19 @@ const ReadingFrequencyData = (props) => {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
+      var sortable = [];
+      Object.keys(totalRF).forEach((key) => {
+        sortable.push([key, totalRF[key]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
       setTotalReadingFrequency(totalRF);
+      setSortedFrequency(sortable);
     };
     fetchReadingFrequency();
+
     if (window.location.hash && window.location.hash === '#frequency') {
       if (frequencyRef) {
         frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -58,13 +69,13 @@ const ReadingFrequencyData = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalReadingFrequency).map((category, i) => (
+          {sortedFrequency.map((item, i) => (
             <tr key={`reading-frequency-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {category}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[category]}
+                {totalReadingFrequency[item[0]]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,5 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
+import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 import { hasuraGetReadingFrequency } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-10 pb-5`;
@@ -7,8 +18,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
-  const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
-  const [sortedFrequency, setSortedFrequency] = useState([]);
+  const [chartData, setChartData] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -25,22 +35,26 @@ const ReadingFrequencyData = (props) => {
       }
       let totalRF = {};
       data.ga_reading_frequency.map((rf) => {
+        console.log(rf.category, rf.count);
         if (totalRF[rf.category]) {
           totalRF[rf.category] += parseInt(rf.count);
         } else {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
-      var sortable = [];
-      Object.keys(totalRF).forEach((key) => {
-        sortable.push([key, totalRF[key]]);
-      });
 
-      sortable.sort(function (a, b) {
-        return b[1] - a[1];
-      });
-      setTotalReadingFrequency(totalRF);
-      setSortedFrequency(sortable);
+      setChartData([
+        { name: '0 posts', count: totalRF['0 posts'] },
+        { name: '1 post', count: totalRF['1 post'] },
+        { name: '2-3 posts', count: totalRF['2-3 posts'] },
+        { name: '4-5 posts', count: totalRF['4-5 posts'] },
+        { name: '6-8 posts', count: totalRF['6-8 posts'] },
+        { name: '9-13 posts', count: totalRF['9-13 posts'] },
+        { name: '14-21 posts', count: totalRF['14-21 posts'] },
+        { name: '22-34 posts', count: totalRF['22-34 posts'] },
+        { name: '35-55 posts', count: totalRF['35-55 posts'] },
+        { name: '56+', count: totalRF['56+'] },
+      ]);
     };
     fetchReadingFrequency();
 
@@ -61,26 +75,24 @@ const ReadingFrequencyData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Number of Articles</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedFrequency.map((item, i) => (
-            <tr key={`reading-frequency-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[item[0]]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -350,16 +350,17 @@ export function getMetricsData(
   });
 }
 
-const INSERT_DATA_IMPORT = `mutation MyMutation($success: Boolean, $notes: String, $end_date: date, $start_date: date, $table_name: String) {
-  insert_ga_data_imports_one(object: {success: $success, end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name}) {
+const INSERT_DATA_IMPORT = `mutation MyMutation($success: Boolean, $notes: String, $end_date: date, $start_date: date, $table_name: String, $row_count: Int) {
+  insert_ga_data_imports_one(object: {success: $success, end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name, row_count: $row_count}) {
     id
     success
     notes
     end_date
-    created_at
     organization_id
     start_date
     table_name
+    row_count
+    created_at
     updated_at
   }
 }`;
@@ -376,6 +377,7 @@ export async function hasuraInsertDataImport(params) {
       end_date: params['end_date'],
       start_date: params['start_date'],
       table_name: params['table_name'],
+      row_count: params['row_count'],
     },
   });
 }


### PR DESCRIPTION
<img width="975" alt="Screen Shot 2021-05-20 at 10 32 30 am" src="https://user-images.githubusercontent.com/3397/118901538-e24daf00-b956-11eb-9042-677551dfd0d1.png">

I added a label to this table as I noticed it was missing, did a fresh import and inspected the GA data to make sure it was really that sparse - it was - and then sorted the rows by date.

Question: I find this pretty hard to review, and that's with the sparse data for only a few days. I'm thinking we should present this differently, what do you think? I'm also wondering, again, how we can get more realistic data in there... 