### PR TITLE
omit tinycms urls from GA tracking

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -49,23 +49,27 @@ const App = ({ Component, pageProps }) => {
     }
 
     let pagePath = window.location.pathname + window.location.search;
-    console.log(
-      'tracking page view',
-      pagePath,
-      'with custom dimensions:',
-      dimensionsData
-    );
-    trackPageViewedWithDimensions(pagePath, dimensionsData);
-
-    const handleRouteChange = () => {
-      let routeChangeData = trackReadingHistoryWithPageView();
+    if (!/tinycms/.test(pagePath)) {
       console.log(
-        'tracking page view for route change',
+        'tracking page view',
         pagePath,
         'with custom dimensions:',
-        routeChangeData
+        dimensionsData
       );
-      trackPageViewedWithDimensions(pagePath, routeChangeData);
+      trackPageViewedWithDimensions(pagePath, dimensionsData);
+    }
+
+    const handleRouteChange = () => {
+      if (!/tinycms/.test(pagePath)) {
+        let routeChangeData = trackReadingHistoryWithPageView();
+        console.log(
+          'tracking page view for route change',
+          pagePath,
+          'with custom dimensions:',
+          routeChangeData
+        );
+        trackPageViewedWithDimensions(pagePath, routeChangeData);
+      }
     };
     Router.events.on('routeChangeComplete', handleRouteChange);
     return () => {


### PR DESCRIPTION
Closes #609 

I tested both tinycms pages and public pages - the cms no longer is tracked, but the rest of the site is.