### PR TITLE
Bugfix/format dates data import api

### DIFF
--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: echo "🖥️ repo and node are setup"
+      - run: echo "${{env.NEXT_PUBLIC_SITE_URL}}/api/import/donate-clicks"
       - name: donate-clicks
         run: curl -f ${{env.NEXT_PUBLIC_SITE_URL}}/api/import/donate-clicks
       - name: donor-reading-frequency

--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - feature/run-one-data-import-at-a-time
+      - bugfix/format-dates-data-import-api
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -49,23 +49,27 @@ const App = ({ Component, pageProps }) => {
     }
 
     let pagePath = window.location.pathname + window.location.search;
-    console.log(
-      'tracking page view',
-      pagePath,
-      'with custom dimensions:',
-      dimensionsData
-    );
-    trackPageViewedWithDimensions(pagePath, dimensionsData);
-
-    const handleRouteChange = () => {
-      let routeChangeData = trackReadingHistoryWithPageView();
+    if (!/tinycms/.test(pagePath)) {
       console.log(
-        'tracking page view for route change',
+        'tracking page view',
         pagePath,
         'with custom dimensions:',
-        routeChangeData
+        dimensionsData
       );
-      trackPageViewedWithDimensions(pagePath, routeChangeData);
+      trackPageViewedWithDimensions(pagePath, dimensionsData);
+    }
+
+    const handleRouteChange = () => {
+      if (!/tinycms/.test(pagePath)) {
+        let routeChangeData = trackReadingHistoryWithPageView();
+        console.log(
+          'tracking page view for route change',
+          pagePath,
+          'with custom dimensions:',
+          routeChangeData
+        );
+        trackPageViewedWithDimensions(pagePath, routeChangeData);
+      }
     };
     Router.events.on('routeChangeComplete', handleRouteChange);
     return () => {

--- a/pages/api/import/donate-clicks.js
+++ b/pages/api/import/donate-clicks.js
@@ -3,6 +3,7 @@ import {
   hasuraInsertDonationClick,
   sanitizePath,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -116,10 +117,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import donation click data:', startDate, endDate);
 
@@ -133,6 +136,7 @@ export default async (req, res) => {
       apiUrl: apiUrl,
     });
   } catch (e) {
+    console.log('error getting data from GA:', e);
     return res.status(e.code).json({
       status: 'error',
       errors: e.message,
@@ -142,7 +146,7 @@ export default async (req, res) => {
   try {
     importDonateClicks(rows);
   } catch (e) {
-    console.error(e);
+    console.error('error importing data into hasura:', e);
     let code = 500;
     if (e && e.code) {
       code = e.code;

--- a/pages/api/import/donor-reading-frequency.js
+++ b/pages/api/import/donor-reading-frequency.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertDonorReadingFrequency,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -120,10 +121,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import donor reading frequency data:', startDate, endDate);
   let rows;

--- a/pages/api/import/donors.js
+++ b/pages/api/import/donors.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertCustomDimension,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -123,10 +124,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   let rows;
   try {

--- a/pages/api/import/geo-sessions.js
+++ b/pages/api/import/geo-sessions.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertGeoSession,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -108,10 +109,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import page views:', startDate, endDate);
   let rows;

--- a/pages/api/import/newsletter-impressions.js
+++ b/pages/api/import/newsletter-impressions.js
@@ -3,6 +3,7 @@ import {
   hasuraInsertNewsletterImpression,
   sanitizePath,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -107,10 +108,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import newsletter impression data:', startDate, endDate);
   let rows;

--- a/pages/api/import/newsletters.js
+++ b/pages/api/import/newsletters.js
@@ -1,8 +1,8 @@
 import {
   hasuraInsertCustomDimension,
   hasuraInsertDataImport,
-  hasuraInsertPageView,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -108,10 +108,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import newsletter signups dimension2:', startDate, endDate);
 

--- a/pages/api/import/page-views.js
+++ b/pages/api/import/page-views.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertPageView,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -99,10 +100,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import page views:', startDate, endDate);
 

--- a/pages/api/import/reading-depth.js
+++ b/pages/api/import/reading-depth.js
@@ -3,6 +3,7 @@ import {
   hasuraInsertReadingDepth,
   sanitizePath,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -129,10 +130,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import reading depth:', startDate, endDate);
   let rows;

--- a/pages/api/import/reading-frequency.js
+++ b/pages/api/import/reading-frequency.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertReadingFrequency,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -104,10 +105,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import reading frequency:', startDate, endDate);
 

--- a/pages/api/import/referral-sessions.js
+++ b/pages/api/import/referral-sessions.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertReferralSession,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -98,10 +99,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
   console.log('data import referral sessions:', startDate, endDate);
 

--- a/pages/api/import/session-duration.js
+++ b/pages/api/import/session-duration.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertSessionDuration,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -95,10 +96,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
 
   console.log('data import:', startDate, endDate);

--- a/pages/api/import/sessions.js
+++ b/pages/api/import/sessions.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertSession,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -94,6 +95,17 @@ function importSessions(rows) {
 
 export default async (req, res) => {
   let { startDate, endDate } = req.query;
+
+  if (startDate === undefined) {
+    let yesterday = new Date();
+    startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
+  }
+
+  if (endDate === undefined) {
+    endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
+  }
 
   console.log('data import page views:', startDate, endDate);
   let rows;

--- a/pages/api/import/subscribers.js
+++ b/pages/api/import/subscribers.js
@@ -2,6 +2,7 @@ import {
   hasuraInsertDataImport,
   hasuraInsertCustomDimension,
 } from '../../../lib/analytics';
+import { format } from 'date-fns';
 
 const { google } = require('googleapis');
 const googleAnalyticsViewID = process.env.NEXT_PUBLIC_ANALYTICS_VIEW_ID;
@@ -99,10 +100,12 @@ export default async (req, res) => {
   if (startDate === undefined) {
     let yesterday = new Date();
     startDate = new Date(yesterday.setDate(yesterday.getDate() - 1));
+    startDate = format(startDate, 'yyyy-MM-dd');
   }
 
   if (endDate === undefined) {
     endDate = new Date();
+    endDate = format(endDate, 'yyyy-MM-dd');
   }
 
   console.log('data import subscriber data:', startDate, endDate);


### PR DESCRIPTION
Closes #615 

This should fix the failing GH action - the GA API expected dates formatted YYYY-MM-DD, which was happening in a wrapper script that the action is no longer using. I've added date formatting to all API endpoints.

I tested the curl commands using the PR branch deployment URL  (ex: `curl https://next-tinynewsdemo-9pty8l6yq-news-catalyst.vercel.app/`) and found GA is no longer error'ing on invalid dates. Once merged, the GH action should run smoothly.