### PR TITLE
Mailchimp audience data

### DIFF
--- a/components/tinycms/analytics/CustomDimensions.js
+++ b/components/tinycms/analytics/CustomDimensions.js
@@ -15,7 +15,7 @@ const SubHeaderContainer = tw.div`pt-10 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
 
 const CustomDimensions = (props) => {
-  const subscriptionsRef = useRef();
+  const customRef = useRef();
   const [chartData, setChartData] = useState([]);
 
   useEffect(() => {
@@ -47,15 +47,15 @@ const CustomDimensions = (props) => {
     console.log(chartData);
 
     if (window.location.hash && window.location.hash === '#subscriptions') {
-      if (subscriptionsRef) {
-        subscriptionsRef.current.scrollIntoView({ behavior: 'smooth' });
+      if (customRef) {
+        customRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }
   }, [props.startDate, props.endDate]);
 
   return (
     <>
-      <SubHeaderContainer ref={subscriptionsRef}>
+      <SubHeaderContainer ref={customRef}>
         <SubHeader>Sessions by audience segment: {props.label}</SubHeader>
       </SubHeaderContainer>
       <p tw="p-2">

--- a/components/tinycms/analytics/DonateClicks.js
+++ b/components/tinycms/analytics/DonateClicks.js
@@ -7,6 +7,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const DonateClicks = (props) => {
   const donationsRef = useRef();
+
   const [donateTableRows, setDonateTableRows] = useState([]);
   const [donorFrequencyRows, setDonorFrequencyRows] = useState([]);
   const [totalClickDatas, setTotalClickDatas] = useState({});
@@ -42,10 +43,6 @@ const DonateClicks = (props) => {
       });
       data.ga_page_views.map((pv) => {
         if (totalClicks[pv.path]) {
-          console.log(
-            'found matching article for page views:',
-            totalClicks[pv.path]
-          );
           if (totalClicks[pv.path]['pageviews']) {
             totalClicks[pv.path]['pageviews'] += parseInt(pv.count);
           } else {
@@ -64,7 +61,6 @@ const DonateClicks = (props) => {
           donorFrequency[rd.date][rd.label] = parseInt(rd.count);
         }
       });
-      console.log('donor frequency:', donorFrequency);
 
       Object.keys(totalClicks).map((path) => {
         if (totalClicks[path]['pageviews'] > 0) {
@@ -171,7 +167,7 @@ const DonateClicks = (props) => {
 
   return (
     <>
-      <SubHeaderContainer>
+      <SubHeaderContainer ref={donationsRef}>
         <SubHeader>Donate Button Clicks with Page Views</SubHeader>
       </SubHeaderContainer>
 

--- a/components/tinycms/analytics/DonateClicks.js
+++ b/components/tinycms/analytics/DonateClicks.js
@@ -1,9 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
-import {
-  getMetricsData,
-  hasuraGetDonationClicks,
-} from '../../../lib/analytics';
+import { hasuraGetDonationClicks } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-3 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
@@ -13,7 +10,6 @@ const DonateClicks = (props) => {
   const [donateTableRows, setDonateTableRows] = useState([]);
   const [donorFrequencyRows, setDonorFrequencyRows] = useState([]);
   const [totalClickDatas, setTotalClickDatas] = useState({});
-  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
     const fetchDonationClicks = async () => {
@@ -123,43 +119,45 @@ const DonateClicks = (props) => {
       setTotalClickDatas(totalClicks);
 
       let donorFreqRows = [];
-      Object.keys(donorFrequency).map((date, i) => {
-        let uniqueRowKey = `frequency-table-row-${i}`;
-        donorFreqRows.push(
-          <tr key={uniqueRowKey}>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {date}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['1 post'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['2-3 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['4-5 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['6-8 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['9-13 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['14-21 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['22-34 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['35-55 posts'] || 0}
-            </td>
-            <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-              {donorFrequency[date]['56+']}
-            </td>
-          </tr>
-        );
-      });
+      Object.keys(donorFrequency)
+        .sort()
+        .map((date, i) => {
+          let uniqueRowKey = `frequency-table-row-${i}`;
+          donorFreqRows.push(
+            <tr key={uniqueRowKey}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {date}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['1 post'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['2-3 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['4-5 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['6-8 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['9-13 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['14-21 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['22-34 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['35-55 posts'] || 0}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {donorFrequency[date]['56+'] || 0}
+              </td>
+            </tr>
+          );
+        });
       setDonorFrequencyRows(donorFreqRows);
     };
     fetchDonationClicks();
@@ -174,8 +172,9 @@ const DonateClicks = (props) => {
   return (
     <>
       <SubHeaderContainer>
-        <SubHeader>Donate Button Clicks</SubHeader>
+        <SubHeader>Donate Button Clicks with Page Views</SubHeader>
       </SubHeaderContainer>
+
       <p tw="p-2">
         {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
         {props.endDate.format('dddd, MMMM Do YYYY')}
@@ -193,6 +192,9 @@ const DonateClicks = (props) => {
         <tbody>{donateTableRows}</tbody>
       </table>
 
+      <SubHeaderContainer>
+        <SubHeader>Donate Button Clicks by Reading Frequency</SubHeader>
+      </SubHeaderContainer>
       <table tw="pt-10 mt-10 w-full table-auto">
         <thead>
           <tr>

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -109,7 +109,7 @@ export default function MailchimpReport(props) {
                   Click Rate
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {Math.round(report.clicks.click_rate * 100)}%
+                  {report.stats.click_rate.toFixed(2)}%
                 </td>
               </tr>
               <tr>
@@ -117,7 +117,7 @@ export default function MailchimpReport(props) {
                   Subscribe Rate
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {Math.round(report.list_stats.sub_rate * 100)}%
+                  {Math.round(report.list_stats.sub_rate * 100).toFixed(2)}%
                 </td>
               </tr>
               <tr>
@@ -125,7 +125,7 @@ export default function MailchimpReport(props) {
                   Unsubscribe Rate
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {Math.round(report.list_stats.unsub_rate * 100)}%
+                  {Math.round(report.list_stats.unsub_rate * 100).toFixed(2)}%
                 </td>
               </tr>
               {report.growth.history.map((month) => (

--- a/components/tinycms/analytics/MailchimpReport.js
+++ b/components/tinycms/analytics/MailchimpReport.js
@@ -20,7 +20,7 @@ export default function MailchimpReport(props) {
       {props.reports.map((report, i) => (
         <div key={`report-${i}`}>
           <SubHeaderContainer>
-            <SubHeader>Newsletter Campaign: {report.campaign_title}</SubHeader>
+            <SubHeader>Newsletter Audience Stats</SubHeader>
           </SubHeaderContainer>
 
           <table tw="w-full table-auto">
@@ -33,18 +33,26 @@ export default function MailchimpReport(props) {
             <tbody>
               <tr>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  List name
+                  Newsletter emails sent
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {report.list_name}
+                  {report.stats.campaign_count}
                 </td>
               </tr>
               <tr>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  Emails sent
+                  Member Count
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {report.emails_sent}
+                  {report.stats.member_count}
+                </td>
+              </tr>
+              <tr>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  Unsubscribe Count
+                </td>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  {report.stats.unsubscribe_count}
                 </td>
               </tr>
               <tr>
@@ -58,6 +66,22 @@ export default function MailchimpReport(props) {
               </tr>
               <tr>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  Signups since last send
+                </td>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  {report.stats.member_count_since_send}
+                </td>
+              </tr>
+              <tr>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  Unsubscribes since last send
+                </td>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                  {report.stats.unsubscribe_count_since_send}
+                </td>
+              </tr>
+              <tr>
+                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
                   Opens (count)
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
@@ -66,18 +90,10 @@ export default function MailchimpReport(props) {
               </tr>
               <tr>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  Unique Opens
+                  Open rate
                 </td>
                 <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {report.opens.unique_opens}
-                </td>
-              </tr>
-              <tr>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  Open Rate
-                </td>
-                <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                  {Math.round(report.opens.open_rate * 100)}%
+                  {report.stats.open_rate.toFixed(2)}%
                 </td>
               </tr>
               <tr>
@@ -121,7 +137,7 @@ export default function MailchimpReport(props) {
                     <table>
                       <tbody>
                         <tr>
-                          <th>Subscribed</th>
+                          <th>Members</th>
                           <td>{month.subscribed}</td>
                         </tr>
                         <tr>

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -112,7 +112,7 @@ const NewsletterSignupFormData = (props) => {
 
   return (
     <>
-      <SubHeaderContainer>
+      <SubHeaderContainer ref={signupRef}>
         <SubHeader>Website Signup Form</SubHeader>
       </SubHeaderContainer>
       <p tw="p-2">

--- a/components/tinycms/analytics/NewsletterSignupFormData.js
+++ b/components/tinycms/analytics/NewsletterSignupFormData.js
@@ -1,6 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
 import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import {
   hasuraGetCustomDimension,
   hasuraGetNewsletterImpressions,
 } from '../../../lib/analytics';
@@ -11,8 +22,8 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const NewsletterSignupFormData = (props) => {
   const signupRef = useRef();
 
+  const [chartData, setChartData] = useState([]);
   const [totalImpressions, setTotalImpressions] = useState({});
-  const [frequencySignups, setFrequencySignups] = useState({});
 
   useEffect(() => {
     let params = {
@@ -42,7 +53,18 @@ const NewsletterSignupFormData = (props) => {
         }
         freqSigns[item.label] += parseInt(item.count);
       });
-      setFrequencySignups(freqSigns);
+      setChartData([
+        { name: '0 posts', count: freqSigns['0 posts'] },
+        { name: '1 post', count: freqSigns['1 post'] },
+        { name: '2-3 posts', count: freqSigns['2-3 posts'] },
+        { name: '4-5 posts', count: freqSigns['4-5 posts'] },
+        { name: '6-8 posts', count: freqSigns['6-8 posts'] },
+        { name: '9-13 posts', count: freqSigns['9-13 posts'] },
+        { name: '14-21 posts', count: freqSigns['14-21 posts'] },
+        { name: '22-34 posts', count: freqSigns['22-34 posts'] },
+        { name: '35-55 posts', count: freqSigns['35-55 posts'] },
+        { name: '56+', count: freqSigns['56+'] },
+      ]);
     };
     fetchCustomDimension();
 
@@ -136,26 +158,24 @@ const NewsletterSignupFormData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Articles Read</th>
-            <th tw="px-4">Signups</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.keys(frequencySignups).map((label, i) => (
-            <tr key={`frequency-signup-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {label}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {frequencySignups[label]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
 import tw from 'twin.macro';
-import moment from 'moment';
 // import { parsePageViews } from '../../../lib/utils';
 import { hasuraGetPageViews } from '../../../lib/analytics';
 
@@ -9,7 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
-  const [pageViews, setPageViews] = useState([]);
+  const [sortedPageViews, setSortedPageViews] = useState([]);
   const [totalPageViews, setTotalPageViews] = useState({});
 
   useEffect(() => {
@@ -33,8 +32,17 @@ const PageViews = (props) => {
           totalPV[pv.path] = parseInt(pv.count);
         }
       });
-      setPageViews(data.ga_page_views);
+      var sortable = [];
+      Object.keys(totalPV).forEach((path) => {
+        sortable.push([path, totalPV[path]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
       setTotalPageViews(totalPV);
+      setSortedPageViews(sortable);
     };
     fetchPageViews();
     if (window.location.hash && window.location.hash === '#pageviews') {
@@ -62,13 +70,13 @@ const PageViews = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalPageViews).map((path, i) => (
+          {sortedPageViews.map((item, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {path}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalPageViews[path]}
+                {item[1]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingDepthData.js
+++ b/components/tinycms/analytics/ReadingDepthData.js
@@ -43,10 +43,6 @@ const ReadingDepthData = (props) => {
 
       data.ga_page_views.map((pv) => {
         if (totalRD[pv.path]) {
-          console.log(
-            'found matching article for page views:',
-            totalRD[pv.path]
-          );
           if (totalRD[pv.path]['pageviews']) {
             totalRD[pv.path]['pageviews'] += parseInt(pv.count);
           } else {

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -8,6 +8,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
   const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
+  const [sortedFrequency, setSortedFrequency] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -30,9 +31,19 @@ const ReadingFrequencyData = (props) => {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
+      var sortable = [];
+      Object.keys(totalRF).forEach((key) => {
+        sortable.push([key, totalRF[key]]);
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
       setTotalReadingFrequency(totalRF);
+      setSortedFrequency(sortable);
     };
     fetchReadingFrequency();
+
     if (window.location.hash && window.location.hash === '#frequency') {
       if (frequencyRef) {
         frequencyRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -58,13 +69,13 @@ const ReadingFrequencyData = (props) => {
           </tr>
         </thead>
         <tbody>
-          {Object.keys(totalReadingFrequency).map((category, i) => (
+          {sortedFrequency.map((item, i) => (
             <tr key={`reading-frequency-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {category}
+                {item[0]}
               </td>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[category]}
+                {totalReadingFrequency[item[0]]}
               </td>
             </tr>
           ))}

--- a/components/tinycms/analytics/ReadingFrequencyData.js
+++ b/components/tinycms/analytics/ReadingFrequencyData.js
@@ -1,5 +1,16 @@
 import React, { useState, useEffect, useRef } from 'react';
 import tw from 'twin.macro';
+import {
+  BarChart,
+  Bar,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
 import { hasuraGetReadingFrequency } from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-10 pb-5`;
@@ -7,8 +18,7 @@ const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracki
 
 const ReadingFrequencyData = (props) => {
   const frequencyRef = useRef();
-  const [totalReadingFrequency, setTotalReadingFrequency] = useState({});
-  const [sortedFrequency, setSortedFrequency] = useState([]);
+  const [chartData, setChartData] = useState([]);
 
   useEffect(() => {
     let params = {
@@ -25,22 +35,26 @@ const ReadingFrequencyData = (props) => {
       }
       let totalRF = {};
       data.ga_reading_frequency.map((rf) => {
+        console.log(rf.category, rf.count);
         if (totalRF[rf.category]) {
           totalRF[rf.category] += parseInt(rf.count);
         } else {
           totalRF[rf.category] = parseInt(rf.count);
         }
       });
-      var sortable = [];
-      Object.keys(totalRF).forEach((key) => {
-        sortable.push([key, totalRF[key]]);
-      });
 
-      sortable.sort(function (a, b) {
-        return b[1] - a[1];
-      });
-      setTotalReadingFrequency(totalRF);
-      setSortedFrequency(sortable);
+      setChartData([
+        { name: '0 posts', count: totalRF['0 posts'] },
+        { name: '1 post', count: totalRF['1 post'] },
+        { name: '2-3 posts', count: totalRF['2-3 posts'] },
+        { name: '4-5 posts', count: totalRF['4-5 posts'] },
+        { name: '6-8 posts', count: totalRF['6-8 posts'] },
+        { name: '9-13 posts', count: totalRF['9-13 posts'] },
+        { name: '14-21 posts', count: totalRF['14-21 posts'] },
+        { name: '22-34 posts', count: totalRF['22-34 posts'] },
+        { name: '35-55 posts', count: totalRF['35-55 posts'] },
+        { name: '56+', count: totalRF['56+'] },
+      ]);
     };
     fetchReadingFrequency();
 
@@ -61,26 +75,24 @@ const ReadingFrequencyData = (props) => {
         {props.endDate.format('dddd, MMMM Do YYYY')}
       </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Number of Articles</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedFrequency.map((item, i) => (
-            <tr key={`reading-frequency-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {totalReadingFrequency[item[0]]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <BarChart
+        width={740}
+        height={400}
+        data={chartData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="count" fill="#8884d8" />
+      </BarChart>
     </>
   );
 };

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -350,16 +350,17 @@ export function getMetricsData(
   });
 }
 
-const INSERT_DATA_IMPORT = `mutation MyMutation($success: Boolean, $notes: String, $end_date: date, $start_date: date, $table_name: String) {
-  insert_ga_data_imports_one(object: {success: $success, end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name}) {
+const INSERT_DATA_IMPORT = `mutation MyMutation($success: Boolean, $notes: String, $end_date: date, $start_date: date, $table_name: String, $row_count: Int) {
+  insert_ga_data_imports_one(object: {success: $success, end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name, row_count: $row_count}) {
     id
     success
     notes
     end_date
-    created_at
     organization_id
     start_date
     table_name
+    row_count
+    created_at
     updated_at
   }
 }`;
@@ -376,6 +377,7 @@ export async function hasuraInsertDataImport(params) {
       end_date: params['end_date'],
       start_date: params['start_date'],
       table_name: params['table_name'],
+      row_count: params['row_count'],
     },
   });
 }

--- a/pages/tinycms/analytics/newsletter.js
+++ b/pages/tinycms/analytics/newsletter.js
@@ -101,8 +101,13 @@ export async function getServerSideProps(context) {
   });
   let report = reportsResponse.reports[0];
   let listId = report.list_id;
-  let data = await mailchimp.lists.getListGrowthHistory(listId);
-  report['growth'] = data;
+  let growthData = await mailchimp.lists.getListGrowthHistory(listId);
+  report['growth'] = growthData;
+
+  let listData = await mailchimp.lists.getList(listId);
+  console.log('list data:', listData.stats);
+  report['stats'] = listData.stats;
+
   fullReports.push(report);
 
   return {


### PR DESCRIPTION
I updated the newsletter stats, switching most to using Mailchimp's [list stats](https://mailchimp.com/developer/marketing/api/lists/get-list-info/) instead of the per-campaign data. 

From the Mailchimp list api endpoint we get:

```
{
  member_count: 9,
  unsubscribe_count: 0,
  cleaned_count: 1,
  member_count_since_send: 0,
  unsubscribe_count_since_send: 0,
  cleaned_count_since_send: 0,
  campaign_count: 3,
  campaign_last_sent: '',
  merge_field_count: 14,
  avg_sub_rate: 1,
  avg_unsub_rate: 0,
  target_sub_rate: 0,
  open_rate: 42.857142857142854,
  click_rate: 10,
  last_sub_date: '2020-06-10T22:15:13+00:00',
  last_unsub_date: ''
}
```

