### PR TITLE
Letterhead-backed Newsletter Subscription

### DIFF
--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -69,7 +69,8 @@ export default function ArticleLink({
     }
   }
 
-  if (mainImageNode) {
+  if (mainImageNode && Object.keys(mainImageNode).length > 0) {
+    console.log(article.slug, 'articleLink mainImageNode:', mainImageNode);
     mainImage = mainImageNode.children[0];
   }
 

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -13,7 +13,7 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
   mainImageNode = translation.main_image;
 
   try {
-    if (mainImageNode) {
+    if (mainImageNode && Object.keys(mainImageNode).length > 0) {
       mainImage = mainImageNode.children[0];
     }
   } catch (err) {

--- a/components/plugins/MailchimpSubscribe.js
+++ b/components/plugins/MailchimpSubscribe.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import tw, { styled } from 'twin.macro';
-import MailchimpSubscribe from 'react-mailchimp-subscribe';
 import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
 import { useInView } from 'react-intersection-observer';
 import { determineTextColor } from '../../lib/utils';
@@ -8,21 +7,35 @@ import Colors from '../common/Colors';
 
 const Group = tw.div`relative`;
 const Input = tw.input`block w-full border-b border-gray-500 opacity-70 text-black font-bold`;
-const Bar = tw.div``;
 const Submit = styled.input(({ textColor, backgroundColor }) => ({
   ...tw`block absolute cursor-pointer rounded-full font-bold leading-none w-8 h-8 pl-2 right-2 z-10`,
   backgroundColor: backgroundColor,
   color: textColor,
 }));
 
-// you can get this url from the embed code form action
-const url = process.env.NEXT_PUBLIC_MAILCHIMP_SUBSCRIBE_URL;
+const url = '/api/subscribe/';
 
-const CustomForm = ({ status, message, onValidated, metadata }) => {
+const Newsletter = ({ articleTitle, metadata }) => {
+  const { trackEvent } = useAnalytics();
+  const [ref, inView] = useInView({ triggerOnce: true });
+
   const [textColor, setTextColor] = useState(null);
   const [backgroundColor, setBackgroundColor] = useState(null);
 
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState(null);
+  const [message, setMessage] = useState(null);
+
   useEffect(() => {
+    if (inView) {
+      trackEvent({
+        action: 'newsletter modal impression 1',
+        category: 'NTG newsletter',
+        label: articleTitle,
+        non_interaction: true,
+      });
+    }
+
     let bgc;
     let tc;
 
@@ -36,97 +49,88 @@ const CustomForm = ({ status, message, onValidated, metadata }) => {
 
     setBackgroundColor(bgc);
     setTextColor(tc);
-  }, [metadata]);
+  }, [inView, articleTitle, trackEvent, metadata]);
 
-  let email, name;
-  const submit = () =>
-    email &&
-    email.value.indexOf('@') > -1 &&
-    onValidated({
-      EMAIL: email.value,
-    });
-
-  return (
-    <div>
-      {status === 'sending' && <div style={{ color: 'blue' }}>sending...</div>}
-      {status === 'error' && (
-        <div
-          style={{ color: '#db2955; font-weight: bold;' }}
-          dangerouslySetInnerHTML={{ __html: message }}
-        />
-      )}
-      {status === 'success' && (
-        <div
-          style={{ color: '#7cae7a; font-weight: bold;' }}
-          dangerouslySetInnerHTML={{ __html: message }}
-        />
-      )}
-      <Group>
-        <Input
-          ref={(node) => (email = node)}
-          type="email"
-          placeholder="Your email"
-          className="input"
-          style={{
-            borderTop: 'none',
-            borderLeft: 'none',
-            borderRight: 'none',
-          }}
-        />
-        <span className="bar"></span>
-        <Submit
-          type="submit"
-          onClick={submit}
-          value="→"
-          style={{
-            bottom: '0.3125rem',
-            paddingTop: '0.375rem',
-            fontSize: '20px',
-            padding: '5px 5px 10px 5px',
-          }}
-          textColor={textColor}
-          backgroundColor={backgroundColor}
-        />
-      </Group>
-    </div>
-  );
-};
-
-const Newsletter = ({ articleTitle, metadata }) => {
-  const { trackEvent } = useAnalytics();
-  const [ref, inView] = useInView({ triggerOnce: true });
-  useEffect(() => {
-    if (inView) {
-      trackEvent({
-        action: 'newsletter modal impression 1',
-        category: 'NTG newsletter',
-        label: articleTitle,
-        non_interaction: true,
-      });
+  const handleSubmit = async (evt) => {
+    evt.preventDefault();
+    setStatus('sending');
+    // (email &&
+    // email.value.indexOf('@') > -1 &&)
+    try {
+      const subscribeURL = url + email;
+      fetch(subscribeURL, {
+        method: 'POST',
+        body: JSON.stringify({
+          email: email,
+        }),
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          console.log(data);
+          setStatus('success');
+          setMessage('Thank you for signing up for our newsletter.');
+          trackEvent({
+            action: 'newsletter signup',
+            category: 'NTG newsletter',
+            label: 'success',
+            non_interaction: false,
+          });
+          return data;
+        })
+        .catch((error) => console.error(error));
+    } catch (error) {
+      return console.error(error);
     }
-  }, [inView, articleTitle, trackEvent]);
+  };
 
   return (
     <div ref={ref}>
-      <MailchimpSubscribe
-        url={url}
-        render={({ subscribe, status, message }) => (
-          <CustomForm
-            status={status}
-            message={message}
-            onValidated={(formData) => {
-              subscribe(formData);
-              trackEvent({
-                action: 'newsletter signup',
-                category: 'NTG newsletter',
-                label: 'success',
-                non_interaction: false,
-              });
-            }}
-            metadata={metadata}
-          />
-        )}
-      />
+      <form onSubmit={handleSubmit}>
+        <div>
+          {status === 'sending' && (
+            <div style={{ color: 'blue' }}>sending...</div>
+          )}
+          {status === 'error' && (
+            <div
+              style={{ color: '#db2955; font-weight: bold' }}
+              dangerouslySetInnerHTML={{ __html: message }}
+            />
+          )}
+          {status === 'success' && (
+            <div
+              style={{ color: '#7cae7a; font-weight: bold' }}
+              dangerouslySetInnerHTML={{ __html: message }}
+            />
+          )}
+          <Group>
+            <Input
+              type="email"
+              placeholder="Your email"
+              className="input"
+              onChange={(ev) => setEmail(ev.target.value)}
+              value={email}
+              style={{
+                borderTop: 'none',
+                borderLeft: 'none',
+                borderRight: 'none',
+              }}
+            />
+            <span className="bar"></span>
+            <Submit
+              type="submit"
+              value="→"
+              style={{
+                bottom: '0.3125rem',
+                paddingTop: '0.375rem',
+                fontSize: '20px',
+                padding: '5px 5px 10px 5px',
+              }}
+              textColor={textColor}
+              backgroundColor={backgroundColor}
+            />
+          </Group>
+        </div>
+      </form>
     </div>
   );
 };

--- a/pages/api/subscribe/[email].js
+++ b/pages/api/subscribe/[email].js
@@ -1,0 +1,36 @@
+export default async function Handler(req, res) {
+  const apiUrl = process.env.LETTERHEAD_API_URL;
+  const apiKey = process.env.LETTERHEAD_API_KEY;
+  const channelSlug = process.env.LETTERHEAD_CHANNEL_SLUG;
+  const subscribeApiUrl = apiUrl + 'channels/' + channelSlug + '/subscribers';
+  // values from https://github.com/news-catalyst/next-tinynewsdemo/issues/718
+  const channelSubscriberStatusValues = {
+    'Not Subscribed': 0,
+    Subscribed: 1,
+    Unsubscribed: 2,
+  };
+
+  const { email } = req.query;
+
+  const response = await fetch(subscribeApiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      channelSubscriberStatus: channelSubscriberStatusValues['Subscribed'],
+      email: email,
+      sendOptin: true,
+    }),
+  });
+
+  // not sure what the response looks like yet as I'm only getting a 500 error page as html currently
+  const responseData = await response.json();
+  console.log('letterhead response:', responseData);
+
+  if (responseData.error) {
+    return res.status(500).json({ message: responseData.error });
+  }
+  return res.status(200).json({ message: responseData });
+}


### PR DESCRIPTION
Note: this is a draft work-in-progress as I'm trying to figure out how to work with the letterhead api subscribe endpoint. I'm getting an error at the moment.

```
→ curl -XPOST https://api.tryletterhead.com/api/v2/channels/catalyst-test/subscribers -H "Authorization: Bearer ${API_KEY}" -H "Content-Type: application/json" -d '{ "channelSubscriberStatus": 0, "email": "MYEMAIL@newscatalyst.org", "sendOptin": true }'
<!DOCTYPE html>
<html>
<head>
    <meta charset="UTF-8" />
    <meta name="robots" content="noindex,nofollow,noarchive" />
    <title>An Error Occurred: Internal Server Error</title>
    <style>body { background-color: #fff; color: #222; font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; margin: 0; }
.container { margin: 30px; max-width: 600px; }
h1 { color: #dc3545; font-size: 24px; }
h2 { font-size: 18px; }</style>
</head>
<body>
<div class="container">
    <h1>Oops! An Error Occurred</h1>
    <h2>The server returned a "500 Internal Server Error".</h2>

    <p>
        Something is broken. Please let us know what you were doing when this error occurred.
        We will fix it as soon as possible. Sorry for any inconvenience caused.
    </p>
</div>
</body>
</html>
```