### PR TITLE
Publish newsletter editions as articles

### DIFF
--- a/components/nodes/NewsletterLinkNode.js
+++ b/components/nodes/NewsletterLinkNode.js
@@ -1,0 +1,10 @@
+import { Paragraph, Anchor } from '../common/CommonStyles';
+
+export default function NewsletterLinkNode({ node }) {
+  let text = (
+    <Anchor key={node.attributes.link} href={node.attributes.link}>
+      {node.insert}
+    </Anchor>
+  );
+  return <Paragraph>{text}</Paragraph>;
+}

--- a/components/nodes/NewsletterTextNode.js
+++ b/components/nodes/NewsletterTextNode.js
@@ -1,0 +1,7 @@
+import { Paragraph } from '../common/CommonStyles';
+
+export default function NewsletterTextNode({ node }) {
+  let text = node.insert;
+
+  return <Paragraph>{text}</Paragraph>;
+}

--- a/lib/newsletters.js
+++ b/lib/newsletters.js
@@ -1,0 +1,65 @@
+import { fetchGraphQL } from './utils';
+
+export const HASURA_LIST_NEWSLETTERS = `query FrontendListNewsletterEditions {
+  newsletter_editions(order_by: {newsletter_published_at: desc}) {
+    byline
+    content
+    headline
+    newsletter_published_at
+    slug
+    subheadline
+  }
+}`;
+
+export function hasuraListNewsletters(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_LIST_NEWSLETTERS,
+    name: 'FrontendListNewsletterEditions',
+  });
+}
+
+export const HASURA_GET_NEWSLETTER = `query FrontendGetNewsletter($locale_code: String!, $slug: String!) {
+  newsletter_editions(where: {slug: {_eq: $slug}}) {
+    byline
+    content
+    headline
+    newsletter_published_at
+    slug
+    subheadline
+  }
+  categories {
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      locale_code
+    }
+    published
+    slug
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
+      data
+      locale_code
+    }
+  }
+  tags(where: {published: {_eq: true}, tag_translations: {locale_code: {_eq: $locale_code}}}) {
+    slug
+    tag_translations {
+      title
+    }
+  }
+}`;
+
+export function hasuraGetNewsletter(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_NEWSLETTER,
+    name: 'FrontendGetNewsletter',
+    variables: {
+      locale_code: params['locale_code'],
+      slug: params['slug'],
+    },
+  });
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,11 +6,17 @@ import EmbedNode from '../components/nodes/EmbedNode.js';
 import ImageNode from '../components/nodes/ImageNode.js';
 import ListNode from '../components/nodes/ListNode.js';
 import TextNode from '../components/nodes/TextNode.js';
-import NewsletterLinkNode from '../components/nodes/NewsletterLinkNode.js';
-import NewsletterTextNode from '../components/nodes/NewsletterTextNode.js';
 import ImageWithTextAd from '../components/ads/ImageWithTextAd.js';
 import { format } from 'date-fns';
 import AdPromotion from '../components/ads/AdPromotion.js';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+} from '../components/common/CommonStyles.js';
+
+var QuillDeltaToHtmlConverter = require('quill-delta-to-html')
+  .QuillDeltaToHtmlConverter;
 
 const ORG_SLUG = process.env.ORG_SLUG;
 const HASURA_API_URL = process.env.HASURA_API_URL;
@@ -281,6 +287,7 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
   }
 };
 
+// letterhead newsletter content isn't localised, this is a slight variation of renderBody
 export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
   let adIndex = 0;
   const adPlacement = 5;
