### PR TITLE
Feature/optional comments

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -22,6 +22,8 @@ export default function Article({
   let canonicalArticleUrl = generateArticleUrl(baseUrl, article);
   siteMetadata['canonicalUrl'] = canonicalArticleUrl;
 
+  const displayComments = siteMetadata['commenting'] === 'on';
+
   return (
     <Layout
       meta={siteMetadata}
@@ -48,7 +50,7 @@ export default function Article({
             metadata={siteMetadata}
           />
         </section>
-        <Comments article={article} isAmp={isAmp} />
+        {displayComments && <Comments article={article} isAmp={isAmp} />}
         <Recirculation
           articles={sectionArticles}
           isAmp={isAmp}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -146,6 +146,8 @@ export default function SiteInfoSettings(props) {
     props.parsedData['twitterDescription']
   );
 
+  const [commenting, setCommenting] = useState(props.parsedData['commenting']);
+
   const [shortName, setShortName] = useState(props.parsedData['shortName']);
   const [siteUrl, setSiteUrl] = useState(props.parsedData['siteUrl']);
   const [color, setColor] = useState(props.parsedData['color']);
@@ -180,6 +182,8 @@ export default function SiteInfoSettings(props) {
     setFacebookDescription(props.parsedData['facebookDescription']);
     setTwitterTitle(props.parsedData['twitterTitle']);
     setTwitterDescription(props.parsedData['twitterDescription']);
+
+    setCommenting(props.parsedData['commenting']);
 
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
@@ -233,6 +237,35 @@ export default function SiteInfoSettings(props) {
             folderName="logos"
           />
         </label>
+      </SiteInfoFieldsContainer>
+
+      <SettingsHeader ref={props.siteInfoRef} id="siteInfo">
+        Comments
+      </SettingsHeader>
+
+      <SiteInfoFieldsContainer>
+        <div>
+          <label>
+            <input
+              type="radio"
+              name="commenting"
+              value="on"
+              checked={commenting === 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">On</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="commenting"
+              value="on"
+              checked={commenting !== 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">Off</span>
+          </label>
+        </div>
       </SiteInfoFieldsContainer>
 
       <SettingsHeader ref={props.designRef} id="design">

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -259,7 +259,7 @@ export default function SiteInfoSettings(props) {
             <input
               type="radio"
               name="commenting"
-              value="on"
+              value="off"
               checked={commenting !== 'on'}
               onChange={props.handleChange}
             />

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -524,7 +524,8 @@ async function createOrganization(opts) {
           "footerBylineName": "News Catalyst",
           "searchDescription": "Page description",
           "twitterDescription": "Twitter description",
-          "facebookDescription": "Facebook description"
+          "facebookDescription": "Facebook description",
+          "commenting": "on"
         };
 
         locales.map( (locale) => {


### PR DESCRIPTION
Closes #661 

I probably should have hooked this work off of the branch pointing at the new coral instance, as then you'd see the working comments form display, but it's still pointing at the old heroku version here.

To test, go to the tinycms settings and turn commenting on, save, load an article, you should see the page try to render off of heroku's coral instance; turning it off prevents that component from being rendered.