### PR TITLE
turned off global footer on curriculum site

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -13,6 +13,7 @@ export default function Article({
   ads,
   siteMetadata,
   sectionArticles,
+  renderFooter,
 }) {
   const isAmp = useAmp();
 
@@ -22,7 +23,12 @@ export default function Article({
   siteMetadata['canonicalUrl'] = canonicalArticleUrl;
 
   return (
-    <Layout meta={siteMetadata} article={article} sections={sections}>
+    <Layout
+      meta={siteMetadata}
+      article={article}
+      sections={sections}
+      renderFooter={renderFooter}
+    >
       <div className="post">
         <ArticleHeader
           article={article}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -22,6 +22,7 @@ export default function Layout({
   article,
   sections,
   renderNav = true,
+  renderFooter = true,
 }) {
   if (meta === null || meta === undefined) {
     meta = {};
@@ -217,7 +218,7 @@ export default function Layout({
           )}
           {children}
         </Main>
-        <GlobalFooter metadata={metaValues} />
+        {renderFooter && <GlobalFooter metadata={metaValues} />}
       </ThemeWrapper>
     </>
   );

--- a/components/curriculum/CurriculumHomepage.js
+++ b/components/curriculum/CurriculumHomepage.js
@@ -24,7 +24,12 @@ export default function CurriculumHomepage({
 
   return (
     <div className="homepage">
-      <Layout meta={siteMetadata} sections={sections} locale={locale}>
+      <Layout
+        meta={siteMetadata}
+        sections={sections}
+        locale={locale}
+        renderFooter={false}
+      >
         <HomepageHeader />
         <Grid
           header="Pre-Program Information & Training"

--- a/pages/[category].js
+++ b/pages/[category].js
@@ -26,7 +26,11 @@ export default function CategoryPage(props) {
   }
 
   return (
-    <Layout meta={props.siteMetadata} sections={props.sections}>
+    <Layout
+      meta={props.siteMetadata}
+      sections={props.sections}
+      renderFooter={props.renderFooter}
+    >
       <ArticleStream
         articles={props.articles}
         sections={props.sections}
@@ -138,6 +142,11 @@ export async function getStaticProps({ locale, params }) {
     expandedAds = allAds.filter((ad) => ad.adTypeId === 166 && ad.status === 4);
   }
 
+  let renderFooter = true;
+  if (process.env.ORG_SLUG === 'tiny-news-curriculum') {
+    renderFooter = false; // turns off the global footer for the curriculum site
+  }
+
   return {
     props: {
       articles,
@@ -147,6 +156,7 @@ export async function getStaticProps({ locale, params }) {
       sections,
       siteMetadata,
       expandedAds,
+      renderFooter,
     },
   };
 }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -127,6 +127,11 @@ export async function getStaticProps({ locale, params }) {
     ads = allAds.filter((ad) => ad.adTypeId === 164 && ad.status === 4);
   }
 
+  let renderFooter = true;
+  if (process.env.ORG_SLUG === 'tiny-news-curriculum') {
+    renderFooter = false; // turns off the global footer for the curriculum site
+  }
+
   return {
     props: {
       article,
@@ -134,6 +139,7 @@ export async function getStaticProps({ locale, params }) {
       ads,
       siteMetadata,
       sectionArticles,
+      renderFooter,
     },
     // Re-generate the post at most once per second
     // if a request comes in


### PR DESCRIPTION
keyed off the ORG_SLUG in the environment. 

we could potentially have this setting (and maybe `renderNav`) be configured in the site settings, but for now, this will remove the problematic footer from the curriculum site.

tested locally by doing:

```
./script/switch oaklyn
yarn dev
// review site, should include footer: article, home, category, author, tag, donate pages
./script/switch curriculum
yarn dev
// review site, should _not_ include footer: home, article, category (IIRC that's it for the member curriculum site)