@@ -307,14 +314,25 @@ export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
 
   const serialize = (node, i) => {
     let renderedNode = null;
-    // console.log("serialize: ", node)
-
-    if (node.insert && !node.attributes && typeof node.insert === 'string') {
-      renderedNode = <NewsletterTextNode node={node} key={i} />;
-    } else if (node.insert && node.attributes && node.attributes.link) {
-      renderedNode = <NewsletterLinkNode node={node} key={i} />;
-    } else {
-      renderedNode = null;
+    switch (node.type) {
+      case 'list':
+        renderedNode = <ListNode node={node} key={i} />;
+        break;
+      case 'text':
+        renderedNode = <TextNode node={node} key={i} />;
+        break;
+      case 'paragraph':
+        renderedNode = <TextNode node={node} key={i} />;
+        break;
+      case 'image':
+        renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
+        break;
+      case 'embed':
+        renderedNode = <EmbedNode node={node} amp={isAmp} key={i} />;
+        break;
+      default:
+        renderedNode = null;
+        break;
     }
 
     if (!metadata.shortName === 'Tiny News Curriculum') {
@@ -334,7 +352,7 @@ export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
       adIndex++;
 
       // if this node is a heading, place the ad before the heading
-      if (node.attributes && node.attributes.header) {
+      if (node.style && node.style.includes('HEADING')) {
         return [adComponent, renderedNode];
       } else {
         return [renderedNode, adComponent];
@@ -344,10 +362,11 @@ export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
     }
   };
 
-  let parsedContent = JSON.parse(content);
-  console.log(content);
-  console.log(parsedContent);
-  return parsedContent.ops.map((node, i) => serialize(node, i));
+  if (content && content !== null && typeof content !== 'string') {
+    return content.map((node, i) => serialize(node, i));
+  } else {
+    return [];
+  }
 };
 
 // Implementation from https://gist.github.com/codeguy/6684588

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,8 @@ import EmbedNode from '../components/nodes/EmbedNode.js';
 import ImageNode from '../components/nodes/ImageNode.js';
 import ListNode from '../components/nodes/ListNode.js';
 import TextNode from '../components/nodes/TextNode.js';
+import NewsletterLinkNode from '../components/nodes/NewsletterLinkNode.js';
+import NewsletterTextNode from '../components/nodes/NewsletterTextNode.js';
 import ImageWithTextAd from '../components/ads/ImageWithTextAd.js';
 import { format } from 'date-fns';
 import AdPromotion from '../components/ads/AdPromotion.js';
@@ -277,6 +279,75 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
   } else {
     return [];
   }
+};
+
+export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
+  let adIndex = 0;
+  const adPlacement = 5;
+
+  const renderAd = (ad) => {
+    return (
+      <ImageWithTextAd
+        ad={{
+          brand: ad.promoterDisplayName,
+          image: {
+            url: ad.promoterImage,
+            alt: ad.promoterImageAlternativeText,
+          },
+          header: ad.heading,
+          body: ad.blurb,
+          call: ad.callToAction,
+          url: ad.resolvedCallToActionUrl,
+          pixel: ad.pixel,
+        }}
+        isAmp={isAmp}
+      />
+    );
+  };
+
+  const serialize = (node, i) => {
+    let renderedNode = null;
+    // console.log("serialize: ", node)
+
+    if (node.insert && !node.attributes && typeof node.insert === 'string') {
+      renderedNode = <NewsletterTextNode node={node} key={i} />;
+    } else if (node.insert && node.attributes && node.attributes.link) {
+      renderedNode = <NewsletterLinkNode node={node} key={i} />;
+    } else {
+      renderedNode = null;
+    }
+
+    if (!metadata.shortName === 'Tiny News Curriculum') {
+      // place an ad every n nodes until we run out of ads
+      if (i > 0 && i % adPlacement === 0 && ads.length === 0 && adIndex === 0) {
+        adIndex = adIndex + 1;
+        return (
+          <>
+            <AdPromotion metadata={metadata} />
+          </>
+        );
+      }
+    }
+
+    if (i > 0 && i % adPlacement === 0 && adIndex <= ads.length - 1) {
+      const adComponent = renderAd(ads[adIndex]);
+      adIndex++;
+
+      // if this node is a heading, place the ad before the heading
+      if (node.attributes && node.attributes.header) {
+        return [adComponent, renderedNode];
+      } else {
+        return [renderedNode, adComponent];
+      }
+    } else {
+      return renderedNode;
+    }
+  };
+
+  let parsedContent = JSON.parse(content);
+  console.log(content);
+  console.log(parsedContent);
+  return parsedContent.ops.map((node, i) => serialize(node, i));
 };
 
 // Implementation from https://gist.github.com/codeguy/6684588

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-preset-env": "^6.7.0",
         "purgecss": "^2.3.0",
