### PR TITLE
Use main_image field instead of full article contents

### DIFF
--- a/components/curriculum/Grid.js
+++ b/components/curriculum/Grid.js
@@ -14,9 +14,7 @@ export default function Grid({ header, type, articles }) {
       articles[i].article_translations[
         articles[i].article_translations.length - 1
       ];
-    const mainImageNode = translation.content.find(
-      (node) => node.type === 'mainImage'
-    );
+    const mainImageNode = translation.main_image;
     let mainImage = null;
 
     if (mainImageNode) {

--- a/components/curriculum/GridItem.js
+++ b/components/curriculum/GridItem.js
@@ -4,7 +4,7 @@ import Image from 'next/image';
 
 const ItemWrapper = tw.div`w-full md:w-1/2 lg:w-1/3 p-4`;
 const Item = tw.div`w-full border border-gray-200 shadow-lg`;
-const ItemImageContainer = tw.div`w-full h-64 mb-4`;
+const ItemImageContainer = tw.div`w-full h-full mb-4`;
 const ItemTextContainer = tw.div`w-full p-6 pt-0`;
 const Hammer = tw.p`text-xs font-bold uppercase mb-2 text-gray-500`;
 const ItemHeader = tw.h3`text-2xl font-bold leading-tight tracking-tight mb-4`;

--- a/components/curriculum/GridItem.js
+++ b/components/curriculum/GridItem.js
@@ -23,15 +23,17 @@ export default function GridItem({ header, dek, image, hammer, article }) {
               minHeight: '25rem',
             }}
           >
-            <ItemImageContainer>
-              <Image
-                src={image.imageUrl}
-                width={1080}
-                height={(image.height / image.width) * 1080}
-                alt={image.imageAlt}
-                className="image"
-              />
-            </ItemImageContainer>
+            {image && (
+              <ItemImageContainer>
+                <Image
+                  src={image.imageUrl}
+                  width={1080}
+                  height={(image.height / image.width) * 1080}
+                  alt={image.imageAlt}
+                  className="image"
+                />
+              </ItemImageContainer>
+            )}
             <ItemTextContainer>
               <Hammer>{hammer}</Hammer>
               <ItemHeader>{header}</ItemHeader>

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -47,17 +47,17 @@ export default function ArticleLink({
     );
   }
 
-  let articleContent = hasuraLocaliseText(
+  let mainImageContent = hasuraLocaliseText(
     article.article_translations,
-    'content'
+    'main_image'
   );
   if (
-    articleContent !== null &&
-    articleContent !== undefined &&
-    typeof articleContent !== 'string'
+    mainImageContent !== null &&
+    mainImageContent !== undefined &&
+    typeof mainImageContent !== 'string'
   ) {
     try {
-      mainImageNode = articleContent.find((node) => node.type === 'mainImage');
+      mainImageNode = mainImageContent;
     } catch (e) {
       console.log(
         article.id,

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -5,26 +5,13 @@ import tw from 'twin.macro';
 const AssetThumbnail = tw.div`overflow-hidden relative w-full mb-4 md:mb-0 md:ml-5 order-2 w-full`;
 
 export default function FeaturedArticleThumbnail({ article, isAmp }) {
-  let mainImage = null;
+  let mainImage = {};
   let mainImageNode = null;
 
   const translation = article['article_translations'][0];
 
-  try {
-    if (translation) {
-      if (typeof translation.content === 'string') {
-        mainImageNode = JSON.parse(translation.content).find(
-          (node) => node.type === 'mainImage'
-        );
-      } else {
-        mainImageNode = translation.content.find(
-          (node) => node.type === 'mainImage'
-        );
-      }
-    }
-  } catch (err) {
-    console.error(err, translation);
-  }
+  console.log('FeaturedArticleThumbnail translation:', translation);
+  mainImageNode = translation.main_image;
 
   try {
     if (mainImageNode) {

--- a/components/nav/GlobalNav.js
+++ b/components/nav/GlobalNav.js
@@ -16,7 +16,7 @@ const SectionLink = styled.a(({ meta }) => ({
 export default function GlobalNav({ metadata, sections }) {
   let sectionLinks;
 
-  if (sections && typeof sections[0].title === 'string') {
+  if (sections && sections[0] && typeof sections[0].title === 'string') {
     sectionLinks = sections.slice(0, 4).map((section) => (
       <Link key={`navbar-${section.slug}`} href={`/${section.slug}`} passHref>
         <SectionLink href={`/${section.slug}`} meta={metadata}>

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -75,14 +75,14 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
   homepage_layout_datas {
     first_article {
       id
-      article_translations(where: {locale_code: {_eq: $locale_code}}) {
-        content
+      article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
         custom_byline
         facebook_description
         facebook_title
         first_published_at
         headline
         last_published_at
+        main_image
         search_description
         search_title
         twitter_description
@@ -123,8 +123,8 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
     }
     second_article {
       id
-      article_translations(where: {locale_code: {_eq: $locale_code}}) {
-        content
+      article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
+        main_image
         custom_byline
         facebook_description
         facebook_title
@@ -166,8 +166,8 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
     }
     third_article {
       id
-      article_translations(where: {locale_code: {_eq: $locale_code}}) {
-        content
+      article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
+        main_image
         custom_byline
         facebook_description
         facebook_title

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -19,12 +19,12 @@ const HASURA_GET_STREAM_ARTICLES = `query FrontendGetStreamArticles($locale_code
   articles(where: {id: {_nin: $ids}, article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}, limit: $limit, order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}) {
     id
     slug
-    article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}) {
-      content
+    article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
       custom_byline
       first_published_at
       headline
       last_published_at
+      main_image
       published
       search_description
       updated_at


### PR DESCRIPTION
https://github.com/news-catalyst/next-tinynewsdemo/issues/682

I switched the featured article(s) query and the article stream query to request the main_image instead of content fields. I updated the components that I saw using these fields to instead use the main_image field directly, which is also JSONB, so the change wasn't too dire.

