### PR TITLE
Coral Talk embed off the new domain

### DIFF
--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -10,7 +10,6 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
 
   const translation = article['article_translations'][0];
 
-  console.log('FeaturedArticleThumbnail translation:', translation);
   mainImageNode = translation.main_image;
 
   try {

--- a/public/coral.js
+++ b/public/coral.js
@@ -2,7 +2,7 @@
     let d = document, s = d.createElement('script');
     let storyURL = window.location.href;
     // s.src = '//' + url + '/assets/js/embed.js';
-    s.src = 'http://coral-talk-lb-1654697893.us-east-1.elb.amazonaws.com/assets/js/embed.js';
+    s.src = '//coral.tinynewsco.org/assets/js/embed.js';
     s.async = false;
     s.defer = true;
     s.onload = function() {
@@ -10,7 +10,7 @@
             id: "coral_thread",
             autoRender: true,
             // rootURL: '//' + url,
-            rootURL: 'http://coral-talk-lb-1654697893.us-east-1.elb.amazonaws.com',
+            rootURL: '//coral.tinynewsco.org',
             // Uncomment these lines and replace with the ID of the
             // story's ID and URL from your CMS to provide the
             // tightest integration. Refer to our documentation at


### PR DESCRIPTION
Closes #709 

Changes coral talk to point at coral.tinynewsco.org and allows rendering embed in firefox.

<img width="1098" alt="Screen Shot 2021-07-29 at 9 04 48 am" src="https://user-images.githubusercontent.com/3397/127407561-da5e9f8c-7776-4e23-8d00-f6c5eb7f8313.png">