+        "quill-delta-to-html": "^0.12.0",
         "react": "^17.0.2",
         "react-analytics-charts": "^1.2.12",
         "react-aws-s3": "^1.5.0",
@@ -50,7 +51,6 @@
         "react-instagram-embed": "^2.0.0",
         "react-intersection-observer": "^8.27.1",
         "react-mailchimp-subscribe": "^2.1.0",
-        "react-paginate": "^7.1.3",
         "react-player": "^2.5.0",
         "react-scroll-percentage": "^4.2.0",
         "react-tiktok": "^1.0.0",
@@ -13990,6 +13990,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -18337,6 +18342,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/quill-delta-to-html": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/quill-delta-to-html/-/quill-delta-to-html-0.12.0.tgz",
+      "integrity": "sha512-Yy6U2e7ov+ZlrFbj5/GbqOBCRjyNu+vuphy0Pk+7668zIMTVHJglZY2JNa++1/zkSiqptPBmP/CpsDzC4Wznsw==",
+      "dependencies": {
+        "lodash.isequal": "^4.5.0"
+      }
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -18712,17 +18725,6 @@
       "peerDependencies": {
         "react": "^0.14 || >=15",
         "react-dom": "^0.14 || >=15"
-      }
-    },
-    "node_modules/react-paginate": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-7.1.3.tgz",
-      "integrity": "sha512-cHTXXE90Z3DlKSJiIQFzAcWoIFs9mq6r1/+rQF099NPvdJpbR8f6E/ES32tlUw4qe1R6qWLOrPZYhvAy4UgHLA==",
-      "dependencies": {
-        "prop-types": "^15.6.1"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-player": {
@@ -36461,6 +36463,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
@@ -39740,6 +39747,14 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "quill-delta-to-html": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/quill-delta-to-html/-/quill-delta-to-html-0.12.0.tgz",
+      "integrity": "sha512-Yy6U2e7ov+ZlrFbj5/GbqOBCRjyNu+vuphy0Pk+7668zIMTVHJglZY2JNa++1/zkSiqptPBmP/CpsDzC4Wznsw==",
+      "requires": {
+        "lodash.isequal": "^4.5.0"
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -40041,14 +40056,6 @@
         "document.contains": "^1.0.1",
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2"
-      }
-    },
-    "react-paginate": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-7.1.3.tgz",
-      "integrity": "sha512-cHTXXE90Z3DlKSJiIQFzAcWoIFs9mq6r1/+rQF099NPvdJpbR8f6E/ES32tlUw4qe1R6qWLOrPZYhvAy4UgHLA==",
-      "requires": {
-        "prop-types": "^15.6.1"
       }
     },
     "react-player": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "next build",
     "cypress:open": "cypress open",
     "build:rss": "node script/generate-rss.js",
+    "build:newsletters": "node script/build-newsletter-editions.js",
     "postbuild": "next-sitemap && node script/generate-rss.js",
     "start": "next start",
     "export": "next build && next export",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cypress:open": "cypress open",
     "build:rss": "node script/generate-rss.js",
     "build:newsletters": "node script/build-newsletter-editions.js",
+    "prebuild": "node script/build-newsletter-editions.js",
     "postbuild": "next-sitemap && node script/generate-rss.js",
     "start": "next start",
     "export": "next build && next export",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^6.7.0",
     "purgecss": "^2.3.0",
