### PR TITLE
Fixed failing test suite

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -1076,9 +1076,11 @@ export function hasuraGetLayout(params) {
 }
 
 export function hasuraGetMetadataByLocale(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_GET_METADATA_BY_LOCALE,
     name: 'FrontendGetMetadataByLocale',
     variables: {
@@ -1100,9 +1102,11 @@ export function hasuraPreviewArticleBySlug(params) {
   });
 }
 export function hasuraGetArticleBySlug(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: params['url'],
-    orgSlug: params['orgSlug'],
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_GET_ARTICLE_BY_SLUG,
     name: 'FrontendGetArticleBySlug',
     variables: {
@@ -1132,18 +1136,22 @@ const HASURA_LIST_PAGE_SLUGS = `query FrontendListPageSlugs {
   }
 }`;
 
-export async function hasuraListAllPageSlugsPreview() {
+export async function hasuraListAllPageSlugsPreview(params = {}) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_LIST_PAGE_SLUGS_PREVIEW,
     name: 'FrontendListPageSlugsPreview',
   });
 }
-export async function hasuraListAllPageSlugs() {
+export async function hasuraListAllPageSlugs(params = {}) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_LIST_PAGE_SLUGS,
     name: 'FrontendListPageSlugs',
   });
@@ -1162,10 +1170,12 @@ const HASURA_LIST_ARTICLE_SLUGS = `query FrontendListArticleSlugs {
   }
 }`;
 
-export async function hasuraListAllArticleSlugs() {
+export async function hasuraListAllArticleSlugs(params = {}) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_LIST_ARTICLE_SLUGS,
     name: 'FrontendListArticleSlugs',
   });
@@ -1180,19 +1190,23 @@ const HASURA_GET_AUTHOR_SLUGS = `query FrontendGetAuthorSlugs {
   }
 }`;
 
-export async function hasuraListAllAuthorPaths() {
+export async function hasuraListAllAuthorPaths(params = {}) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_GET_AUTHOR_SLUGS,
     name: 'FrontendGetAuthorSlugs',
   });
 }
 
 export async function hasuraTagPage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_TAG_PAGE,
     name: 'FrontendTagPage',
     variables: {
@@ -1203,9 +1217,11 @@ export async function hasuraTagPage(params) {
 }
 
 export async function hasuraCategoryPage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_CATEGORY_PAGE,
     name: 'FrontendCategoryPage',
     variables: {
@@ -1216,9 +1232,12 @@ export async function hasuraCategoryPage(params) {
 }
 
 export async function hasuraPreviewArticlePage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
+
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_PREVIEW_ARTICLE_PAGE,
     name: 'FrontendPreviewArticlePage',
     variables: {
@@ -1230,9 +1249,11 @@ export async function hasuraPreviewArticlePage(params) {
 }
 
 export async function hasuraArticlePage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_ARTICLE_PAGE_SLUG_VERSION,
     name: 'FrontendArticlePageSlugVersion',
     variables: {
@@ -1244,9 +1265,11 @@ export async function hasuraArticlePage(params) {
 }
 
 export async function hasuraAuthorPage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_AUTHOR_PAGE,
     name: 'FrontendAuthorPage',
     variables: {
@@ -1456,9 +1479,11 @@ const HASURA_CREATE_ARTICLE = `mutation FrontendTestingCreateArticle($locale_cod
 }`;
 
 export async function hasuraCreateArticle(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_CREATE_ARTICLE,
     name: 'FrontendTestingCreateArticle',
     variables: {
@@ -1479,9 +1504,12 @@ export async function hasuraCreateArticle(params) {
 }
 
 export async function hasuraUpdateArticle(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
+
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_UPDATE_ARTICLE,
     name: 'FrontendTestingUpdateArticle',
     variables: {
@@ -1552,9 +1580,11 @@ const HASURA_CREATE_PAGE = `mutation FrontendTestingCreatePage($slug: String!, $
 }`;
 
 export async function hasuraCreatePage(params) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_CREATE_PAGE,
     name: 'FrontendTestingCreatePage',
     variables: {
@@ -1575,6 +1605,21 @@ const DELETE_ARTICLES_MUTATION = `mutation DeleteArticles {
   delete_article_google_documents(where: {id: {_gt: 0}}) {
     affected_rows
   }
+  delete_article_source(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_homepage_layout_datas(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_tag_articles(where: {id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_article_slug_versions(where: {article_id: {_gt: 0}}) {
+    affected_rows
+  }
+  delete_published_article_translations(where:{id:{_gt: 0}}) {
+    affected_rows
+  }
   delete_article_translations(where: {id: {_gt: 0}}) {
     affected_rows
   }
@@ -1588,8 +1633,8 @@ const DELETE_ARTICLES_MUTATION = `mutation DeleteArticles {
 
 export async function hasuraDeleteArticles(params) {
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: params['url'],
+    orgSlug: params['orgSlug'],
     query: DELETE_ARTICLES_MUTATION,
     name: 'DeleteArticles',
   });

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -104,11 +104,13 @@ const HASURA_UPDATE_AUTHOR = `mutation updateAuthorWithTranslations($author_id: 
   }
 }`;
 
-export function hasuraListAllAuthors(localeCode) {
+export function hasuraListAllAuthors(localeCode, params = {}) {
+  let url = params['url'] || process.env.HASURA_API_URL;
+  let orgSlug = params['orgSlug'] || process.env.ORG_SLUG;
   // console.log('listAllAuthors locale:', localeCode);
   return fetchGraphQL({
-    url: process.env.HASURA_API_URL,
-    orgSlug: process.env.ORG_SLUG,
+    url: url,
+    orgSlug: orgSlug,
     query: HASURA_LIST_AUTHORS,
     name: 'FrontendListAuthors',
     variables: { localeCode: localeCode },


### PR DESCRIPTION
Closes #761

* don't rely on .env.local being configured for testing - instead I have hardcoded the testing API url, which I think is okay in this situation (it's not going to change)
* ensure all tested functions accept api url and token
* added some sleep timers to avoid exceeding hasura api rate limiting - hitting this limit seems unavoidable with our account; I don't mind the extra time if it means we don't get confusing "errors"