### PR TITLE
bugfix: 404 on first article page load after publishing

### DIFF
--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   hasuraListAllArticleSlugs,
   hasuraArticlePage,
@@ -14,12 +14,6 @@ export const config = { amp: 'hybrid' };
 
 export default function ArticlePage(props) {
   const router = useRouter();
-
-  useEffect(() => {
-    if (!props.article) {
-      router.push('/404');
-    }
-  }, [props.article, router]);
 
   // If the page is not yet generated, this will be displayed
   // initially until getStaticProps() finishes running


### PR DESCRIPTION
Closes #745 

I was trying to figure out why the article page 404'd after publishing, intermittently, and think I discovered the answer: this `useEffect` block.

```
useEffect(() => {
  if (!props.article) {
    router.push('/404');
  }
}, [props.article, router]);
```

I don't think this code is necessary as there is also code, outside the useEffect block, to handle the fallback on initial page generation, then to display a 404 if the article really isn't found.

So, this PR removes the `useEffect` block from the article page.

To test, I added a `deleteArticle` button to the admin tools sidebar ~and left it up as `latest code` in the add-on~ (this is no longer in the latest code; it's in this PR https://github.com/news-catalyst/google-app-scripts/pull/314). 

Then I deleted the article, filled in metadata from scratch in the publishing sidebar and clicked "publish" then the article link; consistently got a 404 that way prior to this change. 

Actually testing that the code change prevents the 404 is a bit trickier. I think it will, but it needs to be deployed, unless we use the PR branch to test by changing the URL once this branch is deployed to a new URL.

(Sidenote: do we want this functionality available to tiny news founders? currently they have no way to remove an article... I can't remember if we decided on this already, sorry!)