### PR TITLE
Bugfix: bootstrap + new environment file + site_metadata

### DIFF
--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -271,8 +271,10 @@ function configureNext(name, slug, locales, url, gaTrackingId) {
 async function createOrganization(opts) {
   let name = opts.name;
   let slug = opts.slug;
-  let locales = opts.locales;
+  let locales = opts.locales[0].split(',');
   let url = opts.url;
+
+  console.log("locales:", typeof(locales), locales);
 
   let gaTrackingId = await setupGoogleAnalytics(name, url);
   console.log("GA Tracking ID: ", gaTrackingId);
@@ -422,11 +424,17 @@ async function createOrganization(opts) {
             url: apiUrl,
             adminSecret: adminSecret,
             organization_id: organizationID,
-            data: siteMetadata,
+            data: JSON.stringify(siteMetadata),
             locale_code: locale,
             published: true,
           }).then( (res) => {
-            console.log("created site metadata for " + name + " in locale " + locale);
+            if (res.errors) {
+              console.error("FAILED creating site metadata in locale: " + locale);
+              console.error(JSON.stringify(res.errors));
+            } else {
+              console.log("created site metadata in locale " + locale);
+              console.log(JSON.stringify(res));
+            }
           })
         })
 

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -249,17 +249,23 @@ function configureNext(name, slug, locales, url, gaTrackingId) {
   console.log("Creating new environment file using the following settings:");
   console.log(currentEnv.parsed);
 
-  var stream = fs.createWriteStream(".new.env.local", {flags:'a'});
-  Object.keys(currentEnv.parsed).map((key) =>{
-    stream.write(`${key}=${currentEnv.parsed[key]}` + "\n");
-  })
-  stream.end();
+  let orgEnvFilename = `.env.local-${slug}`
+  let tempEnvFilename = ".new.env.local";
 
-  let newEnvFilename = `.env.local-${slug}`
-  fs.rename('.new.env.local', newEnvFilename, function (err) {
-    if (err) throw err
-    console.log(`Successfully configured env in ${newEnvFilename} with:\n`, JSON.stringify(currentEnv));
-  })
+  var tempFile = fs.createWriteStream(tempEnvFilename, {flags:'a'});
+
+  tempFile.on('open', function(fd) {
+    Object.keys(currentEnv.parsed).map((key) =>{
+      tempFile.write(`${key}=${currentEnv.parsed[key]}` + "\n");
+    })
+    tempFile.end();
+    if (fs.existsSync(tempEnvFilename)) {
+      fs.renameSync(tempEnvFilename, orgEnvFilename);
+      console.log("Created new environment file: ", orgEnvFilename)
+    } else {
+      console.error("Temporary env file does not exist:", tempEnvFilename);
+    }
+  });
 }
 
 async function createOrganization(opts) {

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -424,7 +424,7 @@ async function createOrganization(opts) {
             url: apiUrl,
             adminSecret: adminSecret,
             organization_id: organizationID,
-            data: JSON.stringify(siteMetadata),
+            data: siteMetadata,
             locale_code: locale,
             published: true,
           }).then( (res) => {

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -429,10 +429,10 @@ async function createOrganization(opts) {
             published: true,
           }).then( (res) => {
             if (res.errors) {
-              console.error("FAILED creating site metadata in locale: " + locale);
+              console.error("! Failed creating site metadata in locale: " + locale);
               console.error(JSON.stringify(res.errors));
             } else {
-              console.log("created site metadata in locale " + locale);
+              console.log("Created site metadata in locale " + locale);
               console.log(JSON.stringify(res));
             }
           })

--- a/script/metadata.js
+++ b/script/metadata.js
@@ -1,0 +1,71 @@
+const shared = require("./shared");
+require('dotenv').config({ path: '.env.local' })
+
+const apiUrl = process.env.HASURA_API_URL;
+const adminSecret = process.env.HASURA_ADMIN_SECRET;
+
+let locales = ["en-US", "fil"];
+let organizationID = 101;
+
+let url = "https://diaryo.newscatalyst.org";
+let name = "Test Diaryo";
+
+
+let siteMetadata = {
+  "color": "colorone",
+  "theme": "styleone",
+  "siteUrl": url,
+  "aboutCTA": "Learn more",
+  "aboutDek": `About the ${name} TK`,
+  "aboutHed": "Who We Are",
+  "bodyFont": "Domine",
+  "shortName": name,
+  "supportCTA": "Donate",
+  "supportDek": `${name} exists based on the support of our readers. Chip in today to help us continue delivering quality journalism.`,
+  "supportHed": "Support our work",
+  "supportURL": "https://tiny-news-collective.monkeypod.io/give/support-the-oaklyn-observer?secret=84fc2987ea6e8f11b8f4f8aca8b749d7",
+  "footerTitle": url,
+  "headingFont": "Libre Franklin",
+  "searchTitle": name,
+  "primaryColor": "#de7a00",
+  "twitterTitle": "Twitter title",
+  "facebookTitle": "Facebook title",
+  "homepageTitle": name,
+  "membershipDek": "Support great journalism by becoming a member for a low monthly price.",
+  "membershipHed": "Become a member",
+  "newsletterDek": `Get the latest headlines from ${name} right in your inbox.`,
+  "newsletterHed": "Sign up for our newsletter",
+  "donateBlockDek": "Support our local journalism with a monthly pledge.",
+  "donateBlockHed": "Donate",
+  "secondaryColor": "#002c57",
+  "donationOptions": "[{\n\"amount\": 5,\n\"name\": \"Member\",\n\"description\": \"This is a description.\"\n},\n{\n\"amount\": 10,\n\"name\": \"Supporter\",\n\"description\": \"This is a description.\"\n},\n{\n\"amount\": 20,\n\"name\": \"Superuser\",\n\"description\": \"This is a description.\"\n}]",
+  "footerBylineLink": url,
+  "footerBylineName": name,
+  "searchDescription": "Page description",
+  "twitterDescription": "Twitter description",
+  "facebookDescription": "Facebook description",
+  "commenting": "on"
+};
+
+locales.map( (locale) => {
+  console.log("Saving site metadata for locale " + locale);
+
+  shared.hasuraUpsertMetadata({
+    url: apiUrl,
+    adminSecret: adminSecret,
+    organization_id: organizationID,
+    data: JSON.stringify(siteMetadata),
+    locale_code: locale,
+    published: true,
+  }).then( (res) => {
+    if (res.errors) {
+      console.error("failed creating site metadata in locale " + locale + ":")
+      console.error(JSON.stringify(res.errors));
+    } else {
+      console.log("successfully created site metadata in locale " + locale + ":");
+      console.log(JSON.stringify(res));
+    }
+
+  }).catch(err => console.error(err));
+
+})

--- a/script/shared.js
+++ b/script/shared.js
@@ -145,7 +145,19 @@ function hasuraInsertOrgLocales(params) {
 }
 
 const HASURA_UPSERT_METADATA = `mutation FrontendUpsertMetadata($published: Boolean, $data: jsonb, $locale_code: String, $organization_id: Int!) {
-  insert_site_metadatas(objects: {organization_id: $organization_id, published: $published, site_metadata_translations: {data: {data: $data, locale_code: $locale_code}, on_conflict: {constraint: site_metadata_translations_locale_code_site_metadata_id_key, update_columns: data}}}, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
+  insert_site_metadatas(objects: {
+    organization_id: $organization_id, published: $published, 
+    site_metadata_translations: {
+      data: {
+        data: $data, 
+        locale_code: $locale_code
+      }, 
+      on_conflict: {
+        constraint: site_metadata_translations_locale_code_site_metadata_id_key, 
+        update_columns: data
+      }
+    }
+  }, on_conflict: {constraint: site_metadatas_organization_id_key, update_columns: published}) {
     returning {
       id
       published


### PR DESCRIPTION
I noticed a small issue with bootstrapping an org: the script needs to wait for the temporary environment file with all the new values to be written before renaming it to `.env.local-${slug}`

This fixes the problem by waiting for the file open event before writing and using a sync version of the rename function.

**[edit] Additional fix!**

Closes #780 

Site metadata wasn't being created properly; looks like the value `multiple,locales` as a param wasn't being parsed as an array; also, the graphql was using the wrong foreign key constraint. Fixed.