### PR TITLE
Bugfix: set the title for author, section, and tag pages

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -43,7 +43,12 @@ export default function Layout({
     footerBylineName: meta['footerBylineName'],
   };
 
+  let pageTitle = meta['homepageTitle'];
+
   if (article) {
+    pageTitle = hasuraLocaliseText(article.article_translations, 'headline');
+    pageTitle += ' | ' + metaValues.siteName;
+
     metaValues.section = hasuraLocaliseText(
       article.category.category_translations,
       'title'
@@ -101,7 +106,7 @@ export default function Layout({
   return (
     <>
       <Head>
-        <title>{meta['homepageTitle']}</title>
+        <title>{pageTitle}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta property="description" content={metaValues.searchDescription} />
         {tagList}

--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -36,7 +36,6 @@ export default function ArticleLink({
   let mainImage = null;
   let mainImageNode;
 
-  console.log('article:', article);
   let headline;
   if (article.article_translations) {
     headline = hasuraLocaliseText(article.article_translations, 'headline');
@@ -85,7 +84,6 @@ export default function ArticleLink({
   }
 
   if (mainImageNode && Object.keys(mainImageNode).length > 0) {
-    console.log(article.slug, 'articleLink mainImageNode:', mainImageNode);
     mainImage = mainImageNode.children[0];
   }
 

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -38,6 +38,10 @@ export default function AuthorPage({
     authorTitle = hasuraLocaliseText(author.author_translations, 'title');
     authorBio = hasuraLocaliseText(author.author_translations, 'bio');
     authorTwitter = author.twitter;
+
+    // set page title
+    siteMetadata['homepageTitle'] =
+      authorName + ' | ' + siteMetadata['shortName'];
   }
 
   let twitterCall;

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -28,9 +28,14 @@ export default function CategoryPage(props) {
     return <div>Loading...</div>;
   }
 
+  let siteMetadata = props.siteMetadata;
+  // set page title
+  siteMetadata['homepageTitle'] =
+    props.title + ' | ' + siteMetadata['shortName'];
+
   return (
     <Layout
-      meta={props.siteMetadata}
+      meta={siteMetadata}
       sections={props.sections}
       renderFooter={props.renderFooter}
     >

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -24,6 +24,10 @@ export default function TagPage({
   }
 
   let tagTitle = hasuraLocaliseText(tag.tag_translations, 'title');
+
+  // set page title
+  siteMetadata['homepageTitle'] = tagTitle + ' | ' + siteMetadata['shortName'];
+
   return (
     <Layout meta={siteMetadata} sections={sections}>
       <ArticleStream


### PR DESCRIPTION
Related to #752 

I noticed the page titles weren't set for the following, so I updated these pages as well as the article page. I did it in a separate branch/PR in case we wanted something different for these pages.

* [author index page](http://localhost:3000/authors/tyler-fisher)
* [category index page](http://localhost:3000/categories/business)
* [tag index page](http://localhost:3000/tags/tiny-news-collective)