+    "quill-delta-to-html": "^0.12.0",
     "react": "^17.0.2",
     "react-analytics-charts": "^1.2.12",
     "react-aws-s3": "^1.5.0",

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -1,0 +1,164 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+import tw from 'twin.macro';
+import Layout from '../../components/Layout.js';
+import { cachedContents } from '../../lib/cached';
+import {
+  hasuraGetNewsletter,
+  hasuraListNewsletters,
+} from '../../lib/newsletters.js';
+import { getArticleAds } from '../../lib/ads.js';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+} from '../../components/common/CommonStyles.js';
+import {
+  hasuraLocaliseText,
+  renderNewsletterContent,
+} from '../../lib/utils.js';
+import { useAmp } from 'next/amp';
+
+const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+
+export default function NewsletterEditionPage(props) {
+  const isAmp = useAmp();
+  const router = useRouter();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
+  let body;
+
+  if (props.newsletter) {
+    body = renderNewsletterContent(
+      props.newsletter.content,
+      [],
+      isAmp,
+      props.siteMetadata
+    );
+  }
+
+  return (
+    <Layout
+      meta={props.siteMetadata}
+      sections={props.sections}
+      renderFooter={props.renderFooter}
+    >
+      <SectionContainer>
+        <ArticleTitle meta={props.siteMetadata} tw="text-center">
+          {props.newsletter.headline}
+        </ArticleTitle>
+        <PostText>
+          <PostTextContainer>{body}</PostTextContainer>
+        </PostText>
+      </SectionContainer>
+    </Layout>
+  );
+}
+
+export async function getStaticPaths({ locales }) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  let paths = [];
+  const { errors, data } = await hasuraListNewsletters({
+    url: apiUrl,
+    orgSlug: apiToken,
+  });
+
+  if (errors || !data) {
+    return {
+      paths,
+      fallback: true,
+    };
+  }
+
+  const siteLocales = process.env.LOCALES.split(',');
+
+  for (const newsletter of data.newsletter_editions) {
+    for (const locale of siteLocales) {
+      paths.push({
+        params: {
+          slug: newsletter.slug,
+        },
+        locale: locale.locale_code,
+      });
+    }
+  }
+
+  return {
+    paths,
+    fallback: true,
+  };
+}
+
+export async function getStaticProps({ locale, params }) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  let newsletter;
+  let sections = [];
+  let tags = [];
+  let siteMetadata;
+
+  const { errors, data } = await hasuraGetNewsletter({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: params.slug,
+    locale_code: locale,
+  });
+
+  if (errors || !data) {
+    console.error('error getting newsletter:', errors);
+    return {
+      notFound: true,
+    };
+  } else {
+    newsletter = data.newsletter_editions[0];
+    sections = data.categories;
+
+    for (var i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocaliseText(
+        sections[i].category_translations,
+        'title'
+      );
+    }
+
+    for (var j = 0; j < tags.length; j++) {
+      tags[j].title = hasuraLocaliseText(tags[j].tag_translations, 'title');
+    }
+
+    let metadatas = data.site_metadatas;
+    try {
+      siteMetadata = metadatas[0].site_metadata_translations[0].data;
+    } catch (err) {
+      console.log('failed finding site metadata for ', locale, metadatas);
+    }
+  }
+
+  let expandedAds = [];
+  if (process.env.LETTERHEAD_API_URL) {
+    const allAds = (await cachedContents('ads', getArticleAds)) || [];
+    expandedAds = allAds.filter((ad) => ad.adTypeId === 166 && ad.status === 4);
+  }
+
+  let renderFooter = true;
+  if (process.env.ORG_SLUG === 'tiny-news-curriculum') {
+    renderFooter = false; // turns off the global footer for the curriculum site
+  }
+
+  return {
+    props: {
+      newsletter,
+      tags,
+      sections,
+      siteMetadata,
+      expandedAds,
+      renderFooter,
+    },
+  };
+}

