### PR TITLE
bugfix: limit yesterday's top 10 page views to /articles only

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -86,7 +86,7 @@ const HASURA_GET_YESTERDAYS_DATA = `query FrontendGetYesterday($startDate: date!
     date
     label
   }
-  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_ilike: "/articles%"}}) {
     count
     date
     path


### PR DESCRIPTION
closes #733 