### PR TITLE
Fixes for the data import action

### DIFF
--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -2,6 +2,10 @@ name: GA Data Importer
 on:
   schedule:
     - cron: '5 9 * * *'
+  push:
+    branches:
+      - master
+      - feature/run-action-on-push
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/script/data-import.js
+++ b/script/data-import.js
@@ -46,6 +46,7 @@ async function runDataImport(startDate, endDate, table) {
       }
       let message = JSON.parse(resultData)
       console.log("message:", message);
+
       // results.push(message);
       return message;
     })
@@ -80,8 +81,10 @@ program
       endDate = new Date(opts.endDate);
     }
 
-    runDataImport(startDate, endDate, opts.table);
-
+    setInterval(() => {
+      console.log('Waiting several seconds between requests to the GA API...');
+      runDataImport(startDate, endDate, opts.table);
+    }, 5000)
   });
 
 program.parse(process.argv);

--- a/script/data-import.js
+++ b/script/data-import.js
@@ -65,26 +65,30 @@ program
   .option('-t, --table <table>', 'import a single table only')
   .description("imports daily GA data for each date in the specified range")
   .action( (opts) => {
-    let startDate;
-    if (opts.startDate === undefined) {
-      let yesterday = new Date(); 
-      startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
-    } else {
-      startDate = new Date(opts.startDate);
-    }
+    try {
+      let startDate;
+      if (opts.startDate === undefined) {
+        let yesterday = new Date(); 
+        startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+      } else {
+        startDate = new Date(opts.startDate);
+      }
 
-    let endDate;
-    if (opts.endDate === undefined) {
-      let today = new Date(); 
-      endDate = new Date(today.setDate(today.getDate() - 1));
-    } else {
-      endDate = new Date(opts.endDate);
-    }
+      let endDate;
+      if (opts.endDate === undefined) {
+        let today = new Date(); 
+        endDate = new Date(today.setDate(today.getDate() - 1));
+      } else {
+        endDate = new Date(opts.endDate);
+      }
 
-    setInterval(() => {
-      console.log('Waiting several seconds between requests to the GA API...');
-      runDataImport(startDate, endDate, opts.table);
-    }, 5000)
+      setInterval(() => {
+        console.log('Waiting several seconds between requests to the GA API...');
+        runDataImport(startDate, endDate, opts.table);
+      }, 5000)
+    } catch(error) {
+      core.setFailed(error.message);
+    }
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
Closes #598

* fixes the main issue causing the failing jobs: missing a step to install the `commander` package
* additional fix for an intermittent error with the analytics API: 429 too many concurrent requests - this happens and persists for a couple hours if you hit the GA api too much
  * in a previous PR I consolidated a lot of the previous requests into one per data point by adding the `ga:date` dimension (instead of looping over a date array and making one request per date)
  * and in this PR I've added an interval/delay of 5 seconds between requests, because lodging them all at the same still resulted in this `429` error
 * finally, I've also added proper exit status reporting to the action following [the github actions reference guide](https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#setting-a-failure-exit-code-in-a-javascript-action) - just wrap the entire thing in a try/catch and set the job as failed on error. This should help with monitoring going forward... but we probably still need some work on that.