--- a/pages/newsletters/[slug].js
+++ b/pages/newsletters/[slug].js
@@ -34,6 +34,7 @@ export default function NewsletterEditionPage(props) {
   let body;
 
   if (props.newsletter) {
+    console.log(typeof props.newsletter.content, props.newsletter.content);
     body = renderNewsletterContent(
       props.newsletter.content,
       [],

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -34,7 +34,13 @@ async function saveNewsletterEditions(letterheadData) {
       continue;
     }
 
+    let slug = slugify(newsletter.title);
+    if (!slug) {
+      continue;
+    }
+
     let editionData = {
+      slug: slug,
       headline: newsletter.title,
       letterhead_id: newsletter.id,
       letterhead_unique_id: newsletter.uniqueId,
@@ -58,10 +64,31 @@ async function saveNewsletterEditions(letterheadData) {
     if (result.errors) {
       console.error("! Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' had an error saving:", result.errors);
     } else {
-      console.log(". Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' was published at " + newsletter.publicationDate + ", saved in Hasura with ID#" + result.data.insert_newsletter_editions_one.id + ".")
+      console.log(". Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' was published at " + newsletter.publicationDate + ", saved in Hasura with slug: " + result.data.insert_newsletter_editions_one.slug)
     }
 
   }
 }
+
+const slugify = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return '';
+  }
+  value = value.trim();
+  value = value.toLowerCase();
+  var from = 'àáäâèéëêìíïîòóöôùúüûñç·/_,:;';
+  var to = 'aaaaeeeeiiiioooouuuunc------';
+  for (var i = 0, l = from.length; i < l; i++) {
+    value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+  }
+
+  value = value
+    .replace(/[^a-z0-9 -]/g, '') // remove invalid chars
+    .replace(/\s+/g, '-') // collapse whitespace and replace by -
+    .replace(/-+/g, '-'); // collapse dashes
+
+  return value;
+};
+
 
 getNewsletterEditions();

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -1,0 +1,67 @@
+#! /usr/bin/env node
+
+require('dotenv').config({ path: '.env.local' })
+
+const fetch = require('node-fetch');
+
+const shared = require("./shared");
+
+const apiUrl = process.env.HASURA_API_URL;
+const apiToken = process.env.ORG_SLUG;
+
+function getNewsletterEditions() {
+  const letterheadUrl = process.env.LETTERHEAD_API_URL + "channels/" + process.env.LETTERHEAD_CHANNEL_SLUG + "/letters";
+  const opts = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.LETTERHEAD_API_KEY}`,
+    },
+  };
+  fetch(letterheadUrl, opts)
+    .then((res) => res.json())
+    .then((data) => {
+      saveNewsletterEditions(data);
+    })
+    .catch(console.error);
+}
+
+async function saveNewsletterEditions(letterheadData) {
+  console.log("Letterhead returned", letterheadData.length, "newsletter editions in total:");
+
+  for await (let newsletter of letterheadData) {
+    if (!newsletter.publicationDate) {
+      console.log("> Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' is not published, skipping.")
+      continue;
+    }
+
+    let editionData = {
+      headline: newsletter.title,
+      letterhead_id: newsletter.id,
+      letterhead_unique_id: newsletter.uniqueId,
+      content: newsletter.delta,
+      newsletter_created_at: newsletter.createdAt,
+      newsletter_published_at: newsletter.publicationDate,
+    }
+    if (newsletter.customizedByline) {
+      editionData['byline'] = newsletter.customizedByline;
+    }
+    if (newsletter.customizedByline) {
+      editionData['subheadline'] = newsletter.subtitle;
+    }
+
+    const result = await shared.hasuraInsertNewsletterEdition({
+      url: apiUrl,
+      orgSlug: apiToken,
+      data: editionData,
+    });
+
+    if (result.errors) {
+      console.error("! Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' had an error saving:", result.errors);
+    } else {
+      console.log(". Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' was published at " + newsletter.publicationDate + ", saved in Hasura with ID#" + result.data.insert_newsletter_editions_one.id + ".")
+    }
+
+  }
+}
+
+getNewsletterEditions();

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -25,9 +25,195 @@ function getNewsletterEditions() {
     .catch(console.error);
 }
 
+//{"ops":[{"insert":"This is my newsletter"},{"attributes":{"header":1},"insert":"\n"},{"insert":"By Tyler \nThis is a paragraph followed by a list:\nlist item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 3"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Section title"},{"attributes":{"header":2},"insert":"\n"},{"attributes":{"bold":true},"insert":"Bold text. "},{"attributes":{"italic":true,"bold":true},"insert":"Italic bold text. "},{"attributes":{"italic":true},"insert":"Just italic."},{"insert":"\n\n"}]}
+
+
+function transformDelta(delta) {
+  // console.log(delta);
+
+  let elements = [];
+
+  delta.ops.forEach((element, i) => {
+    if (!element.insert) {
+      console.log("no element.insert: ", element);
+      return;
+    }
+    if (typeof(element.insert) !== 'string') {
+      console.log("element.insert is a", typeof(element.insert), ": ", element.insert);
+      return;
+    }
+
+    let lines = element.insert.split('\n');
+    if (!element.attributes && lines.length > 1) {
+      lines.forEach((line) => {
+        if (line) {
+          elements.push({
+            "insert": line
+          });
+        }
+      })
+    } else {
+      elements.push(element);
+    }
+  });
+
+  // console.log(elements);
+
+  let list = {items: []};
+  let paragraph = {children: []};
+
+  let formattedElements = [];
+  elements.forEach((element, i) => {
+    if (element.attributes && element.attributes.header) {
+      console.log(i, "header:", elements[i-1].insert)
+      formattedElements.push( {
+        "link": null,
+        "type": "text",
+        "style": "HEADING_" + element.attributes.header,
+        "children": [
+          {
+            "index": i,
+            "style": {},
+            "content": elements[i-1].insert
+          }
+        ]
+      })
+    } else if (element.attributes && element.attributes.list) {
+      console.log(i, "list:", elements[i-1].insert)
+
+      list.items.push({
+        "index": i,
+        "children": [
+          {
+            "style": {},
+            "content": elements[i-1].insert
+          }
+        ],
+        "nestingLevel": 0
+      })
+
+      // if there is a second next element and it's not a list, this is the last item in the list;
+      // if there is no second next element, this is also the last item in the list; finish it
+      // by pushing it onto the formattedElements, then set it to an empty object again
+      // we do this in case there are more lists in the email
+      // if there is a second next element and it has a list attr, this list has more items
+      if ( (elements[i+2] && (!elements[i+2].attributes || !elements[i+2].attributes.list)) || !elements[i+2] ) {
+         // hardcode as "bullet" for now
+         formattedElements.push({
+          "type": "list",
+          "listType": "BULLET",
+          "items": list.items,
+          "link": null
+        })
+        // reset the list holder
+        list = {items: []};
+      }
+
+    } else if (element.attributes && (element.attributes.bold || element.attributes.italic)) {
+      console.log(i, "formatted text:", element.insert);
+      let style = {};
+      if (element.attributes.bold) {
+        style["bold"] = true;
+      }
+      if (element.attributes.italic) {
+        style["italic"] = true;
+      }
+
+      paragraph.children.push({
+        "index": i,
+        "style": style,
+        "content": element.insert
+      })
+
+      // if this is the last element of the newsletter, or
+      // if the next element is blank string, or 
+      // if the next element is a list/header item, close the paragraph
+      if (
+        (!elements[i+1]) ||
+        ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
+        ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+      ) {
+        
+        formattedElements.push({
+          "link": null,
+          "type": "text",
+          "style": "NORMAL_TEXT",
+          "children": paragraph.children
+        });  
+        paragraph = { "children": []}
+        // otherwise, continue on
+      }
+      
+
+    } else if (element.attributes && element.attributes.link) {
+      console.log(i, "link:", element.attributes.link);
+
+      formattedElements.push({
+        "link": null,
+        "type": "text",
+        "style": "NORMAL_TEXT",
+        "children": [
+          {
+            "link": element.attributes.link,
+            "index": i,
+            "style": {
+              "underline": true
+            },
+            "content": element.insert
+          }
+        ]
+      })
+    } else if (element.attributes) {
+      console.log(i, "unknown attrs:", element.attributes);
+
+    } else {
+      if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.header) {
+        console.log(i, "skip, header is handled next:", element.insert);
+      } else if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.list) {
+        console.log(i, "skip, list is handled next:", element.insert);
+      } else {
+        console.log(i, "plain text:", element.insert);
+
+        paragraph.children.push({
+            "link": null,
+            "type": "text",
+            "style": "NORMAL_TEXT",
+            "children": [
+              {
+                "index": i,
+                "style": {},
+                "content": element.insert
+              }
+            ]
+        })
+
+        // if this is the last element of the newsletter, or
+        // if the next element is blank string, or 
+        // if the next element is a list/header item, close the paragraph
+        if (
+          (!elements[i+1]) ||
+          ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
+          ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+        ) {
+          formattedElements.push({
+            "link": null,
+            "type": "text",
+            "style": "NORMAL_TEXT",
+            "children": paragraph.children
+          });  
+          paragraph = { "children": []}
+        }
+      }
+    }
+  })
+
+  // console.log(formattedElements);
+
+  return formattedElements;
+}
+
 async function saveNewsletterEditions(letterheadData) {
   console.log("Letterhead returned", letterheadData.length, "newsletter editions in total:");
-
   for await (let newsletter of letterheadData) {
     if (!newsletter.publicationDate) {
       console.log("> Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' is not published, skipping.")
@@ -39,12 +225,15 @@ async function saveNewsletterEditions(letterheadData) {
       continue;
     }
 
+    let content = transformDelta(JSON.parse(newsletter.delta));
+console.log(content);
+
     let editionData = {
       slug: slug,
       headline: newsletter.title,
       letterhead_id: newsletter.id,
       letterhead_unique_id: newsletter.uniqueId,
-      content: newsletter.delta,
+      content: content,
       newsletter_created_at: newsletter.createdAt,
       newsletter_published_at: newsletter.publicationDate,
     }

--- a/script/shared.js
+++ b/script/shared.js
@@ -1,5 +1,32 @@
 const fetch = require("node-fetch");
 
+const INSERT_NEWSLETTER_EDITION = `mutation FrontendInsertNewsletterEdition($byline: String, $content: jsonb, $headline: String, $letterhead_id: Int, $letterhead_unique_id: String, $newsletter_created_at: timestamptz, $newsletter_published_at: timestamptz, $subheadline: String) {
+  insert_newsletter_editions_one(object: {byline: $byline, content: $content, headline: $headline, letterhead_id: $letterhead_id, letterhead_unique_id: $letterhead_unique_id, newsletter_created_at: $newsletter_created_at, newsletter_published_at: $newsletter_published_at, subheadline: $subheadline}, on_conflict: {constraint: newsletter_editions_organization_id_letterhead_unique_id_key, update_columns: headline}) {
+    id
+    headline
+  }
+}`;
+
+function hasuraInsertNewsletterEdition(params) {
+  // console.log(params['data']);
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: INSERT_NEWSLETTER_EDITION,
+    name: 'FrontendInsertNewsletterEdition',
+    variables: {
+      byline: params['data']['byline'],
+      content: params['data']['content'],
+      headline: params['data']['headline'],
+      letterhead_id: params['data']['letterhead_id'],
+      letterhead_unique_id: params['data']['letterhead_unique_id'],
+      newsletter_created_at: params['data']['newsletter_created_at'],
+      newsletter_published_at: params['data']['newsletter_published_at'],
+      subheadline: params['data']['subheadline'],
+    },
+  });
+}
+
 const INSERT_DATA_IMPORT = `mutation FrontendInsertDataImport($notes: String, $end_date: date, $start_date: date, $table_name: String) {
   insert_ga_data_imports_one(object: {end_date: $end_date, notes: $notes, start_date: $start_date, table_name: $table_name}) {
     id
@@ -700,6 +727,7 @@ function sanitizePath(path) {
 }
 
 module.exports = {
+  hasuraInsertNewsletterEdition,
   hasuraInsertOrganization,
   hasuraInsertOrgLocales,
   hasuraInsertPageView,

--- a/script/shared.js
+++ b/script/shared.js
@@ -1,14 +1,15 @@
 const fetch = require("node-fetch");
 
-const INSERT_NEWSLETTER_EDITION = `mutation FrontendInsertNewsletterEdition($byline: String, $content: jsonb, $headline: String, $letterhead_id: Int, $letterhead_unique_id: String, $newsletter_created_at: timestamptz, $newsletter_published_at: timestamptz, $subheadline: String) {
-  insert_newsletter_editions_one(object: {byline: $byline, content: $content, headline: $headline, letterhead_id: $letterhead_id, letterhead_unique_id: $letterhead_unique_id, newsletter_created_at: $newsletter_created_at, newsletter_published_at: $newsletter_published_at, subheadline: $subheadline}, on_conflict: {constraint: newsletter_editions_organization_id_letterhead_unique_id_key, update_columns: headline}) {
+const INSERT_NEWSLETTER_EDITION = `mutation FrontendInsertNewsletterEdition($slug: String, $byline: String, $content: jsonb, $headline: String, $letterhead_id: Int, $letterhead_unique_id: String, $newsletter_created_at: timestamptz, $newsletter_published_at: timestamptz, $subheadline: String) {
+  insert_newsletter_editions_one(object: {slug: $slug, byline: $byline, content: $content, headline: $headline, letterhead_id: $letterhead_id, letterhead_unique_id: $letterhead_unique_id, newsletter_created_at: $newsletter_created_at, newsletter_published_at: $newsletter_published_at, subheadline: $subheadline}, on_conflict: {constraint: newsletter_editions_organization_id_letterhead_unique_id_key, update_columns: headline}) {
     id
     headline
+    slug
   }
 }`;
 
 function hasuraInsertNewsletterEdition(params) {
-  // console.log(params['data']);
+  console.log(params['data']);
   return fetchGraphQL({
     url: params['url'],
     orgSlug: params['orgSlug'],
@@ -16,6 +17,7 @@ function hasuraInsertNewsletterEdition(params) {
     name: 'FrontendInsertNewsletterEdition',
     variables: {
       byline: params['data']['byline'],
+      slug: params['data']['slug'],
       content: params['data']['content'],
       headline: params['data']['headline'],
       letterhead_id: params['data']['letterhead_id'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7958,6 +7958,11 @@
   "resolved" "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
   "version" "3.0.3"
 
+"lodash.isequal@^4.5.0":
+  "integrity" "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+  "resolved" "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
+  "version" "4.5.0"
+
 "lodash.isinteger@^4.0.4":
   "integrity" "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
   "resolved" "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
@@ -10105,6 +10110,13 @@
   "resolved" "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz"
   "version" "5.1.1"
 
+"quill-delta-to-html@^0.12.0":
+  "integrity" "sha512-Yy6U2e7ov+ZlrFbj5/GbqOBCRjyNu+vuphy0Pk+7668zIMTVHJglZY2JNa++1/zkSiqptPBmP/CpsDzC4Wznsw=="
+  "resolved" "https://registry.npmjs.org/quill-delta-to-html/-/quill-delta-to-html-0.12.0.tgz"
+  "version" "0.12.0"
+  dependencies:
+    "lodash.isequal" "^4.5.0"
+
 "raf@^3.4.0", "raf@^3.4.1":
   "integrity" "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA=="
   "resolved" "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
@@ -10375,13 +10387,6 @@
     "document.contains" "^1.0.1"
     "object.values" "^1.1.0"
     "prop-types" "^15.7.2"
-
-"react-paginate@^7.1.3":
-  "integrity" "sha512-cHTXXE90Z3DlKSJiIQFzAcWoIFs9mq6r1/+rQF099NPvdJpbR8f6E/ES32tlUw4qe1R6qWLOrPZYhvAy4UgHLA=="
-  "resolved" "https://registry.npmjs.org/react-paginate/-/react-paginate-7.1.3.tgz"
-  "version" "7.1.3"
-  dependencies:
-    "prop-types" "^15.6.1"
 
 "react-player@^2.5.0":
   "integrity" "sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA=="


### PR DESCRIPTION
Closes #734 

This adds a new script that imports newsletter editions from letterhead and transforms the content format into something our front-end expects before storing in Hasura. It also adds a template for displaying each edition on the site under `/newsletters/[slug]`.

The tricky part of this was wrangling the `delta` data format into something usable by our frontend html formatting.

The newsletter import can be run multiple times (it does an upsert/on_conflict) and is now run before `yarn build` as a `prebuild` command.