### PR TITLE
Read in other language link for Article, Generic Static, Author, Category & Tag pages

### DIFF
--- a/.github/workflows/import-data-from-ga-two-languages.yml
+++ b/.github/workflows/import-data-from-ga-two-languages.yml
@@ -1,0 +1,51 @@
+name: GA Data Importer
+'on':
+  schedule:
+    - cron: 5 9 * * *
+  push:
+    branches:
+      - main
+jobs:
+  GA-Data-Importer:
+    runs-on: ubuntu-latest
+    environment: data_import_two-languages
+    env:
+      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
+      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
+      GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+    steps:
+      - run: echo "🔎 Running GA data importer"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm install
+      - run: echo "🖥️ repo and node are setup"
+      - name: donate-clicks
+        run: node script/ga.js -d donate-clicks
+      - name: donor-reading-frequency
+        run: node script/ga.js -d donor-reading-frequency
+      - name: donors
+        run: node script/ga.js -d donors
+      - name: geo-sessions
+        run: node script/ga.js -d geo-sessions
+      - name: newsletter-impressions
+        run: node script/ga.js -d newsletter-impressions
+      - name: newsletters
+        run: node script/ga.js -d newsletters
+      - name: page-views
+        run: node script/ga.js -d page-views
+      - name: reading-depth
+        run: node script/ga.js -d reading-depth
+      - name: reading-frequency
+        run: node script/ga.js -d reading-frequency
+      - name: referral-sessions
+        run: node script/ga.js -d referral-sessions
+      - name: session-duration
+        run: node script/ga.js -d session-duration
+      - name: sessions
+        run: node script/ga.js -d sessions
+      - name: subscribers
+        run: node script/ga.js -d subscribers
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/components/Article.js
+++ b/components/Article.js
@@ -14,6 +14,7 @@ export default function Article({
   siteMetadata,
   sectionArticles,
   renderFooter,
+  locales,
 }) {
   const isAmp = useAmp();
 
@@ -62,6 +63,7 @@ export default function Article({
           isAmp={isAmp}
           metadata={siteMetadata}
           mainImage={mainImage}
+          locales={locales}
         />
         <section className="section post__body rich-text" key="body">
           <ArticleBody

--- a/components/Article.js
+++ b/components/Article.js
@@ -15,6 +15,7 @@ export default function Article({
   sectionArticles,
   renderFooter,
   locales,
+  publishedLocales,
 }) {
   const isAmp = useAmp();
 
@@ -64,6 +65,7 @@ export default function Article({
           metadata={siteMetadata}
           mainImage={mainImage}
           locales={locales}
+          publishedLocales={publishedLocales}
         />
         <section className="section post__body rich-text" key="body">
           <ArticleBody

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -5,11 +5,21 @@ import {
   ArticleTitle,
   PostTextContainer,
   PostText,
+  SectionLayout,
+  Block,
 } from './common/CommonStyles.js';
+import ReadInOtherLanguage from '../components/articles/ReadInOtherLanguage';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
-export default function StaticPage({ siteMetadata, sections, page, isAmp }) {
+export default function StaticPage({
+  siteMetadata,
+  sections,
+  page,
+  isAmp,
+  locales,
+  currentLocale,
+}) {
   let baseUrl = process.env.NEXT_PUBLIC_SITE_URL || siteMetadata['siteUrl'];
   // this is used for the canonical link tag in the Layout component
   let canonicalPageUrl = generatePageUrl(baseUrl, page);
@@ -32,6 +42,19 @@ export default function StaticPage({ siteMetadata, sections, page, isAmp }) {
         <PostText>
           <PostTextContainer>{body}</PostTextContainer>
         </PostText>
+
+        {locales.length > 1 && (
+          <SectionLayout>
+            <SectionContainer>
+              <Block>
+                <ReadInOtherLanguage
+                  locales={locales}
+                  currentLocale={currentLocale}
+                />
+              </Block>
+            </SectionContainer>
+          </SectionLayout>
+        )}
       </SectionContainer>
     </Layout>
   );

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -41,6 +41,7 @@ export default function ArticleHeader({
   metadata,
   mainImage,
   locales,
+  publishedLocales,
 }) {
   if (!article) {
     return null;
@@ -69,6 +70,23 @@ export default function ArticleHeader({
     authorPhoto = article.author_articles[0].author.photoUrl;
   }
 
+  // this block of code bui9lds an array of locales the article is available in
+  // by comparing the list of all site locales with the list of published translations
+  // ex: site locales [en, es]; this article published in [en, es]; current locale is english;
+  // 'ReadInOtherLanguage' component should show "Read in Spanish" link
+  // (logic around current locale is in the component itself)
+  let readLocales = [];
+  let currentLocale = article.article_translations[0].locale_code;
+  if (locales.length > 1) {
+    locales.forEach((siteLocale) => {
+      publishedLocales.forEach((articleLocale) => {
+        if (siteLocale.locale.code === articleLocale.locale_code) {
+          readLocales.push(siteLocale);
+        }
+      });
+    });
+  }
+
   return (
     <section key="title" className="section post__header">
       <SectionContainer>
@@ -83,10 +101,10 @@ export default function ArticleHeader({
         <ArticleTitle meta={metadata}>{headline}</ArticleTitle>
         <ArticleDek meta={metadata}>{searchDescription}</ArticleDek>
         <PublishDate article={article} meta={metadata} />
-        {locales.length > 1 && (
+        {readLocales.length > 1 && (
           <ReadInOtherLanguage
-            locales={locales}
-            currentLocale={article.article_translations[0].locale_code}
+            locales={readLocales}
+            currentLocale={currentLocale}
           />
         )}
         <ArticleFeaturedMedia>

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -7,6 +7,7 @@ import MainImage from './MainImage.js';
 import { hasuraLocaliseText, renderAuthors } from '../../lib/utils.js';
 import { ArticleTitle } from '../common/CommonStyles.js';
 import Typography from '../common/Typography';
+import ReadInOtherLanguage from './ReadInOtherLanguage.js';
 
 const SectionContainer = tw.div`flex mx-auto max-w-5xl px-4 flex-col flex-nowrap`;
 const ArticleDescriptor = styled.span(({ meta }) => ({
@@ -34,7 +35,13 @@ const ArticleShareWrapper = tw.ul`inline-flex flex-row flex-nowrap items-center`
 const ShareItem = tw.li`mr-2`;
 const ShareButton = tw.span`bg-no-repeat bg-center border-gray-200 border inline-flex flex items-center justify-center w-10 h-10 pl-6 overflow-hidden rounded-full leading-none text-sm`;
 
-export default function ArticleHeader({ article, isAmp, metadata, mainImage }) {
+export default function ArticleHeader({
+  article,
+  isAmp,
+  metadata,
+  mainImage,
+  locales,
+}) {
   if (!article) {
     return null;
   }
@@ -76,6 +83,10 @@ export default function ArticleHeader({ article, isAmp, metadata, mainImage }) {
         <ArticleTitle meta={metadata}>{headline}</ArticleTitle>
         <ArticleDek meta={metadata}>{searchDescription}</ArticleDek>
         <PublishDate article={article} meta={metadata} />
+        <ReadInOtherLanguage
+          locales={locales}
+          translations={article.article_translations}
+        />
         <ArticleFeaturedMedia>
           <FeaturedMediaFigure>
             <FeaturedMediaWrapper>

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -83,10 +83,12 @@ export default function ArticleHeader({
         <ArticleTitle meta={metadata}>{headline}</ArticleTitle>
         <ArticleDek meta={metadata}>{searchDescription}</ArticleDek>
         <PublishDate article={article} meta={metadata} />
-        <ReadInOtherLanguage
-          locales={locales}
-          currentLocale={article.article_translations[0].locale_code}
-        />
+        {locales.length > 1 && (
+          <ReadInOtherLanguage
+            locales={locales}
+            currentLocale={article.article_translations[0].locale_code}
+          />
+        )}
         <ArticleFeaturedMedia>
           <FeaturedMediaFigure>
             <FeaturedMediaWrapper>

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -85,7 +85,7 @@ export default function ArticleHeader({
         <PublishDate article={article} meta={metadata} />
         <ReadInOtherLanguage
           locales={locales}
-          translations={article.article_translations}
+          currentLocale={article.article_translations[0].locale_code}
         />
         <ArticleFeaturedMedia>
           <FeaturedMediaFigure>

--- a/components/articles/ReadInOtherLanguage.js
+++ b/components/articles/ReadInOtherLanguage.js
@@ -2,10 +2,6 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 
 export default function ReadInOtherLanguage({ locales, currentLocale }) {
-  if (locales.length < 1) {
-    return;
-  }
-
   const router = useRouter();
 
   let otherLocales = locales.filter(

--- a/components/articles/ReadInOtherLanguage.js
+++ b/components/articles/ReadInOtherLanguage.js
@@ -1,14 +1,12 @@
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
-export default function ReadInOtherLanguage({ locales, translations }) {
+export default function ReadInOtherLanguage({ locales, currentLocale }) {
   if (locales.length < 1) {
     return;
   }
 
   const router = useRouter();
-
-  let currentLocale = translations[0].locale_code;
 
   let otherLocales = locales.filter(
     (locale) => locale.locale.code !== currentLocale

--- a/components/articles/ReadInOtherLanguage.js
+++ b/components/articles/ReadInOtherLanguage.js
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+export default function ReadInOtherLanguage({ locales, translations }) {
+  if (locales.length < 1) {
+    return;
+  }
+
+  const router = useRouter();
+
+  let currentLocale = translations[0].locale_code;
+
+  let otherLocales = locales.filter(
+    (locale) => locale.locale.code !== currentLocale
+  );
+  let otherLanguageLinks = otherLocales.map((otherLocale) => {
+    return (
+      <Link
+        key={otherLocale.locale.code}
+        href={router.asPath}
+        locale={otherLocale.locale.code}
+      >
+        <a>Read in {otherLocale.locale.name}</a>
+      </Link>
+    );
+  });
+
+  return <>{otherLanguageLinks}</>;
+}

--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -12,3 +12,6 @@ export const H1 = tw.h1`font-bold text-3xl lg:text-4xl leading-tight mt-10 mb-4`
 export const H2 = tw.h2`font-bold text-2xl leading-tight mt-10 mb-4`;
 export const H3 = tw.h3`font-bold text-xl leading-tight mt-10 mb-4`;
 export const Anchor = tw.a`text-black cursor-pointer border-b border-blue-500`;
+export const SectionLayout = tw.section`flex mb-8`;
+export const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
+export const Block = tw.div`w-full`;

--- a/components/homepage/BigFeaturedStory.js
+++ b/components/homepage/BigFeaturedStory.js
@@ -52,7 +52,7 @@ export default function BigFeaturedStory(props) {
         <Block>
           <Asset>
             {props.editable && (
-              <div style={{ position: 'relative' }}>
+              <div>
                 <ModalArticleSearch
                   apiUrl={props.apiUrl}
                   apiToken={props.apiToken}

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -9,10 +9,8 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
   let mainImageNode = null;
 
   const translation = article['article_translations'][0];
-
-  mainImageNode = translation.main_image;
-
   try {
+    mainImageNode = translation.main_image;
     if (mainImageNode && Object.keys(mainImageNode).length > 0) {
       mainImage = mainImageNode.children[0];
     }

--- a/components/tinycms/ModalArticleSearch.js
+++ b/components/tinycms/ModalArticleSearch.js
@@ -7,6 +7,8 @@ export default function ModalArticleSearch(props) {
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState([]);
 
+  console.log('ModalArticleSearch', props.isActive);
+
   function selectArticle(article) {
     console.log(
       'changing featured article from:',

--- a/components/tinycms/Notification.js
+++ b/components/tinycms/Notification.js
@@ -1,7 +1,4 @@
-import tw, { css, styled } from 'twin.macro';
-
-const DangerContainer = styled.div`bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative`;
-const SuccessContainer = styled.div`bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative`;
+import tw from 'twin.macro';
 
 export default function Notification(props) {
   let messages = props.message;
@@ -9,6 +6,7 @@ export default function Notification(props) {
     messages = [props.message];
   }
   let alertBox;
+  console.log('props:', props);
   if (props.notificationType === 'success') {
     alertBox = (
       <div tw="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative">
@@ -18,17 +16,6 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-green-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   } else {
@@ -41,33 +28,8 @@ export default function Notification(props) {
             {msg}
           </span>
         ))}
-        <span tw="absolute top-0 bottom-0 right-0 px-4 py-3">
-          <svg
-            tw="fill-current h-6 w-6 text-red-500"
-            role="button"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-          >
-            <title>Close</title>
-            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" />
-          </svg>
-        </span>
       </div>
     );
   }
   return alertBox;
-
-  // <div className={`notification is-${props.notificationType}`}>
-  //   <button
-  //     className="delete"
-  //     onClick={() => props.setShowNotification(false)}
-  //   ></button>
-  //   {messages.map((msg) => (
-  //     <div key={msg}>
-  //       {msg}
-  //       <br />
-  //     </div>
-  //   ))}
-  // </div>
-  // );
 }

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -151,6 +151,10 @@ export default function SiteInfoSettings(props) {
     props.parsedData['twitterDescription']
   );
 
+  const [landingPage, setLandingPage] = useState(
+    props.parsedData['landingPage']
+  );
+
   const [commenting, setCommenting] = useState(props.parsedData['commenting']);
 
   const [shortName, setShortName] = useState(props.parsedData['shortName']);
@@ -201,6 +205,7 @@ export default function SiteInfoSettings(props) {
     setFacebookDescription(props.parsedData['facebookDescription']);
     setTwitterTitle(props.parsedData['twitterTitle']);
     setTwitterDescription(props.parsedData['twitterDescription']);
+    setLandingPage(props.parsedData['landingPage']);
     setCommenting(props.parsedData['commenting']);
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
@@ -270,7 +275,35 @@ export default function SiteInfoSettings(props) {
         </label>
       </SiteInfoFieldsContainer>
 
-      <SettingsHeader ref={props.siteInfoRef} id="siteInfo">
+      <SettingsHeader ref={props.landingPageRef} id="landingPage">
+        Landing Page
+      </SettingsHeader>
+      <SiteInfoFieldsContainer>
+        <div>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="on"
+              checked={landingPage === 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">On</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="landingPage"
+              value="off"
+              checked={landingPage !== 'on'}
+              onChange={props.handleChange}
+            />
+            <span tw="p-2 mt-1 font-bold">Off</span>
+          </label>
+        </div>
+      </SiteInfoFieldsContainer>
+
+      <SettingsHeader ref={props.commentsRef} id="comments">
         Comments
       </SettingsHeader>
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -632,6 +632,12 @@ const HASURA_CATEGORY_PAGE = `query FrontendCategoryPage($category_slug: String!
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -365,6 +365,7 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
         first_published_at
         headline
         last_published_at
+        locale_code
         search_description
         search_title
         twitter_description
@@ -408,6 +409,12 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
     id
     published
     slug
+  }
+  organization_locales {
+    locale {
+      code
+      name
+    }
   }
   tags(where: {published: {_eq: true}}) {
     id

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -216,6 +216,11 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -219,6 +219,7 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
   organization_locales {
     locale {
       code
+      name
     }
   }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
@@ -941,6 +942,12 @@ const HASURA_AUTHOR_PAGE = `query FrontendAuthorPage($locale_code: String!, $aut
     }
     published
     slug
+  }
+  organization_locales {
+    locale {
+      code
+      name
+    }
   }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -699,6 +699,7 @@ const HASURA_GET_PAGE_SLUG_VERSION = `query FrontendGetPageSlugVersion($slug: St
         first_published_at
         headline
         last_published_at
+        locale_code
         published
         search_description
         search_title
@@ -727,6 +728,21 @@ const HASURA_GET_PAGE_SLUG_VERSION = `query FrontendGetPageSlugVersion($slug: St
     published
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
+    }
+  }
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
+  pages(where: {slug: {_eq: $slug}, page_translations: {published: {_eq: true}}}) {
+    page_translations {
+      locale {
+        code
+        name
+      }
+      id
     }
   }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -539,6 +539,12 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($locale_code: String, $tag_slug: 
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -430,6 +430,9 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
       locale_code
     }
   }
+  published_article_translations(where: {article: {slug: {_eq: $slug}}}) {
+    locale_code
+  }
 }`;
 
 const HASURA_ARTICLE_PAGE = `query FrontendArticlePage($category_slug: String!, $locale_code: String!, $slug: String!) {

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -65,6 +65,7 @@ export async function getStaticProps({ locale, params }) {
   let article = {};
   let sectionArticles = [];
   let sections = [];
+  let locales = [];
   let siteMetadata;
   const { errors, data } = await hasuraArticlePage({
     url: apiUrl,
@@ -92,6 +93,7 @@ export async function getStaticProps({ locale, params }) {
       );
     }
 
+    locales = data.organization_locales;
     article = data.article_slug_versions[0].article;
     // article = data.articles.find((a) => a.slug === params.slug);
 
@@ -134,6 +136,7 @@ export async function getStaticProps({ locale, params }) {
       siteMetadata,
       sectionArticles,
       renderFooter,
+      locales,
     },
     // Re-generate the post at most once per second
     // if a request comes in

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -66,6 +66,7 @@ export async function getStaticProps({ locale, params }) {
   let sectionArticles = [];
   let sections = [];
   let locales = [];
+  let publishedLocales = [];
   let siteMetadata;
   const { errors, data } = await hasuraArticlePage({
     url: apiUrl,
@@ -94,6 +95,7 @@ export async function getStaticProps({ locale, params }) {
     }
 
     locales = data.organization_locales;
+    publishedLocales = data.published_article_translations;
     article = data.article_slug_versions[0].article;
     // article = data.articles.find((a) => a.slug === params.slug);
 
@@ -137,6 +139,7 @@ export async function getStaticProps({ locale, params }) {
       sectionArticles,
       renderFooter,
       locales,
+      publishedLocales,
     },
     // Re-generate the post at most once per second
     // if a request comes in

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -95,13 +95,15 @@ export default function AuthorPage({
         metadata={siteMetadata}
         ads={expandedAds}
       />
-      <SectionLayout>
-        <SectionContainer>
-          <Block>
-            <ReadInOtherLanguage locales={locales} currentLocale={locale} />
-          </Block>
-        </SectionContainer>
-      </SectionLayout>
+      {locales.length > 1 && (
+        <SectionLayout>
+          <SectionContainer>
+            <Block>
+              <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+            </Block>
+          </SectionContainer>
+        </SectionLayout>
+      )}
     </Layout>
   );
 }

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -11,6 +11,12 @@ import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
 import tw from 'twin.macro';
 import { Anchor } from '../../components/common/CommonStyles.js';
+import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
+import {
+  SectionContainer,
+  SectionLayout,
+  Block,
+} from '../../components/common/CommonStyles';
 
 export default function AuthorPage({
   sections,
@@ -18,6 +24,8 @@ export default function AuthorPage({
   author,
   siteMetadata,
   expandedAds,
+  locales,
+  locale,
 }) {
   const router = useRouter();
   const isAmp = useAmp();
@@ -87,6 +95,13 @@ export default function AuthorPage({
         metadata={siteMetadata}
         ads={expandedAds}
       />
+      <SectionLayout>
+        <SectionContainer>
+          <Block>
+            <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+          </Block>
+        </SectionContainer>
+      </SectionLayout>
     </Layout>
   );
 }
@@ -134,6 +149,7 @@ export async function getStaticProps({ locale, params }) {
 
   let articles = [];
   let sections = [];
+  let locales = [];
   let author;
   let siteMetadata;
 
@@ -152,6 +168,7 @@ export async function getStaticProps({ locale, params }) {
     articles = data.articles;
     sections = data.categories;
     author = data.authors[0];
+    locales = data.organization_locales;
 
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
@@ -187,6 +204,8 @@ export async function getStaticProps({ locale, params }) {
       author,
       siteMetadata,
       expandedAds,
+      locales,
+      locale,
     },
   };
 }

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import tw from 'twin.macro';
 import React, { useEffect } from 'react';
 import Layout from '../../components/Layout.js';
 import { cachedContents } from '../../lib/cached';
@@ -10,6 +11,11 @@ import { getArticleAds } from '../../lib/ads.js';
 import { hasuraLocaliseText } from '../../lib/utils.js';
 import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
+import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
+
+const SectionLayout = tw.section`flex mb-8`;
+const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
+const Block = tw.div`w-full`;
 
 export default function CategoryPage(props) {
   const isAmp = useAmp();
@@ -48,6 +54,17 @@ export default function CategoryPage(props) {
         metadata={props.siteMetadata}
         ads={props.expandedAds}
       />
+
+      <SectionLayout>
+        <SectionContainer>
+          <Block>
+            <ReadInOtherLanguage
+              locales={props.locales}
+              currentLocale={props.locale}
+            />
+          </Block>
+        </SectionContainer>
+      </SectionLayout>
     </Layout>
   );
 }
@@ -97,6 +114,7 @@ export async function getStaticProps({ locale, params }) {
   let articles = [];
   let sections = [];
   let tags = [];
+  let locales = [];
   let siteMetadata;
   let title;
   let categoryExists = false;
@@ -116,6 +134,7 @@ export async function getStaticProps({ locale, params }) {
   } else {
     articles = data.articles;
     sections = data.categories;
+    locales = data.organization_locales;
 
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
@@ -165,6 +184,8 @@ export async function getStaticProps({ locale, params }) {
       siteMetadata,
       expandedAds,
       renderFooter,
+      locale,
+      locales,
     },
   };
 }

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import tw from 'twin.macro';
 import React, { useEffect } from 'react';
 import Layout from '../../components/Layout.js';
 import { cachedContents } from '../../lib/cached';
@@ -12,10 +11,11 @@ import { hasuraLocaliseText } from '../../lib/utils.js';
 import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
 import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
-
-const SectionLayout = tw.section`flex mb-8`;
-const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
-const Block = tw.div`w-full`;
+import {
+  SectionContainer,
+  SectionLayout,
+  Block,
+} from '../../components/common/CommonStyles';
 
 export default function CategoryPage(props) {
   const isAmp = useAmp();

--- a/pages/categories/[category].js
+++ b/pages/categories/[category].js
@@ -54,17 +54,18 @@ export default function CategoryPage(props) {
         metadata={props.siteMetadata}
         ads={props.expandedAds}
       />
-
-      <SectionLayout>
-        <SectionContainer>
-          <Block>
-            <ReadInOtherLanguage
-              locales={props.locales}
-              currentLocale={props.locale}
-            />
-          </Block>
-        </SectionContainer>
-      </SectionLayout>
+      {props.locales.length > 1 && (
+        <SectionLayout>
+          <SectionContainer>
+            <Block>
+              <ReadInOtherLanguage
+                locales={props.locales}
+                currentLocale={props.locale}
+              />
+            </Block>
+          </SectionContainer>
+        </SectionLayout>
+      )}
     </Layout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ export default function Home(props) {
   }
 
   const component =
-    props.siteMetadata.landingPage || !props.selectedLayout ? (
+    props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
     ) : (
       <Homepage {...props} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,6 +13,7 @@ export default function Home(props) {
     return <CurriculumHomepage {...props} />;
   }
 
+  console.log(props.siteMetadata.landingPage, props.selectedLayout);
   const component =
     props.siteMetadata.landingPage === 'on' || !props.selectedLayout ? (
       <LandingPage {...props} />
@@ -45,7 +46,7 @@ export async function getStaticProps({ locale }) {
     console.log('failed finding site metadata for ', locale, metadatas);
   }
 
-  if (siteMetadata && siteMetadata.landingPage) {
+  if (siteMetadata && siteMetadata.landingPage === 'on') {
     return {
       props: {
         locale,

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -105,9 +105,9 @@ export async function getStaticProps({ locale, params }) {
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
 
     sections = data.categories;
-    for (var i = 0; i < sections.length; i++) {
-      sections[i].title = hasuraLocaliseText(
-        sections[i].category_translations,
+    for (var j = 0; j < sections.length; j++) {
+      sections[j].title = hasuraLocaliseText(
+        sections[j].category_translations,
         'title'
       );
     }

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -5,7 +5,13 @@ import { hasuraGetPage, hasuraListAllPageSlugs } from '../../lib/articles.js';
 import { hasuraLocaliseText } from '../../lib/utils';
 import StaticPage from '../../components/StaticPage';
 
-export default function Static({ page, sections, siteMetadata }) {
+export default function Static({
+  page,
+  sections,
+  siteMetadata,
+  locales,
+  locale,
+}) {
   const router = useRouter();
   const isAmp = useAmp();
 
@@ -18,12 +24,16 @@ export default function Static({ page, sections, siteMetadata }) {
   }
 
   return (
-    <StaticPage
-      isAmp={isAmp}
-      page={page}
-      sections={sections}
-      siteMetadata={siteMetadata}
-    />
+    <>
+      <StaticPage
+        isAmp={isAmp}
+        page={page}
+        sections={sections}
+        siteMetadata={siteMetadata}
+        locales={locales}
+        currentLocale={locale}
+      />
+    </>
   );
 }
 
@@ -57,6 +67,7 @@ export async function getStaticProps({ locale, params }) {
 
   let page = {};
   let sections;
+  let locales = [];
   let siteMetadata = {};
 
   const { errors, data } = await hasuraGetPage({
@@ -81,8 +92,19 @@ export async function getStaticProps({ locale, params }) {
     }
 
     page = data.page_slug_versions[0].page;
-    sections = data.categories;
+    var allPageLocales = data.pages[0].page_translations;
+    var distinctLocaleCodes = [];
+    var distinctLocales = [];
+    for (var i = 0; i < allPageLocales.length; i++) {
+      if (!distinctLocaleCodes.includes(allPageLocales[i].locale.code)) {
+        distinctLocaleCodes.push(allPageLocales[i].locale.code);
+        distinctLocales.push(allPageLocales[i]);
+      }
+    }
+    locales = distinctLocales;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+
+    sections = data.categories;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
         sections[i].category_translations,
@@ -96,6 +118,8 @@ export async function getStaticProps({ locale, params }) {
       page,
       sections,
       siteMetadata,
+      locales,
+      locale,
     },
   };
 }

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import tw from 'twin.macro';
 import Layout from '../../components/Layout.js';
 import { hasuraTagPage, hasuraListAllTags } from '../../lib/articles.js';
 import { cachedContents } from '../../lib/cached';
@@ -8,10 +7,11 @@ import { hasuraLocaliseText } from '../../lib/utils.js';
 import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
 import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
-
-const SectionLayout = tw.section`flex mb-8`;
-const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
-const Block = tw.div`w-full`;
+import {
+  SectionContainer,
+  SectionLayout,
+  Block,
+} from '../../components/common/CommonStyles';
 
 export default function TagPage({
   articles,

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -47,13 +47,15 @@ export default function TagPage({
         metadata={siteMetadata}
         ads={expandedAds}
       />
-      <SectionLayout>
-        <SectionContainer>
-          <Block>
-            <ReadInOtherLanguage locales={locales} currentLocale={locale} />
-          </Block>
-        </SectionContainer>
-      </SectionLayout>
+      {locales.length > 1 && (
+        <SectionLayout>
+          <SectionContainer>
+            <Block>
+              <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+            </Block>
+          </SectionContainer>
+        </SectionLayout>
+      )}
     </Layout>
   );
 }

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import tw from 'twin.macro';
 import Layout from '../../components/Layout.js';
 import { hasuraTagPage, hasuraListAllTags } from '../../lib/articles.js';
 import { cachedContents } from '../../lib/cached';
@@ -6,6 +7,11 @@ import { getArticleAds } from '../../lib/ads.js';
 import { hasuraLocaliseText } from '../../lib/utils.js';
 import { useAmp } from 'next/amp';
 import ArticleStream from '../../components/homepage/ArticleStream';
+import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
+
+const SectionLayout = tw.section`flex mb-8`;
+const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
+const Block = tw.div`w-full`;
 
 export default function TagPage({
   articles,
@@ -13,6 +19,8 @@ export default function TagPage({
   sections,
   siteMetadata,
   expandedAds,
+  locale,
+  locales,
 }) {
   const router = useRouter();
   const isAmp = useAmp();
@@ -39,6 +47,13 @@ export default function TagPage({
         metadata={siteMetadata}
         ads={expandedAds}
       />
+      <SectionLayout>
+        <SectionContainer>
+          <Block>
+            <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+          </Block>
+        </SectionContainer>
+      </SectionLayout>
     </Layout>
   );
 }
@@ -81,6 +96,7 @@ export async function getStaticProps({ locale, params }) {
 
   let articles = [];
   let sections = [];
+  let locales = [];
   let tag;
   let siteMetadata;
 
@@ -116,6 +132,8 @@ export async function getStaticProps({ locale, params }) {
       );
     }
 
+    locales = data.organization_locales;
+
     let metadatas = data.site_metadatas;
     try {
       siteMetadata = metadatas[0].site_metadata_translations[0].data;
@@ -137,6 +155,8 @@ export async function getStaticProps({ locale, params }) {
       sections,
       siteMetadata,
       expandedAds,
+      locale,
+      locales,
     },
   };
 }

--- a/pages/tinycms/homepage.js
+++ b/pages/tinycms/homepage.js
@@ -24,6 +24,7 @@ export default function HomePageEditor({
   tags,
   sections,
   locale,
+  locales,
   siteMetadata,
   apiUrl,
   apiToken,
@@ -49,6 +50,14 @@ export default function HomePageEditor({
   }
 
   async function saveAndPublishHomepage() {
+    if (!featuredArticle) {
+      setNotificationMessage(
+        'Sorry, you must feature at least one article to save the homepage!'
+      );
+      setNotificationType('error');
+      setShowNotification(true);
+      return;
+    }
     let article1 = featuredArticle.id;
     let article2 = null;
     let article3 = null;
@@ -91,6 +100,8 @@ export default function HomePageEditor({
   return (
     <AdminLayout>
       <AdminNav
+        currentLocale={locale}
+        locales={locales}
         switchLocales={true}
         homePageEditor={true}
         layoutSchemas={layoutSchemas}
@@ -171,6 +182,8 @@ export async function getServerSideProps({ locale }) {
   }
 
   const layoutSchemas = data.homepage_layout_schemas;
+  const locales = data.organization_locales;
+
   let hpData = data.homepage_layout_datas[0];
   let hpArticles = [];
 
@@ -213,6 +226,7 @@ export async function getServerSideProps({ locale }) {
       tags,
       sections,
       locale,
+      locales,
       siteMetadata,
       apiUrl,
       apiToken,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -52,6 +52,8 @@ export default function Settings({
 }) {
   const siteInfoRef = useRef();
   const designRef = useRef();
+  const landingPageRef = useRef();
+  const commentsRef = useRef();
   const homepagePromoRef = useRef();
   const newsletterRef = useRef();
   const membershipRef = useRef();
@@ -115,6 +117,17 @@ export default function Settings({
       if (siteInfoRef) {
         siteInfoRef.current.scrollIntoView({ behavior: 'smooth' });
       }
+    } else if (window.location.hash && window.location.hash === '#comments') {
+      if (commentsRef) {
+        commentsRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (
+      window.location.hash &&
+      window.location.hash === '#landingPage'
+    ) {
+      if (landingPageRef) {
+        landingPageRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
     } else if (window.location.hash && window.location.hash === '#design') {
       if (designRef) {
         designRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -151,7 +164,7 @@ export default function Settings({
 
   async function handleCancel(ev) {
     ev.preventDefault();
-    router.push('/tinycms/config');
+    router.push('/tinycms');
   }
 
   async function handleSubmit(ev) {
@@ -205,6 +218,11 @@ export default function Settings({
                 <li>
                   <Link href="/tinycms/settings#siteInfo">
                     <a>Site Information</a>
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/tinycms/settings#landingPage">
+                    <a>Landing Page</a>
                   </Link>
                 </li>
                 <li>
@@ -264,6 +282,8 @@ export default function Settings({
             <SettingsContainer>
               <SiteInfoSettings
                 siteInfoRef={siteInfoRef}
+                commentsRef={commentsRef}
+                landingPageRef={landingPageRef}
                 seoRef={seoRef}
                 newsletterRef={newsletterRef}
                 membershipRef={membershipRef}

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -1,22 +1,26 @@
 #! /usr/bin/env node
 
-require('dotenv').config({ path: '.env.local' })
+require('dotenv').config({ path: '.env.local' });
 
 const fetch = require('node-fetch');
 
-const shared = require("./shared");
+const shared = require('./shared');
 
 const apiUrl = process.env.HASURA_API_URL;
 const apiToken = process.env.ORG_SLUG;
 
 function getNewsletterEditions() {
-  const letterheadUrl = process.env.LETTERHEAD_API_URL + "channels/" + process.env.LETTERHEAD_CHANNEL_SLUG + "/letters";
-  console.log("Letterhead API URL:", letterheadUrl);
+  const letterheadUrl =
+    process.env.LETTERHEAD_API_URL +
+    'channels/' +
+    process.env.LETTERHEAD_CHANNEL_SLUG +
+    '/letters';
+  console.log('Letterhead API URL:', letterheadUrl);
 
   if (!process.env.LETTERHEAD_API_URL) {
     return;
   }
-  
+
   const opts = {
     headers: {
       'Content-Type': 'application/json',
@@ -33,7 +37,6 @@ function getNewsletterEditions() {
 
 //{"ops":[{"insert":"This is my newsletter"},{"attributes":{"header":1},"insert":"\n"},{"insert":"By Tyler \nThis is a paragraph followed by a list:\nlist item 1"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 2"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"list item 3"},{"attributes":{"list":"bullet"},"insert":"\n"},{"insert":"Section title"},{"attributes":{"header":2},"insert":"\n"},{"attributes":{"bold":true},"insert":"Bold text. "},{"attributes":{"italic":true,"bold":true},"insert":"Italic bold text. "},{"attributes":{"italic":true},"insert":"Just italic."},{"insert":"\n\n"}]}
 
-
 function transformDelta(delta) {
   // console.log(delta);
 
@@ -43,7 +46,7 @@ function transformDelta(delta) {
     if (!element.insert) {
       return;
     }
-    if (typeof(element.insert) !== 'string') {
+    if (typeof element.insert !== 'string') {
       return;
     }
 
@@ -52,10 +55,10 @@ function transformDelta(delta) {
       lines.forEach((line) => {
         if (line) {
           elements.push({
-            "insert": line
+            insert: line,
           });
         }
-      })
+      });
     } else {
       elements.push(element);
     }
@@ -63,153 +66,173 @@ function transformDelta(delta) {
 
   // console.log(elements);
 
-  let list = {items: []};
-  let paragraph = {children: []};
+  let list = { items: [] };
+  let paragraph = { children: [] };
 
   let formattedElements = [];
   elements.forEach((element, i) => {
     if (element.attributes && element.attributes.header) {
       // console.log(i, "header:", elements[i-1].insert)
-      formattedElements.push( {
-        "link": null,
-        "type": "text",
-        "style": "HEADING_" + element.attributes.header,
-        "children": [
+      formattedElements.push({
+        link: null,
+        type: 'text',
+        style: 'HEADING_' + element.attributes.header,
+        children: [
           {
-            "index": i,
-            "style": {},
-            "content": elements[i-1].insert
-          }
-        ]
-      })
+            index: i,
+            style: {},
+            content: elements[i - 1].insert,
+          },
+        ],
+      });
     } else if (element.attributes && element.attributes.list) {
       // console.log(i, "list:", elements[i-1].insert)
 
       list.items.push({
-        "index": i,
-        "children": [
+        index: i,
+        children: [
           {
-            "style": {},
-            "content": elements[i-1].insert
-          }
+            style: {},
+            content: elements[i - 1].insert,
+          },
         ],
-        "nestingLevel": 0
-      })
+        nestingLevel: 0,
+      });
 
       // if there is a second next element and it's not a list, this is the last item in the list;
       // if there is no second next element, this is also the last item in the list; finish it
       // by pushing it onto the formattedElements, then set it to an empty object again
       // we do this in case there are more lists in the email
       // if there is a second next element and it has a list attr, this list has more items
-      if ( (elements[i+2] && (!elements[i+2].attributes || !elements[i+2].attributes.list)) || !elements[i+2] ) {
-         // hardcode as "bullet" for now
-         formattedElements.push({
-          "type": "list",
-          "listType": "BULLET",
-          "items": list.items,
-          "link": null
-        })
+      if (
+        (elements[i + 2] &&
+          (!elements[i + 2].attributes || !elements[i + 2].attributes.list)) ||
+        !elements[i + 2]
+      ) {
+        // hardcode as "bullet" for now
+        formattedElements.push({
+          type: 'list',
+          listType: 'BULLET',
+          items: list.items,
+          link: null,
+        });
         // reset the list holder
-        list = {items: []};
+        list = { items: [] };
       }
-
-    } else if (element.attributes && (element.attributes.bold || element.attributes.italic)) {
+    } else if (
+      element.attributes &&
+      (element.attributes.bold || element.attributes.italic)
+    ) {
       // console.log(i, "formatted text:", element.insert);
       let style = {};
       if (element.attributes.bold) {
-        style["bold"] = true;
+        style['bold'] = true;
       }
       if (element.attributes.italic) {
-        style["italic"] = true;
+        style['italic'] = true;
       }
 
       paragraph.children.push({
-        "index": i,
-        "style": style,
-        "content": element.insert
-      })
+        index: i,
+        style: style,
+        content: element.insert,
+      });
 
       // if this is the last element of the newsletter, or
-      // if the next element is blank string, or 
+      // if the next element is blank string, or
       // if the next element is a list/header item, close the paragraph
       if (
-        (!elements[i+1]) ||
-        ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
-        ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+        !elements[i + 1] ||
+        (elements[i + 1] &&
+          elements[i + 1].insert &&
+          !elements[i + 1].insert.replace(/[\\n]|\n/g, '')) ||
+        (elements[i + 1] &&
+          elements[i + 1].attributes &&
+          (elements[i + 1].attributes.list ||
+            elements[i + 1].attributes.header))
       ) {
-        
         formattedElements.push({
-          "link": null,
-          "type": "text",
-          "style": "NORMAL_TEXT",
-          "children": paragraph.children
-        });  
-        paragraph = { "children": []}
+          link: null,
+          type: 'text',
+          style: 'NORMAL_TEXT',
+          children: paragraph.children,
+        });
+        paragraph = { children: [] };
         // otherwise, continue on
       }
-      
-
     } else if (element.attributes && element.attributes.link) {
       // console.log(i, "link:", element.attributes.link);
 
       formattedElements.push({
-        "link": null,
-        "type": "text",
-        "style": "NORMAL_TEXT",
-        "children": [
+        link: null,
+        type: 'text',
+        style: 'NORMAL_TEXT',
+        children: [
           {
-            "link": element.attributes.link,
-            "index": i,
-            "style": {
-              "underline": true
+            link: element.attributes.link,
+            index: i,
+            style: {
+              underline: true,
             },
-            "content": element.insert
-          }
-        ]
-      })
+            content: element.insert,
+          },
+        ],
+      });
     } else if (element.attributes) {
       // console.log(i, "unknown attrs:", element.attributes);
-
     } else {
-      if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.header) {
-        console.log(i, "skip, header is handled next:", element.insert);
-      } else if (elements[i+1] && elements[i+1].attributes && elements[i+1].attributes.list) {
-        console.log(i, "skip, list is handled next:", element.insert);
+      if (
+        elements[i + 1] &&
+        elements[i + 1].attributes &&
+        elements[i + 1].attributes.header
+      ) {
+        console.log(i, 'skip, header is handled next:', element.insert);
+      } else if (
+        elements[i + 1] &&
+        elements[i + 1].attributes &&
+        elements[i + 1].attributes.list
+      ) {
+        console.log(i, 'skip, list is handled next:', element.insert);
       } else {
-        console.log(i, "plain text:", element.insert);
+        console.log(i, 'plain text:', element.insert);
 
         paragraph.children.push({
-            "link": null,
-            "type": "text",
-            "style": "NORMAL_TEXT",
-            "children": [
-              {
-                "index": i,
-                "style": {},
-                "content": element.insert
-              }
-            ]
-        })
+          link: null,
+          type: 'text',
+          style: 'NORMAL_TEXT',
+          children: [
+            {
+              index: i,
+              style: {},
+              content: element.insert,
+            },
+          ],
+        });
 
         // if this is the last element of the newsletter, or
-        // if the next element is blank string, or 
+        // if the next element is blank string, or
         // if the next element is a list/header item, close the paragraph
         if (
-          (!elements[i+1]) ||
-          ( elements[i+1] && elements[i+1].insert && !(elements[i+1].insert.replace(/[\\n]|\n/g, '')) ) ||
-          ( elements[i+1] && elements[i+1].attributes && (elements[i+1].attributes.list || elements[i+1].attributes.header) )
+          !elements[i + 1] ||
+          (elements[i + 1] &&
+            elements[i + 1].insert &&
+            !elements[i + 1].insert.replace(/[\\n]|\n/g, '')) ||
+          (elements[i + 1] &&
+            elements[i + 1].attributes &&
+            (elements[i + 1].attributes.list ||
+              elements[i + 1].attributes.header))
         ) {
           formattedElements.push({
-            "link": null,
-            "type": "text",
-            "style": "NORMAL_TEXT",
-            "children": paragraph.children
-          });  
-          paragraph = { "children": []}
+            link: null,
+            type: 'text',
+            style: 'NORMAL_TEXT',
+            children: paragraph.children,
+          });
+          paragraph = { children: [] };
         }
       }
     }
-  })
+  });
 
   // console.log(formattedElements);
 
@@ -217,10 +240,20 @@ function transformDelta(delta) {
 }
 
 async function saveNewsletterEditions(letterheadData) {
-  console.log("Letterhead returned", letterheadData.length, "newsletter editions in total:");
+  console.log(
+    'Letterhead returned',
+    letterheadData.length,
+    'newsletter editions in total:'
+  );
   for await (let newsletter of letterheadData) {
     if (!newsletter.publicationDate) {
-      console.log("> Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' is not published, skipping.")
+      console.log(
+        '> Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' is not published, skipping."
+      );
       continue;
     }
 
@@ -239,7 +272,7 @@ async function saveNewsletterEditions(letterheadData) {
       content: content,
       newsletter_created_at: newsletter.createdAt,
       newsletter_published_at: newsletter.publicationDate,
-    }
+    };
     if (newsletter.customizedByline) {
       editionData['byline'] = newsletter.customizedByline;
     }
@@ -254,11 +287,26 @@ async function saveNewsletterEditions(letterheadData) {
     });
 
     if (result.errors) {
-      console.error("! Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' had an error saving:", result.errors);
+      console.error(
+        '! Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' had an error saving:",
+        result.errors
+      );
     } else {
-      console.log(". Newsletter ID#" + newsletter.id + " '" + newsletter.title + "' was published at " + newsletter.publicationDate + ", saved in Hasura with slug: " + result.data.insert_newsletter_editions_one.slug)
+      console.log(
+        '. Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          newsletter.title +
+          "' was published at " +
+          newsletter.publicationDate +
+          ', saved in Hasura with slug: ' +
+          result.data.insert_newsletter_editions_one.slug
+      );
     }
-
   }
 }
 
@@ -283,10 +331,9 @@ const slugify = (value) => {
 };
 
 const publishNewsletters = process.env.PUBLISH_NEWSLETTERS;
-console.log("publish newsletters?", typeof(publishNewsletters), publishNewsletters);
 
-if (!publishNewsletters || publishNewsletters === "false") {
-  console.log("Not publishing newsletters for " + apiToken);
+if (!publishNewsletters || publishNewsletters === 'false') {
+  console.log('Not publishing newsletters for ' + apiToken);
   return;
 } else {
   getNewsletterEditions();


### PR DESCRIPTION
Part of #776

This adds a "read in {language}" link to the following index pages:

* author
* category
* tag

And to the generic static page (ex: http://localhost:3000/static/history on test-diaryo).

It also conditionally adds the link to the article page if that article has been translated to the other locale. Using test-diaryo:

* http://localhost:3000/articles/news/english-language-first-article should display a "read in filipino" link as I've published it in both locales
* http://localhost:3000/articles/news/english-only should not display a link as I've only published it in english