### PR TITLE
return the actual error code when GA requests fail

### DIFF
--- a/pages/api/import/donor-reading-frequency.js
+++ b/pages/api/import/donor-reading-frequency.js
@@ -115,7 +115,7 @@ function importDonorReadingFrequency(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -137,9 +137,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting donor reading frequency data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/geo-sessions.js
+++ b/pages/api/import/geo-sessions.js
@@ -103,7 +103,7 @@ function importGeoSessions(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -124,9 +124,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting geo sessions data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/newsletter-impressions.js
+++ b/pages/api/import/newsletter-impressions.js
@@ -102,7 +102,7 @@ function importNewsletterImpressions(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -123,9 +123,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting newsletter impressions data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/newsletters.js
+++ b/pages/api/import/newsletters.js
@@ -103,7 +103,7 @@ function importNewsletters(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -125,9 +125,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting newsletters data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/page-views.js
+++ b/pages/api/import/page-views.js
@@ -94,7 +94,7 @@ function importPageViews(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -116,9 +116,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting page views data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/reading-depth.js
+++ b/pages/api/import/reading-depth.js
@@ -124,7 +124,7 @@ function importReadingDepth(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -145,9 +145,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting reading depth data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/reading-frequency.js
+++ b/pages/api/import/reading-frequency.js
@@ -99,7 +99,7 @@ function importReadingFrequency(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -122,9 +122,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting reading frequency data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/referral-sessions.js
+++ b/pages/api/import/referral-sessions.js
@@ -93,7 +93,7 @@ function importReferralSessions(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -116,9 +116,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting referral sessions data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/session-duration.js
+++ b/pages/api/import/session-duration.js
@@ -90,7 +90,7 @@ function importSessionDuration(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -114,9 +114,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting session durations data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/sessions.js
+++ b/pages/api/import/sessions.js
@@ -93,7 +93,7 @@ function importSessions(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   console.log('data import page views:', startDate, endDate);
   let rows;
@@ -107,9 +107,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting sessions data from GA',
+      errors: e.message,
     });
   }
 

--- a/pages/api/import/subscribers.js
+++ b/pages/api/import/subscribers.js
@@ -94,7 +94,7 @@ function importSubscribers(rows) {
 }
 
 export default async (req, res) => {
-  const { startDate, endDate } = req.query;
+  let { startDate, endDate } = req.query;
 
   if (startDate === undefined) {
     let yesterday = new Date();
@@ -118,9 +118,9 @@ export default async (req, res) => {
     });
   } catch (e) {
     console.error(e);
-    return res.status(500).json({
+    return res.status(e.code).json({
       status: 'error',
-      errors: 'Failed getting subscribers data from GA',
+      errors: e.message,
     });
   }
 

--- a/script/data-import.js
+++ b/script/data-import.js
@@ -16,8 +16,12 @@ async function runDataImport(startDate, endDate, table) {
   fetch(endpointURL, {
     method: "GET",
   })
-  .then(res => res.json())
+  .then(res => {
+    console.log("converting res to json", res)
+    return res.json()
+  })
   .then(resultData => {
+    console.log("got resultData:", resultData)
     if (resultData.status === 'error' || resultData.errors) {
       const error = new Error("Failed importing data");
       error.code = 500;
@@ -29,6 +33,7 @@ async function runDataImport(startDate, endDate, table) {
     return message;
   })
   .catch(err => {
+    console.log("error from data import api:", err)
     return err
   })
 }


### PR DESCRIPTION
Instead of a generic 500, return the actual error code from google's API. for instance, if we're hitting the rate limit:

```
± |master {10} U:3 ?:13 ✗| → curl -f http://localhost:3000/api/import/donors
curl: (22) The requested URL returned error: 429 Too Many Requests

± |master {10} U:3 ?:13 ✗| → curl -f http://localhost:3000/api/import/donor-reading-frequency
curl: (22) The requested URL returned error: 500 Internal Server Error

± |master {10} U:4 ?:13 ✗| → curl -f http://localhost:3000/api/import/donor-reading-frequency
curl: (22) The requested URL returned error: 429 Too Many Requests

± |master {10} U:4 ?:13 ✗| → curl -f http://localhost:3000/api/import/subscribers
curl: (22) The requested URL returned error: 429 Too Many Requests

± |master {10} U:14 ?:13 ✗| → curl -f http://localhost:3000/api/import/page-views
curl: (22) The requested URL returned error: 429 Too Many Requests
```