### PR TITLE
Default opengraph image uploader

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -37,11 +37,12 @@ export default function Layout({
     facebookDescription: meta['facebookDescription'],
     twitterTitle: meta['twitterTitle'],
     twitterDescription: meta['twitterDescription'],
-    coverImage: meta['coverImage'],
+    coverImage: meta['coverImage'] || meta['defaultSocialImage'],
     footerTitle: meta['footerTitle'],
     footerBylineLink: meta['footerBylineLink'],
     footerBylineName: meta['footerBylineName'],
   };
+
   if (article) {
     metaValues.section = hasuraLocaliseText(
       article.category.category_translations,

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -603,7 +603,13 @@ export default function SiteInfoSettings(props) {
         <div tw="mt-2">
           <label htmlFor="defaultSocialImage">
             <span tw="mt-1 font-bold">Default social image</span>{' '}
-            <span tw="text-gray-600">(used when article lacks an image)</span>
+            <span tw="text-gray-600">
+              (for best results, use an image with a 16:9 aspect ratio.{' '}
+              <a href="https://pixelhunter.io/#Facebook" target="_new">
+                Pixelhunter has several examples for reference
+              </a>
+              .)
+            </span>
             <Upload
               awsConfig={props.awsConfig}
               slug={shortName}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -182,6 +182,9 @@ export default function SiteInfoSettings(props) {
     props.parsedData['newsletterDek']
   );
   const [logo, setLogo] = useState(props.parsedData['logo']);
+  const [defaultSocialImage, setDefaultSocialImage] = useState(
+    props.parsedData['defaultSocialImage']
+  );
 
   useEffect(() => {
     setSearchTitle(props.parsedData['searchTitle']);
@@ -209,6 +212,9 @@ export default function SiteInfoSettings(props) {
     setMembershipHed(props.parsedData['membershipHed']);
     setNewsletterDek(props.parsedData['newsletterDek']);
     setNewsletterHed(props.parsedData['newsletterHed']);
+
+    setLogo(props.parsedData['logo']);
+    setDefaultSocialImage(props.parsedData['defaultSocialImage']);
   }, [props.parsedData]);
 
   return (
@@ -242,6 +248,7 @@ export default function SiteInfoSettings(props) {
             awsConfig={props.awsConfig}
             slug={shortName}
             image={logo}
+            imageKey="logo"
             updateParsedData={props.updateParsedData}
             parsedData={props.parsedData}
             setter={setLogo}
@@ -592,6 +599,26 @@ export default function SiteInfoSettings(props) {
         <SettingsHeader tw="col-span-3 mt-5" id="seo">
           SEO and Social Metadata
         </SettingsHeader>
+
+        <div tw="mt-2">
+          <label htmlFor="defaultSocialImage">
+            <span tw="mt-1 font-bold">Default social image</span>{' '}
+            <span tw="text-gray-600">(used when article lacks an image)</span>
+            <Upload
+              awsConfig={props.awsConfig}
+              slug={shortName}
+              imageKey="defaultSocialImage"
+              image={defaultSocialImage}
+              updateParsedData={props.updateParsedData}
+              parsedData={props.parsedData}
+              setter={setDefaultSocialImage}
+              setNotificationMessage={props.setNotificationMessage}
+              setNotificationType={props.setNotificationType}
+              setShowNotification={props.setShowNotification}
+              folderName="social"
+            />
+          </label>
+        </div>
 
         <div tw="mt-2">
           <label htmlFor="searchTitle">

--- a/components/tinycms/Upload.js
+++ b/components/tinycms/Upload.js
@@ -28,10 +28,11 @@ export default function Upload(props) {
         if (data.status === 204) {
           props.setter(data.location);
 
-          let updatedParsedData = props.parsedData;
-          updatedParsedData['logo'] = data.location;
-
-          props.updateParsedData(updatedParsedData);
+          if (props.parsedData) {
+            let updatedParsedData = props.parsedData;
+            updatedParsedData[props.imageKey] = data.location;
+            props.updateParsedData(updatedParsedData);
+          }
 
           setImageSrc(data.location + '?' + Math.random());
           setRandomKey(Math.random());


### PR DESCRIPTION
Closes #691 

Adds an image uploader to TinyCMS settings under SEO/Social. I included short help text mentioning image aspect ratio and linked to a page I use for this stuff at Pixelhunter, but I'm happy to change that if you have a better reference.

This PR also updates the Layout component to use this default image if no coverImage is found on the article.