### PR TITLE
Use Vercel's ignore build step to prevent preview deployments

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -58,12 +58,16 @@ export async function getStaticProps({ locale }) {
     throw errors;
   } else {
     sections = data.categories;
-    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
         sections[i].category_translations,
         'title'
       );
+    }
+    try {
+      siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+    } catch (e) {
+      console.error(e);
     }
   }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -45,7 +45,7 @@ export async function getStaticProps({ locale }) {
     console.log('failed finding site metadata for ', locale, metadatas);
   }
 
-  if (siteMetadata.landingPage) {
+  if (siteMetadata && siteMetadata.landingPage) {
     return {
       props: {
         locale,

--- a/script/build-vercel.sh
+++ b/script/build-vercel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_ENV: $VERCEL_ENV"
+
+if [[ "$VERCEL_ENV" == "production" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled: not production"
+  exit 0;
+fi

--- a/script/build-vercel.sh
+++ b/script/build-vercel.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 echo "VERCEL_ENV: $VERCEL_ENV"
+echo "PREVIEW_DEPLOY: $PREVIEW_DEPLOY"
 
-if [[ "$VERCEL_ENV" == "production" ]] ; then
+if [[ "$VERCEL_ENV" == "production" || "$PREVIEW_DEPLOY" == "1" ]] ; then
   # Proceed with the build
   echo "✅ - Build can proceed"
   exit 1;
 
 else
   # Don't build
-  echo "🛑 - Build cancelled: not production"
+  echo "🛑 - Build cancelled: preview deploys are turned off (set PREVIEW_DEPLOY to '1' to turn on)"
   exit 0;
 fi

--- a/script/vercel.js
+++ b/script/vercel.js
@@ -125,6 +125,34 @@ async function createProject(name, slug) {
         }
         results.push(result);
       }
+      // next set the VERCEL_ENV for preview and production
+      const productionEnvResult = await fetch(envUrl, {
+        method: 'POST',
+        headers: requestHeaders,
+        body: JSON.stringify({
+          "type": "encrypted",
+          "key": "VERCEL_ENV",
+          "value": "production",
+          "target": [
+            "production",
+          ]
+        })
+      });
+      results.push(productionEnvResult);
+      const previewEnvResult = await fetch(envUrl, {
+        method: 'POST',
+        headers: requestHeaders,
+        body: JSON.stringify({
+          "type": "encrypted",
+          "key": "VERCEL_ENV",
+          "value": "preview",
+          "target": [
+            "preview",
+          ]
+        })
+      });
+      results.push(previewEnvResult);
+
       console.log();
       console.log("✅ Done! The project is created in Vercel. To deploy, push to the master branch on github");
       if (envSuccess) {


### PR DESCRIPTION
Closes #626 

This uses vercel's "ignore build step" (see https://vercel.com/support/articles/how-do-i-use-the-ignored-build-step-field-on-vercel#with-a-script) to turn off preview deployments per-org.

* if production env/branch (master), deploy main branch
* if PREVIEW_DEPLOY is set to `1`, deploy this non-main branch
* when bootstrapping a new org, set `PREVIEW_DEPLOY` to `0`
* ... and ensure `VERCEL_ENV` is set to "production" in prod and "preview" in preview (this info isn't available in the build script otherwise)

So if that preview deploy env isn't set, or is set to anything but `1`, and this isn't the main branch, the deployment will be cancelled.