### PR TITLE
homepage editor fixes; setting for toggling the landing page on or off

### DIFF
--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -52,7 +52,7 @@ export default function BigFeaturedStory(props) {
         <Block>
           <Asset>
             {props.editable && (
-              <div style={{ position: 'relative' }}>
+              <div>
                 <ModalArticleSearch
                   apiUrl={props.apiUrl}
                   apiToken={props.apiToken}

--- a/components/tinycms/ModalArticleSearch.js
+++ b/components/tinycms/ModalArticleSearch.js
@@ -7,6 +7,8 @@ export default function ModalArticleSearch(props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
 
+  console.log('ModalArticleSearch', props.isActive);
+
   function selectArticle(article) {
     console.log(
       'changing featured article from:',

--- a/components/tinycms/Notification.js
+++ b/components/tinycms/Notification.js
@@ -1,7 +1,4 @@
-import tw, { css, styled } from 'twin.macro';
-
-const DangerContainer = styled.div`bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`;
-const SuccessContainer = styled.div`bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative`;
+import tw from 'twin.macro';
 
 export default function Notification(props) {
   let messages = props.message;
@@ -9,6 +6,7 @@ export default function Notification(props) {
     messages = [props.message];
   }
   let alertBox;
+  console.log('props:', props);
   if (props.notificationType === 'success') {
     alertBox = (
       <div tw="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative">
@@ -18,17 +16,6 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-green-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   } else {
@@ -41,33 +28,8 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-red-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   }
   return alertBox;
-
-  // <div className={`notification is-${props.notificationType}`}>
-  //   <button
-  //     className="delete"
-  //     onClick={() => props.setShowNotification(false)}
-  //   ></button>
-  //   {messages.map((msg) => (
-  //     <div key={msg}>
-  //       {msg}
-  //       <br />
-  //     </div>
-  //   ))}
-  // </div>
-  // );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -151,6 +151,10 @@ export default function SiteInfoSettings(props) {
     props.parsedData['twitterDescription']
   );
 
+  const [landingPage, setLandingPage] = useState(
+    props.parsedData['landingPage']
+  );
+
   const [commenting, setCommenting] = useState(props.parsedData['commenting']);
 
   const [shortName, setShortName] = useState(props.parsedData['shortName']);
@@ -201,6 +205,7 @@ export default function SiteInfoSettings(props) {
     setFacebookDescription(props.parsedData['facebookDescription']);
     setTwitterTitle(props.parsedData['twitterTitle']);
     setTwitterDescription(props.parsedData['twitterDescription']);
+    setLandingPage(props.parsedData['landingPage']);
     setCommenting(props.parsedData['commenting']);
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
@@ -270,7 +275,35 @@ export default function SiteInfoSettings(props) {
         </label>
       </SiteInfoFieldsContainer>
 
-      <SettingsHeader ref={props.siteInfoRef} id="siteInfo">
+      <SettingsHeader ref={props.landingPageRef} id="landingPage">
+        Landing Page
+      </SettingsHeader>
+      <SiteInfoFieldsContainer>
+        <div>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="on"
+              checked={landingPage === 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">On</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="off"
+              checked={landingPage !== 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">Off</span>
+          </label>
+        </div>
+      </SiteInfoFieldsContainer>
+
+      <SettingsHeader ref={props.commentsRef} id="comments">
         Comments
       </SettingsHeader>
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -216,6 +216,11 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ export default function Home(props) {
   }
 
   const component =
-    props.siteMetadata.landingPage || !props.selectedLayout ? (
+    props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
     ) : (
       <Homepage {...props} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,7 @@ export default function Home(props) {
     return <CurriculumHomepage {...props} />;
   }
 
+  console.log(props.siteMetadata.landingPage, props.selectedLayout);
   const component =
     props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
@@ -45,7 +46,7 @@ export async function getStaticProps({ locale }) {
     console.log('failed finding site metadata for ', locale, metadatas);
   }
 
-  if (siteMetadata && siteMetadata.landingPage) {
+  if (siteMetadata && siteMetadata.landingPage === 'on') {
     return {
       props: {
         locale,

--- a/pages/tinycms/homepage.js
+++ b/pages/tinycms/homepage.js
@@ -24,6 +24,7 @@ export default function HomePageEditor({
   tags,
   sections,
   locale,
+  locales,
   siteMetadata,
   apiUrl,
   apiToken,
@@ -49,6 +50,14 @@ export default function HomePageEditor({
   }
 
   async function saveAndPublishHomepage() {
+    if (!featuredArticle) {
+      setNotificationMessage(
+        'Sorry, you must feature at least one article to save the homepage!'
+      );
+      setNotificationType('error');
+      setShowNotification(true);
+      return;
+    }
     let article1 = featuredArticle.id;
     let article2 = null;
     let article3 = null;
@@ -91,6 +100,8 @@ export default function HomePageEditor({
   return (
     <AdminLayout>
       <AdminNav
+        currentLocale={locale}
+        locales={locales}
         switchLocales={true}
         homePageEditor={true}
         layoutSchemas={layoutSchemas}
@@ -171,6 +182,8 @@ export async function getServerSideProps({ locale }) {
   }
 
   const layoutSchemas = data.homepage_layout_schemas;
+  const locales = data.organization_locales;
+
   let hpData = data.homepage_layout_datas[0];
   let hpArticles = [];
 
@@ -213,6 +226,7 @@ export async function getServerSideProps({ locale }) {
       tags,
       sections,
       locale,
+      locales,
       siteMetadata,
       apiUrl,
       apiToken,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -52,6 +52,8 @@ export default function Settings({
 }) {
   const siteInfoRef = useRef();
   const designRef = useRef();
+  const landingPageRef = useRef();
+  const commentsRef = useRef();
   const homepagePromoRef = useRef();
   const newsletterRef = useRef();
   const membershipRef = useRef();
@@ -115,6 +117,17 @@ export default function Settings({
       if (siteInfoRef) {
         siteInfoRef.current.scrollIntoView({ behavior: 'smooth' });
       }
+    } else if (window.location.hash && window.location.hash === '#comments') {
+      if (commentsRef) {
+        commentsRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (
+      window.location.hash &&
+      window.location.hash === '#landingPage'
+    ) {
+      if (landingPageRef) {
+        landingPageRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
     } else if (window.location.hash && window.location.hash === '#design') {
       if (designRef) {
         designRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -151,7 +164,7 @@ export default function Settings({
 
   async function handleCancel(ev) {
     ev.preventDefault();
-    router.push('/tinycms/config');
+    router.push('/tinycms');
   }
 
   async function handleSubmit(ev) {
@@ -205,6 +218,11 @@ export default function Settings({
                 <li>
                   <Link href="/tinycms/settings#siteInfo">
                     <a>Site Information</a>
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/tinycms/settings#landingPage">
+                    <a>Landing Page</a>
                   </Link>
                 </li>
                 <li>
@@ -264,6 +282,8 @@ export default function Settings({
             <SettingsContainer>
               <SiteInfoSettings
                 siteInfoRef={siteInfoRef}
+                commentsRef={commentsRef}
+                landingPageRef={landingPageRef}
                 seoRef={seoRef}
                 newsletterRef={newsletterRef}
                 membershipRef={membershipRef}


### PR DESCRIPTION
Closes #782
Closes #783 

This contains fixes for the homepage editor, which include:

* locale switcher now populated (was empty)
* modal for article search now properly displays when 'big featured story' selected on newly configured site

It also adds a landing page toggle to the TinyCMS settings:

Note that the landing page will be displayed even if this setting is "off" if there is no homepage layout selected. Should we display a message about that on the setting? If the landing page option is set to off, the page could display:

(also checks if a hp layout is selected)

* you [have|haven't] selected a homepage layout, so the landing page [will not|will] be shown

(doesn't check the selected layout setting)

* the landing page will continue to be displayed until you select a homepage layout and feature one or more articles