### PR TITLE
Read in other language link for articles

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -14,6 +14,7 @@ export default function Article({
   siteMetadata,
   sectionArticles,
   renderFooter,
+  locales,
 }) {
   const isAmp = useAmp();
 
@@ -62,6 +63,7 @@ export default function Article({
           isAmp={isAmp}
           metadata={siteMetadata}
           mainImage={mainImage}
+          locales={locales}
         />
         <section className="section post__body rich-text" key="body">
           <ArticleBody

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -7,6 +7,7 @@ import MainImage from './MainImage.js';
 import { hasuraLocaliseText, renderAuthors } from '../../lib/utils.js';
 import { ArticleTitle } from '../common/CommonStyles.js';
 import Typography from '../common/Typography';
+import ReadInOtherLanguage from './ReadInOtherLanguage.js';
 
 const SectionContainer = tw.div`flex mx-auto max-w-5xl px-4 flex-col flex-nowrap`;
 const ArticleDescriptor = styled.span(({ meta }) => ({
@@ -34,7 +35,13 @@ const ArticleShareWrapper = tw.ul`inline-flex flex-row flex-nowrap items-center`
 const ShareItem = tw.li`mr-2`;
 const ShareButton = tw.span`bg-no-repeat bg-center border-gray-200 border inline-flex flex items-center justify-center w-10 h-10 pl-6 overflow-hidden rounded-full leading-none text-sm`;
 
-export default function ArticleHeader({ article, isAmp, metadata, mainImage }) {
+export default function ArticleHeader({
+  article,
+  isAmp,
+  metadata,
+  mainImage,
+  locales,
+}) {
   if (!article) {
     return null;
   }
@@ -76,6 +83,10 @@ export default function ArticleHeader({ article, isAmp, metadata, mainImage }) {
         <ArticleTitle meta={metadata}>{headline}</ArticleTitle>
         <ArticleDek meta={metadata}>{searchDescription}</ArticleDek>
         <PublishDate article={article} meta={metadata} />
+        <ReadInOtherLanguage
+          locales={locales}
+          translations={article.article_translations}
+        />
         <ArticleFeaturedMedia>
           <FeaturedMediaFigure>
             <FeaturedMediaWrapper>

--- a/components/articles/ReadInOtherLanguage.js
+++ b/components/articles/ReadInOtherLanguage.js
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+export default function ReadInOtherLanguage({ locales, translations }) {
+  if (locales.length < 1) {
+    return;
+  }
+
+  const router = useRouter();
+
+  let currentLocale = translations[0].locale_code;
+
+  let otherLocales = locales.filter(
+    (locale) => locale.locale.code !== currentLocale
+  );
+  let otherLanguageLinks = otherLocales.map((otherLocale) => {
+    return (
+      <Link
+        key={otherLocale.locale.code}
+        href={router.asPath}
+        locale={otherLocale.locale.code}
+      >
+        <a>Read in {otherLocale.locale.name}</a>
+      </Link>
+    );
+  });
+
+  return <>{otherLanguageLinks}</>;
+}

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -52,7 +52,7 @@ export default function BigFeaturedStory(props) {
         <Block>
           <Asset>
             {props.editable && (
-              <div style={{ position: 'relative' }}>
+              <div>
                 <ModalArticleSearch
                   apiUrl={props.apiUrl}
                   apiToken={props.apiToken}

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -9,10 +9,8 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
   let mainImageNode = null;
 
   const translation = article['article_translations'][0];
-
-  mainImageNode = translation.main_image;
-
   try {
+    mainImageNode = translation.main_image;
     if (mainImageNode && Object.keys(mainImageNode).length > 0) {
       mainImage = mainImageNode.children[0];
     }

--- a/components/tinycms/ModalArticleSearch.js
+++ b/components/tinycms/ModalArticleSearch.js
@@ -7,6 +7,8 @@ export default function ModalArticleSearch(props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
 
+  console.log('ModalArticleSearch', props.isActive);
+
   function selectArticle(article) {
     console.log(
       'changing featured article from:',

--- a/components/tinycms/Notification.js
+++ b/components/tinycms/Notification.js
@@ -1,7 +1,4 @@
-import tw, { css, styled } from 'twin.macro';
-
-const DangerContainer = styled.div`bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`;
-const SuccessContainer = styled.div`bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative`;
+import tw from 'twin.macro';
 
 export default function Notification(props) {
   let messages = props.message;
@@ -9,6 +6,7 @@ export default function Notification(props) {
     messages = [props.message];
   }
   let alertBox;
+  console.log('props:', props);
   if (props.notificationType === 'success') {
     alertBox = (
       <div tw="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative">
@@ -18,17 +16,6 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-green-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   } else {
@@ -41,33 +28,8 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-red-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   }
   return alertBox;
-
-  // <div className={`notification is-${props.notificationType}`}>
-  //   <button
-  //     className="delete"
-  //     onClick={() => props.setShowNotification(false)}
-  //   ></button>
-  //   {messages.map((msg) => (
-  //     <div key={msg}>
-  //       {msg}
-  //       <br />
-  //     </div>
-  //   ))}
-  // </div>
-  // );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -151,6 +151,10 @@ export default function SiteInfoSettings(props) {
     props.parsedData['twitterDescription']
   );
 
+  const [landingPage, setLandingPage] = useState(
+    props.parsedData['landingPage']
+  );
+
   const [commenting, setCommenting] = useState(props.parsedData['commenting']);
 
   const [shortName, setShortName] = useState(props.parsedData['shortName']);
@@ -201,6 +205,7 @@ export default function SiteInfoSettings(props) {
     setFacebookDescription(props.parsedData['facebookDescription']);
     setTwitterTitle(props.parsedData['twitterTitle']);
     setTwitterDescription(props.parsedData['twitterDescription']);
+    setLandingPage(props.parsedData['landingPage']);
     setCommenting(props.parsedData['commenting']);
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
@@ -270,7 +275,35 @@ export default function SiteInfoSettings(props) {
         </label>
       </SiteInfoFieldsContainer>
 
-      <SettingsHeader ref={props.siteInfoRef} id="siteInfo">
+      <SettingsHeader ref={props.landingPageRef} id="landingPage">
+        Landing Page
+      </SettingsHeader>
+      <SiteInfoFieldsContainer>
+        <div>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="on"
+              checked={landingPage === 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">On</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="off"
+              checked={landingPage !== 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">Off</span>
+          </label>
+        </div>
+      </SiteInfoFieldsContainer>
+
+      <SettingsHeader ref={props.commentsRef} id="comments">
         Comments
       </SettingsHeader>
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -365,6 +365,7 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
         first_published_at
         headline
         last_published_at
+        locale_code
         search_description
         search_title
         twitter_description
@@ -408,6 +409,12 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
     id
     published
     slug
+  }
+  organization_locales {
+    locale {
+      code
+      name
+    }
   }
   tags(where: {published: {_eq: true}}) {
     id

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -216,6 +216,11 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -65,6 +65,7 @@ export async function getStaticProps({ locale, params }) {
   let article = {};
   let sectionArticles = [];
   let sections = [];
+  let locales = [];
   let siteMetadata;
   const { errors, data } = await hasuraArticlePage({
     url: apiUrl,
@@ -92,6 +93,7 @@ export async function getStaticProps({ locale, params }) {
       );
     }
 
+    locales = data.organization_locales;
     article = data.article_slug_versions[0].article;
     // article = data.articles.find((a) => a.slug === params.slug);
 
@@ -134,6 +136,7 @@ export async function getStaticProps({ locale, params }) {
       siteMetadata,
       sectionArticles,
       renderFooter,
+      locales,
     },
     // Re-generate the post at most once per second
     // if a request comes in

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ export default function Home(props) {
   }
 
   const component =
-    props.siteMetadata.landingPage || !props.selectedLayout ? (
+    props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
     ) : (
       <Homepage {...props} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,7 @@ export default function Home(props) {
     return <CurriculumHomepage {...props} />;
   }
 
+  console.log(props.siteMetadata.landingPage, props.selectedLayout);
   const component =
     props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
@@ -45,7 +46,7 @@ export async function getStaticProps({ locale }) {
     console.log('failed finding site metadata for ', locale, metadatas);
   }
 
-  if (siteMetadata && siteMetadata.landingPage) {
+  if (siteMetadata && siteMetadata.landingPage === 'on') {
     return {
       props: {
         locale,

--- a/pages/tinycms/homepage.js
+++ b/pages/tinycms/homepage.js
@@ -24,6 +24,7 @@ export default function HomePageEditor({
   tags,
   sections,
   locale,
+  locales,
   siteMetadata,
   apiUrl,
   apiToken,
@@ -49,6 +50,14 @@ export default function HomePageEditor({
   }
 
   async function saveAndPublishHomepage() {
+    if (!featuredArticle) {
+      setNotificationMessage(
+        'Sorry, you must feature at least one article to save the homepage!'
+      );
+      setNotificationType('error');
+      setShowNotification(true);
+      return;
+    }
     let article1 = featuredArticle.id;
     let article2 = null;
     let article3 = null;
@@ -91,6 +100,8 @@ export default function HomePageEditor({
   return (
     <AdminLayout>
       <AdminNav
+        currentLocale={locale}
+        locales={locales}
         switchLocales={true}
         homePageEditor={true}
         layoutSchemas={layoutSchemas}
@@ -171,6 +182,8 @@ export async function getServerSideProps({ locale }) {
   }
 
   const layoutSchemas = data.homepage_layout_schemas;
+  const locales = data.organization_locales;
+
   let hpData = data.homepage_layout_datas[0];
   let hpArticles = [];
 
@@ -213,6 +226,7 @@ export async function getServerSideProps({ locale }) {
       tags,
       sections,
       locale,
+      locales,
       siteMetadata,
       apiUrl,
       apiToken,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -52,6 +52,8 @@ export default function Settings({
 }) {
   const siteInfoRef = useRef();
   const designRef = useRef();
+  const landingPageRef = useRef();
+  const commentsRef = useRef();
   const homepagePromoRef = useRef();
   const newsletterRef = useRef();
   const membershipRef = useRef();
@@ -115,6 +117,17 @@ export default function Settings({
       if (siteInfoRef) {
         siteInfoRef.current.scrollIntoView({ behavior: 'smooth' });
       }
+    } else if (window.location.hash && window.location.hash === '#comments') {
+      if (commentsRef) {
+        commentsRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (
+      window.location.hash &&
+      window.location.hash === '#landingPage'
+    ) {
+      if (landingPageRef) {
+        landingPageRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
     } else if (window.location.hash && window.location.hash === '#design') {
       if (designRef) {
         designRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -151,7 +164,7 @@ export default function Settings({
 
   async function handleCancel(ev) {
     ev.preventDefault();
-    router.push('/tinycms/config');
+    router.push('/tinycms');
   }
 
   async function handleSubmit(ev) {
@@ -205,6 +218,11 @@ export default function Settings({
                 <li>
                   <Link href="/tinycms/settings#siteInfo">
                     <a>Site Information</a>
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/tinycms/settings#landingPage">
+                    <a>Landing Page</a>
                   </Link>
                 </li>
                 <li>
@@ -264,6 +282,8 @@ export default function Settings({
             <SettingsContainer>
               <SiteInfoSettings
                 siteInfoRef={siteInfoRef}
+                commentsRef={commentsRef}
+                landingPageRef={landingPageRef}
                 seoRef={seoRef}
                 newsletterRef={newsletterRef}
                 membershipRef={membershipRef}

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -1,22 +1,26 @@
 #! /usr/bin/env node
 
-require('dotenv').config({ path: '.env.local' })
+require('dotenv').config({ path: '.env.local' });
 
 const fetch = require('node-fetch');
 
-const shared = require("./shared");
+const shared = require('./shared');
 
 const apiUrl = process.env.HASURA_API_URL;
 const apiToken = process.env.ORG_SLUG;
 
 function getNewsletterEditions() {
-  const letterheadUrl = process.env.LETTERHEAD_API_URL + "channels/" + process.env.LETTERHEAD_CHANNEL_SLUG + "/letters";
-  console.log("Letterhead API URL:", letterheadUrl);
+  const letterheadUrl =
+    process.env.LETTERHEAD_API_URL +
+    'channels/' +
+    process.env.LETTERHEAD_CHANNEL_SLUG +
+    '/letters';
+  console.log('Letterhead API URL:', letterheadUrl);
 
   if (!process.env.LETTERHEAD_API_URL) {
     return;
   }
-  
+
   const opts = {
     headers: {
       'Content-Type': 'application/json',
@@ -33,7 +37,6 @@ function getNewsletterEditions() {
 
 //{"ops":[{"insert":"This is my newsletter"},{"attributes":{"header":1},"insert":"\n"},{"insert":"By Tyler \nThis is a paragraph followed by a list:\nlist item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 3"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Section title"},{"attributes":{"header":2},"insert":"\n"},{"attributes":{"bold":true},"insert":"Bold text. "},{"attributes":{"italic":true,"bold":true},"insert":"Italic bold text. "},{"attributes":{"italic":true},"insert":"Just italic."},{"insert":"\n\n"}]}
 
-
 function transformDelta(delta) {
   // console.log(delta);
 
@@ -43,7 +46,7 @@ function transformDelta(delta) {
     if (!element.insert) {
       return;
     }
-    if (typeof(element.insert) !== 'string') {
+    if (typeof element.insert !== 'string') {
       return;
     }
 
@@ -52,10 +55,10 @@ function transformDelta(delta) {
       lines.forEach((line) => {
         if (line) {
           elements.push({
-            "insert": line
+            insert: line,
           });
         }
-      })
+      });
     } else {
       elements.push(element);
     }
@@ -63,153 +66,173 @@ function transformDelta(delta) {
 
   // console.log(elements);
 
-  let list = {items: []};
-  let paragraph = {children: []};
+  let list = { items: [] };
+  let paragraph = { children: [] };
 
   let formattedElements = [];
   elements.forEach((element, i) => {
     if (element.attributes && element.attributes.header) {
       // console.log(i, "header:", elements[i-1].insert)
-      formattedElements.push( {
-        "link": null,
-        "type": "text",
-        "style": "HEADING_" + element.attributes.header,
-        "children": [
+      formattedElements.push({
+        link: null,
+        type: 'text',
+        style: 'HEADING_' + element.attributes.header,
+        children: [
           {
-            "index": i,
-            "style": {},
-            "content": elements[i-1].insert
-          }
-        ]
-      })
+            index: i,
+            style: {},
+            content: elements[i - 1].insert,
+          },
+        ],
+      });
     } else if (element.attributes && element.attributes.list) {
       // console.log(i, "list:", elements[i-1].insert)
 
       list.items.push({
-        "index": i,
-        "children": [
+        index: i,
+        children: [
           {
-            "style": {},
-            "content": elements[i-1].insert
-          }
+            style: {},
+            content: elements[i - 1].insert,
+          },
         ],
-        "nestingLevel": 0
-      })
+        nestingLevel: 0,
+      });
 
       // if there is a second next element and it's not a list, this is the last item in the list;
       // if there is no second next element, this is also the last item in the list; finish it
       // by pushing it onto the formattedElements, then set it to an empty object again
       // we do this in case there are more lists in the email
       // if there is a second next element and it has a list attr, this list has more items
-      if ( (elements[i+2] && (!elements[i+2].attributes || !elements[i+2].attributes.list)) || !elements[i+2] ) {
-         // hardcode as "bullet" for now
-         formattedElements.push({
-          "type": "list",
-          "listType": "BULLET",
-          "items": list.items,
-          "link": null
-        })
+      if (
+        (elements[i + 2] &&
+          (!elements[i + 2].attributes || !elements[i + 2].attributes.list)) ||
+        !elements[i + 2]
+      ) {
+        // hardcode as "bullet" for now
+        formattedElements.push({
+          type: 'list',
+          listType: 'BULLET',
+          items: list.items,
+          link: null,
+        });
         // reset the list holder
-        list = {items: []};
+        list = { items: [] };
       }
-
-    } else if (element.attributes && (element.attributes.bold || element.attributes.italic)) {
+    } else if (
+      element.attributes &&
+      (element.attributes.bold || element.attributes.italic)
+    ) {
       // console.log(i, "formatted text:", element.insert);
       let style = {};
       if (element.attributes.bold) {
-        style["bold"] = true;
+        style['bold'] = true;
       }
       if (element.attributes.italic) {
-        style["italic"] = true;
+        style['italic'] = true;
       }
 
       paragraph.children.push({
-        "index": i,
-        "style": style,
-        "content": element.insert
-      })
+        index: i,
+        style: style,
+        content: element.insert,
+      });
 
       // if this is the last element of the newsletter, or
-      // if the next element is blank string, or 
+      // if the next element is blank string, or
       // if the next element is a list/header item, close the paragraph
       if (
-        (!elements[i+1]) ||
-        ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
-        ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+        !elements[i + 1] ||
+        (elements[i + 1] &&
+          elements[i + 1].insert &&
+          !elements[i + 1].insert.replace(/[\\n]|\n/g, '')) ||
+        (elements[i + 1] &&
+          elements[i + 1].attributes &&
+          (elements[i + 1].attributes.list ||
+            elements[i + 1].attributes.header))
       ) {
-        
         formattedElements.push({
-          "link": null,
-          "type": "text",
-          "style": "NORMAL_TEXT",
-          "children": paragraph.children
-        });  
-        paragraph = { "children": []}
+          link: null,
+          type: 'text',
+          style: 'NORMAL_TEXT',
+          children: paragraph.children,
+        });
+        paragraph = { children: [] };
         // otherwise, continue on
       }
-      
-
     } else if (element.attributes && element.attributes.link) {
       // console.log(i, "link:", element.attributes.link);
 
       formattedElements.push({
-        "link": null,
-        "type": "text",
-        "style": "NORMAL_TEXT",
-        "children": [
+        link: null,
+        type: 'text',
+        style: 'NORMAL_TEXT',
+        children: [
           {
-            "link": element.attributes.link,
-            "index": i,
-            "style": {
-              "underline": true
+            link: element.attributes.link,
+            index: i,
+            style: {
+              underline: true,
             },
-            "content": element.insert
-          }
-        ]
-      })
+            content: element.insert,
+          },
+        ],
+      });
     } else if (element.attributes) {
       // console.log(i, "unknown attrs:", element.attributes);
-
     } else {
-      if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.header) {
-        console.log(i, "skip, header is handled next:", element.insert);
-      } else if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.list) {
-        console.log(i, "skip, list is handled next:", element.insert);
+      if (
+        elements[i + 1] &&
+        elements[i + 1].attributes &&
+        elements[i + 1].attributes.header
+      ) {
+        console.log(i, 'skip, header is handled next:', element.insert);
+      } else if (
+        elements[i + 1] &&
+        elements[i + 1].attributes &&
+        elements[i + 1].attributes.list
+      ) {
+        console.log(i, 'skip, list is handled next:', element.insert);
       } else {
-        console.log(i, "plain text:", element.insert);
+        console.log(i, 'plain text:', element.insert);
 
         paragraph.children.push({
-            "link": null,
-            "type": "text",
-            "style": "NORMAL_TEXT",
-            "children": [
-              {
-                "index": i,
-                "style": {},
-                "content": element.insert
-              }
-            ]
-        })
+          link: null,
+          type: 'text',
+          style: 'NORMAL_TEXT',
+          children: [
+            {
+              index: i,
+              style: {},
+              content: element.insert,
+            },
+          ],
+        });
 
         // if this is the last element of the newsletter, or
-        // if the next element is blank string, or 
+        // if the next element is blank string, or
         // if the next element is a list/header item, close the paragraph
         if (
-          (!elements[i+1]) ||
-          ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
-          ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+          !elements[i + 1] ||
+          (elements[i + 1] &&
+            elements[i + 1].insert &&
+            !elements[i + 1].insert.replace(/[\\n]|\n/g, '')) ||
+          (elements[i + 1] &&
+            elements[i + 1].attributes &&
+            (elements[i + 1].attributes.list ||
+              elements[i + 1].attributes.header))
         ) {
           formattedElements.push({
-            "link": null,
-            "type": "text",
-            "style": "NORMAL_TEXT",
-            "children": paragraph.children
-          });  
-          paragraph = { "children": []}
+            link: null,
+            type: 'text',
+            style: 'NORMAL_TEXT',
+            children: paragraph.children,
+          });
+          paragraph = { children: [] };
         }
       }
     }
-  })
+  });
 
   // console.log(formattedElements);
 
@@ -217,10 +240,20 @@ function transformDelta(delta) {
 }
 
 async function saveNewsletterEditions(letterheadData) {
-  console.log("Letterhead returned", letterheadData.length, "newsletter editions in total:");
+  console.log(
+    'Letterhead returned',
+    letterheadData.length,
+    'newsletter editions in total:'
+  );
   for await (let newsletter of letterheadData) {
     if (!newsletter.publicationDate) {
-      console.log("> Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' is not published, skipping.")
+      console.log(
+        '> Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' is not published, skipping."
+      );
       continue;
     }
 
@@ -239,7 +272,7 @@ async function saveNewsletterEditions(letterheadData) {
       content: content,
       newsletter_created_at: newsletter.createdAt,
       newsletter_published_at: newsletter.publicationDate,
-    }
+    };
     if (newsletter.customizedByline) {
       editionData['byline'] = newsletter.customizedByline;
     }
@@ -254,11 +287,26 @@ async function saveNewsletterEditions(letterheadData) {
     });
 
     if (result.errors) {
-      console.error("! Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' had an error saving:", result.errors);
+      console.error(
+        '! Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' had an error saving:",
+        result.errors
+      );
     } else {
-      console.log(". Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' was published at " + newsletter.publicationDate + ", saved in Hasura with slug: " + result.data.insert_newsletter_editions_one.slug)
+      console.log(
+        '. Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' was published at " +
+          newsletter.publicationDate +
+          ', saved in Hasura with slug: ' +
+          result.data.insert_newsletter_editions_one.slug
+      );
     }
-
   }
 }
 
@@ -283,10 +331,9 @@ const slugify = (value) => {
 };
 
 const publishNewsletters = process.env.PUBLISH_NEWSLETTERS;
-console.log("publish newsletters?", typeof(publishNewsletters), publishNewsletters);
 
-if (!publishNewsletters || publishNewsletters === "false") {
-  console.log("Not publishing newsletters for " + apiToken);
+if (!publishNewsletters || publishNewsletters === 'false') {
+  console.log('Not publishing newsletters for ' + apiToken);
   return;
 } else {
   getNewsletterEditions();


### PR DESCRIPTION
Part of #776 

This adds "read in" links to the article page for viewing the content in other languages:

* "Read in {language name}" in article header
* as currently implemented this will repeat for all other locales other than the current one; I think most sites will have 2 at most, but I thought I'd point that out. Maybe we would want to either limit it to one other language or display: `Read in {language 1} or {language 2}`
* Does a simple nextjs router switch on the locale, does not check if content exists in that locale