### PR TITLE
2 issues with building the site: main image and newsletter publishing

### DIFF
--- a/components/curriculum/Grid.js
+++ b/components/curriculum/Grid.js
@@ -15,10 +15,11 @@ export default function Grid({ header, type, articles }) {
       articles[i].article_translations[
         articles[i].article_translations.length - 1
       ];
+
     const mainImageNode = translation.main_image;
     let mainImage = null;
 
-    if (mainImageNode) {
+    if (mainImageNode && mainImageNode.children) {
       mainImage = mainImageNode.children[0];
     }
 

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -282,5 +282,12 @@ const slugify = (value) => {
   return value;
 };
 
+const publishNewsletters = process.env.PUBLISH_NEWSLETTERS;
+console.log("publish newsletters?", typeof(publishNewsletters), publishNewsletters);
 
-getNewsletterEditions();
+if (!publishNewsletters || publishNewsletters === "false") {
+  console.log("Not publishing newsletters for " + apiToken);
+  return;
+} else {
+  getNewsletterEditions();
+}


### PR DESCRIPTION
Related to https://github.com/news-catalyst/google-app-scripts/issues/306

* I added a small check to the existing code for determining whether an article had a main image that tests the node has children
* I also added a check before publishing newsletters based on an env var

On the way to figuring out what was going on with the main image nodes on the homepage, which involved me trying to build the curriculum site locally a few times, I realised that we don't necessary want to publish newsletter editions for all sites even if they have a newsletter configured in the env. 

So I've added a `PUBLISH_NEWSLETTERS` env var to my `.env.local` - it's set to `true` for oaklyn and `false` for curriculum. The build newsletters script will abort if the var is false, but publish according to the configured letterhead values otherwise.
