### PR TITLE
Bugfix/local storage tracking

### DIFF
--- a/components/plugins/PromotionBlock.js
+++ b/components/plugins/PromotionBlock.js
@@ -1,5 +1,6 @@
 import NewsletterBlock from './NewsletterBlock';
 import DonationBlock from './DonationBlock';
+import storage from 'local-storage-fallback';
 
 export default function PromotionBlock({ metadata, prefer }) {
   let promo = null;
@@ -7,7 +8,10 @@ export default function PromotionBlock({ metadata, prefer }) {
   const donation = <DonationBlock metadata={metadata} />;
 
   if (prefer === 'newsletter') {
-    if (process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL) {
+    if (
+      process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL &&
+      !storage.getItem('TNCNewsletterSubscriber')
+    ) {
       promo = newsletter;
     } else if (process.env.NEXT_PUBLIC_MONKEYPOD_URL) {
       promo = donation;

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -38,8 +38,6 @@ export const useAnalytics = () => {
       );
     },
     trackMailChimpParams: () => {
-      const cookies = new Cookies();
-
       let campaignId = getQueryVariable('mc_cid');
       let emailId = getQueryVariable('mc_eid');
 
@@ -48,15 +46,14 @@ export const useAnalytics = () => {
           campaignId: campaignId,
           emailId: emailId,
         };
-        cookies.set('nc_mct', JSON.stringify(cookieValue), {
-          path: '/',
-          maxAge: 3600, // Expires after 1hr
-          sameSite: true,
-        });
+        storage.setItem('TNCNewsletterSubscriber', JSON.stringify(cookieValue));
         return true;
       } else {
         return false;
       }
+    },
+    newsletterStatusFromStorage: () => {
+      return storage.getItem('TNCNewsletterSubscriber');
     },
     logReadingHistory: () => {
       let history = JSON.parse(storage.getItem('TNCHistory'));
@@ -77,23 +74,17 @@ export const useAnalytics = () => {
 
       storage.setItem('TNCHistory', JSON.stringify(history));
     },
-    donorStatusFromCookie: () => {
-      const cookies = new Cookies();
-      return cookies.get('nc_donor');
+    donorStatusFromStorage: () => {
+      return storage.getItem('TNCDonor');
     },
     checkReferrer: (referrer) => {
       if (!referrer) {
         return false;
       }
 
-      const cookies = new Cookies();
       let parsedReferrer = new URL(referrer);
       if (/monkeypod\.io/.test(parsedReferrer.hostname)) {
-        cookies.set('nc_donor', true, {
-          path: '/',
-          maxAge: 3600, // Expires after 1hr
-          sameSite: true,
-        });
+        storage.setItem('TNCDonor', true);
         return true;
       }
       return false;

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -1,6 +1,5 @@
 import ReactGA from 'react-ga';
 import storage from 'local-storage-fallback';
-import Cookies from 'universal-cookie';
 import { getQueryVariable } from '../utils.js';
 
 export const useAnalytics = () => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -27,7 +27,8 @@ const App = ({ Component, pageProps }) => {
     setDimension,
     logReadingHistory,
     summarizeReadingHistory,
-    donorStatusFromCookie,
+    donorStatusFromStorage,
+    newsletterStatusFromStorage,
     trackMailChimpParams,
   } = useAnalytics();
   const isAmp = useAmp();
@@ -37,8 +38,9 @@ const App = ({ Component, pageProps }) => {
     }
 
     function trackNewsletterVisits(trackMailChimpParams) {
-      let isSubscriber = trackMailChimpParams();
-      if (isSubscriber) {
+      let hitFromSubscriber = trackMailChimpParams();
+      let isLoggedSubscriber = newsletterStatusFromStorage();
+      if (hitFromSubscriber || isLoggedSubscriber) {
         setDimension('dimension5', true);
         return {
           dimension5: true,
@@ -66,7 +68,7 @@ const App = ({ Component, pageProps }) => {
       ...newsletterDimensionsData,
     };
 
-    let donorStatus = donorStatusFromCookie();
+    let donorStatus = donorStatusFromStorage();
     if (donorStatus) {
       setDimension('dimension4', true);
       dimensionsData['dimension4'] = true;


### PR DESCRIPTION
This moves donation/subscription tracking to local storage so we can track across sessions. It also adds logic for newsletter subscribers to see donation prompts instead. Closes #712. Closes #690.