### PR TITLE
Split the about page into about and staff pages

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -13,13 +13,7 @@ import {
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
-export default function AboutPage({
-  page,
-  sections,
-  siteMetadata,
-  authors,
-  isAmp,
-}) {
+export default function AboutPage({ page, sections, siteMetadata, isAmp }) {
   // there will only be one translation returned for a given page + locale
   const localisedPage = page.page_translations[0];
   const body = renderBody(page.page_translations, [], isAmp, siteMetadata);
@@ -35,21 +29,7 @@ export default function AboutPage({
           </div>
           <div className="section post__body rich-text" key="body">
             <PostText>
-              <PostTextContainer>
-                {body}
-                <H2>Our Staff</H2>
-                {authors.map((author) => (
-                  <div className="author mb-4" key={author.name}>
-                    <H3>
-                      {author.name},{' '}
-                      {hasuraLocaliseText(author.author_translations, 'title')}
-                    </H3>
-                    <Paragraph>
-                      {hasuraLocaliseText(author.author_translations, 'bio')}
-                    </Paragraph>
-                  </div>
-                ))}
-              </PostTextContainer>
+              <PostTextContainer>{body}</PostTextContainer>
             </PostText>
           </div>
         </SectionContainer>

--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -1,14 +1,11 @@
 import tw from 'twin.macro';
-import { hasuraLocaliseText } from '../lib/utils';
+import Link from 'next/link';
 import Layout from './Layout';
 import { renderBody } from '../lib/utils.js';
 import {
   ArticleTitle,
   PostTextContainer,
   PostText,
-  Paragraph,
-  H2,
-  H3,
 } from './common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
@@ -32,6 +29,16 @@ export default function AboutPage({ page, sections, siteMetadata, isAmp }) {
               <PostTextContainer>{body}</PostTextContainer>
             </PostText>
           </div>
+
+          <SectionLayout>
+            <SectionContainer>
+              <Block>
+                <Link href="/staff">
+                  <a href="/staff">Staff</a>
+                </Link>
+              </Block>
+            </SectionContainer>
+          </SectionLayout>
         </SectionContainer>
       </article>
     </Layout>

--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -6,6 +6,8 @@ import {
   ArticleTitle,
   PostTextContainer,
   PostText,
+  SectionLayout,
+  Block,
 } from './common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -1,7 +1,6 @@
 import tw from 'twin.macro';
-import { hasuraLocaliseText } from '../lib/utils';
+import { displayAuthorName, hasuraLocaliseText } from '../lib/utils';
 import Layout from './Layout';
-import { renderBody } from '../lib/utils.js';
 import {
   ArticleTitle,
   PostTextContainer,
@@ -13,17 +12,7 @@ import {
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
-export default function StaffPage({
-  page,
-  sections,
-  siteMetadata,
-  authors,
-  isAmp,
-}) {
-  // // there will only be one translation returned for a given page + locale
-  // const localisedPage = page.page_translations[0];
-  // const body = renderBody(page.page_translations, [], isAmp, siteMetadata);
-
+export default function StaffPage({ sections, siteMetadata, authors }) {
   return (
     <Layout meta={siteMetadata} sections={sections}>
       <article className="container">
@@ -35,9 +24,9 @@ export default function StaffPage({
             <PostText>
               <PostTextContainer>
                 {authors.map((author) => (
-                  <div className="author mb-4" key={author.name}>
+                  <div className="author mb-4" key={author.last_name}>
                     <H3>
-                      {author.name},{' '}
+                      {displayAuthorName(author.first_names, author.last_name)},{' '}
                       {hasuraLocaliseText(author.author_translations, 'title')}
                     </H3>
                     <Paragraph>

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -7,8 +7,6 @@ import {
   PostTextContainer,
   PostText,
   Paragraph,
-  H2,
-  H3,
 } from './common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -1,4 +1,5 @@
 import tw from 'twin.macro';
+import Image from 'next/image';
 import { displayAuthorName, hasuraLocaliseText } from '../lib/utils';
 import Layout from './Layout';
 import {
@@ -11,8 +12,10 @@ import {
 } from './common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+const AuthorName = tw.h3`font-bold text-xl leading-tight mt-5 mb-4`;
+const AuthorAvatar = tw.div`overflow-hidden relative w-full rounded-full h-12 w-12 mr-2 float-left`;
 
-export default function StaffPage({ sections, siteMetadata, authors }) {
+export default function StaffPage({ sections, siteMetadata, authors, isAmp }) {
   return (
     <Layout meta={siteMetadata} sections={sections}>
       <article className="container">
@@ -25,10 +28,34 @@ export default function StaffPage({ sections, siteMetadata, authors }) {
               <PostTextContainer>
                 {authors.map((author) => (
                   <div className="author mb-4" key={author.last_name}>
-                    <H3>
+                    {author.photoUrl && (
+                      <AuthorAvatar>
+                        <figure>
+                          <a className="content" href="#">
+                            {isAmp ? (
+                              <amp-img
+                                width={82}
+                                height={82}
+                                src={author.photoUrl}
+                                alt="author"
+                                layout="responsive"
+                              />
+                            ) : (
+                              <Image
+                                src={author.photoUrl}
+                                width={82}
+                                height={82}
+                                alt="author"
+                              />
+                            )}
+                          </a>
+                        </figure>
+                      </AuthorAvatar>
+                    )}
+                    <AuthorName>
                       {displayAuthorName(author.first_names, author.last_name)},{' '}
                       {hasuraLocaliseText(author.author_translations, 'title')}
-                    </H3>
+                    </AuthorName>
                     <Paragraph>
                       {hasuraLocaliseText(author.author_translations, 'bio')}
                     </Paragraph>

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -1,0 +1,55 @@
+import tw from 'twin.macro';
+import { hasuraLocaliseText } from '../lib/utils';
+import Layout from './Layout';
+import { renderBody } from '../lib/utils.js';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+  Paragraph,
+  H2,
+  H3,
+} from './common/CommonStyles.js';
+
+const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+
+export default function StaffPage({
+  page,
+  sections,
+  siteMetadata,
+  authors,
+  isAmp,
+}) {
+  // // there will only be one translation returned for a given page + locale
+  // const localisedPage = page.page_translations[0];
+  // const body = renderBody(page.page_translations, [], isAmp, siteMetadata);
+
+  return (
+    <Layout meta={siteMetadata} sections={sections}>
+      <article className="container">
+        <SectionContainer>
+          <div key="title" className="section post__header">
+            <ArticleTitle meta={siteMetadata}>Staff</ArticleTitle>
+          </div>
+          <div className="section post__body rich-text" key="body">
+            <PostText>
+              <PostTextContainer>
+                {authors.map((author) => (
+                  <div className="author mb-4" key={author.name}>
+                    <H3>
+                      {author.name},{' '}
+                      {hasuraLocaliseText(author.author_translations, 'title')}
+                    </H3>
+                    <Paragraph>
+                      {hasuraLocaliseText(author.author_translations, 'bio')}
+                    </Paragraph>
+                  </div>
+                ))}
+              </PostTextContainer>
+            </PostText>
+          </div>
+        </SectionContainer>
+      </article>
+    </Layout>
+  );
+}

--- a/cypress/integration/tinycms_authors_spec.js
+++ b/cypress/integration/tinycms_authors_spec.js
@@ -1,37 +1,37 @@
 // import { cypressDeleteAuthors } from "../../lib/authors"
 
 describe('tinycms authors', () => {
-  
   it('renders the list', () => {
-    cy.visit('/tinycms/authors')
-    cy.get('h1').contains("Authors")
+    cy.visit('/tinycms/authors');
+    cy.get('h1').contains('Authors');
     // has at least one header
-    cy.get('table thead tr th')
-    cy.get('th').contains("Name")
-  })
+    cy.get('table thead tr th');
+    cy.get('th').contains('Name');
+  });
 
- it('adds a new author', () => {
-    cy.task("db:authors");
-    cy.visit('/tinycms/authors/add')
-    cy.location('pathname').should('eq', '/tinycms/authors/add')
-    cy.get('input[name="name"').type("New AuthorName")
-    cy.get('input[name="title"').type("Staff Editor")
-    cy.get('input[name="twitter"').type("@twitterHandle")
+  it('adds a new author', () => {
+    cy.task('db:authors');
+    cy.visit('/tinycms/authors/add');
+    cy.location('pathname').should('eq', '/tinycms/authors/add');
+    cy.get('input[name="first_names"').type('New');
+    cy.get('input[name="last_name"').type('AuthorName');
+    cy.get('input[name="title"').type('Staff Editor');
+    cy.get('input[name="twitter"').type('@twitterHandle');
     // cy.get('input[name="slug"').type("new-author-name")
-    cy.get('textarea[name="bio"]').type("New author bio copy tk.")
-    cy.get('[type="radio"]').first().check() // Check first radio element - staff
+    cy.get('textarea[name="bio"]').type('New author bio copy tk.');
+    cy.get('[type="radio"]').first().check(); // Check first radio element - staff
     cy.get('form').submit({
-      timeout: 10000
-    })
-    cy.get('strong', { timeout: 10000 }).contains('Success')
-  })
+      timeout: 10000,
+    });
+    cy.get('strong', { timeout: 10000 }).contains('Success');
+  });
 
- it('updates an existing author', () => {
-    cy.visit('/tinycms/authors')
+  it('updates an existing author', () => {
+    cy.visit('/tinycms/authors');
     cy.get('table>tbody>tr>td>a').click();
 
-    cy.get('input[name="title"').clear().type("Staff Writer")
-    cy.get('form').submit()
-    cy.get('strong', { timeout: 10000 }).contains('Success')
-  })
-})
+    cy.get('input[name="title"').clear().type('Staff Writer');
+    cy.get('form').submit();
+    cy.get('strong', { timeout: 10000 }).contains('Success');
+  });
+});

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -47,7 +47,8 @@ const HASURA_SEARCH_ARTICLES = `query FrontendSearchArticles($locale_code: Strin
     slug
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -99,7 +100,8 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
       slug
       author_articles {
         author {
-          name
+          first_names
+          last_name
           photoUrl
           slug
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -147,7 +149,8 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
       slug
       author_articles {
         author {
-          name
+          first_names
+          last_name
           photoUrl
           slug
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -190,7 +193,8 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
       slug
       author_articles {
         author {
-          name
+          first_names
+          last_name
           photoUrl
           slug
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -314,7 +318,8 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query FrontendPreviewArticlePage($slug: Str
     slug
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -383,7 +388,8 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
       slug
       author_articles {
         author {
-          name
+          first_names
+          last_name
           photoUrl
           twitter
           slug
@@ -461,7 +467,8 @@ const HASURA_ARTICLE_PAGE = `query FrontendArticlePage($category_slug: String!, 
     slug
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         twitter
         slug
@@ -586,7 +593,8 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($locale_code: String, $tag_slug: 
         slug
         author_articles {
           author {
-            name
+            first_names
+            last_name
             photoUrl
             slug
             author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -625,7 +633,8 @@ const HASURA_CATEGORY_PAGE = `query FrontendCategoryPage($category_slug: String!
     slug
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -685,7 +694,8 @@ const HASURA_GET_PAGE_SLUG_VERSION = `query FrontendGetPageSlugVersion($slug: St
       author_pages {
         author {
           id
-          name
+          first_names
+          last_name
           slug
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
             title
@@ -709,9 +719,10 @@ const HASURA_GET_PAGE_SLUG_VERSION = `query FrontendGetPageSlugVersion($slug: St
       slug
     }
   }
-  authors {
+  authors(order_by: {last_name: asc}) {
     id
-    name
+    first_names
+    last_name
     created_at
     slug
     staff
@@ -758,7 +769,8 @@ const HASURA_GET_PAGE = `query FrontendGetPage($slug: String!, $locale_code: Str
     author_pages {
       author {
         id
-        name
+        first_names
+        last_name
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
           title
@@ -800,7 +812,8 @@ const HASURA_GET_PAGE_PREVIEW = `query FrontendGetPagePreview($slug: String!, $l
     author_pages {
       author {
         id
-        name
+        first_names
+        last_name
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
           title
@@ -860,7 +873,8 @@ const HASURA_PREVIEW_ARTICLE_BY_SLUG = `query FrontendPreviewArticleBySlug($slug
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter
@@ -898,7 +912,8 @@ const HASURA_GET_ARTICLE_BY_SLUG = `query FrontendGetArticleBySlug($slug: String
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter
@@ -937,7 +952,8 @@ const HASURA_AUTHOR_PAGE = `query FrontendAuthorPage($locale_code: String!, $aut
     slug
     author_articles(where: {author: {slug: {_eq: $author_slug}}}) {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         author_translations(where: {locale_code: {_eq: $locale_code}}) {
@@ -1719,7 +1735,8 @@ const HASURA_PAGINATED_ARTICLES_ARCHIVE_PAGE = `query FrontendPaginatedArticlesA
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -697,6 +697,7 @@ const HASURA_GET_PAGE_SLUG_VERSION = `query FrontendGetPageSlugVersion($slug: St
           first_names
           last_name
           slug
+          photoUrl
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
             title
           }

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -9,7 +9,8 @@ const HASURA_LIST_AUTHORS = `
     }
     authors {
       id
-      name
+      first_names
+      last_name
       created_at
       slug
       staff
@@ -24,10 +25,11 @@ const HASURA_LIST_AUTHORS = `
   }
 `;
 
-const HASURA_INSERT_AUTHOR = `mutation FrontendInsertAuthor($bio: String, $name: String, $locale_code: String, $title: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
-  insert_authors(objects: {name: $name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_key, update_columns: [name, slug, twitter, staff, published, photoUrl]}) {
+const HASURA_INSERT_AUTHOR = `mutation FrontendInsertAuthor($bio: String, $first_names: String, $last_name: String, $locale_code: String, $title: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
+  insert_authors(objects: {first_names: $first_names, last_name: $last_name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_key, update_columns: [first_names, last_name, slug, twitter, staff, published, photoUrl]}) {
     returning {
-      name
+      first_names
+      last_name
       photoUrl
       published
       slug
@@ -46,7 +48,8 @@ const HASURA_INSERT_AUTHOR = `mutation FrontendInsertAuthor($bio: String, $name:
 const HASURA_GET_AUTHOR_BY_SLUG = `query FrontendGetAuthorBySlug($slug: String) {
   authors(where: {slug: {_eq: $slug}}) {
     id
-    name
+    first_names
+    last_name
     photoUrl
     published
     slug
@@ -69,7 +72,8 @@ const HASURA_GET_AUTHOR_BY_ID = `query FrontendGetAuthorByID($id: Int!) {
   }
   authors_by_pk(id: $id) {
     id
-    name
+    first_names
+    last_name
     photoUrl
     published
     slug
@@ -84,16 +88,17 @@ const HASURA_GET_AUTHOR_BY_ID = `query FrontendGetAuthorByID($id: Int!) {
   }
 }`;
 
-const HASURA_UPDATE_AUTHOR = `mutation updateAuthorWithTranslations($author_id: Int!, $locale_code: String!, $title: String, $bio: String, $name: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
+const HASURA_UPDATE_AUTHOR = `mutation updateAuthorWithTranslations($author_id: Int!, $locale_code: String!, $title: String, $bio: String, $first_names: String, $last_name: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
   delete_author_translations(where: {author_id: {_eq: $author_id}, locale_code: {_eq: $locale_code}}) {
     affected_rows
   }
   insert_author_translations(objects: [{author_id: $author_id, locale_code: $locale_code, title: $title, bio: $bio}]) {
     affected_rows
   }
-  update_authors_by_pk(pk_columns: {id: $author_id}, _set: {name: $name, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}) {
+  update_authors_by_pk(pk_columns: {id: $author_id}, _set: {first_names: $first_names, last_name: $last_name, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}) {
     id
-    name
+    first_names
+    last_name
     photoUrl
     published
     slug
@@ -127,7 +132,8 @@ export function hasuraCreateAuthor(params) {
       locale_code: params['localeCode'],
       bio: params['bio'],
       title: params['title'],
-      name: params['name'],
+      first_names: params['first_names'],
+      last_name: params['last_name'],
       photoUrl: params['photoUrl'],
       published: params['published'],
       slug: params['slug'],
@@ -148,7 +154,8 @@ export function hasuraUpdateAuthor(params) {
       locale_code: params['localeCode'],
       bio: params['bio'],
       title: params['title'],
-      name: params['name'],
+      first_names: params['first_names'],
+      last_name: params['last_name'],
       photoUrl: params['photoUrl'],
       published: params['published'],
       slug: params['slug'],

--- a/lib/homepage.js
+++ b/lib/homepage.js
@@ -31,7 +31,8 @@ const HASURA_GET_STREAM_ARTICLES = `query FrontendGetStreamArticles($locale_code
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter
@@ -71,7 +72,8 @@ const HASURA_GET_HOMEPAGE_DATA = `query FrontendGetHomepage($locale_code: String
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,6 +123,10 @@ export const localiseText = (locale, field) => {
   return text;
 };
 
+export const displayAuthorName = (firstNames, lastName) => {
+  return [firstNames, lastName].filter(Boolean).join(' ');
+};
+
 export const renderAuthor = (author, i) => {
   // not sure how or why this is happening, but this function keeps getting called twice, once with i=0, again with i=undefined
   if (i === undefined) {
@@ -412,7 +416,7 @@ export const transformToDate = (string) => {
     string.substring(6, 8)
   );
 };
-export const validateAuthorName = (name) => {
+export const validateAuthorName = (first_names, last_name) => {
   const fakeNames = [
     'Staff Reporter',
     'Staff Editor',
@@ -436,7 +440,8 @@ export const validateAuthorName = (name) => {
   const regexPattern = '^(' + fakeNames.join('|') + ')$';
   const regex = new RegExp(regexPattern, 'i');
 
-  let isFake = regex.test(name);
+  const fullAuthorName = displayAuthorName(first_names, last_name);
+  let isFake = regex.test(fullAuthorName);
   if (isFake) {
     return false;
   } else {

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -1,12 +1,12 @@
 import { useAmp } from 'next/amp';
 import { hasuraGetPage } from '../lib/articles.js';
 import { hasuraLocaliseText } from '../lib/utils';
-import AboutPage from '../components/AboutPage';
+import StaffPage from '../components/StaffPage';
 
-export default function About(props) {
+export default function Staff(props) {
   const isAmp = useAmp();
 
-  return <AboutPage {...props} isAmp={isAmp} />;
+  return <StaffPage {...props} isAmp={isAmp} />;
 }
 
 export async function getStaticProps({ locale }) {
@@ -16,6 +16,7 @@ export async function getStaticProps({ locale }) {
   let page = {};
   let sections;
   let siteMetadata = {};
+  let authors = [];
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
@@ -36,6 +37,7 @@ export async function getStaticProps({ locale }) {
     }
     page = data.page_slug_versions[0].page;
     sections = data.categories;
+    authors = data.authors;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
@@ -50,6 +52,7 @@ export async function getStaticProps({ locale }) {
       page,
       sections,
       siteMetadata,
+      authors,
     },
   };
 }

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -25,6 +25,7 @@ export async function getStaticProps({ locale }) {
     localeCode: locale,
   });
   if (errors || !data) {
+    console.log(errors);
     return {
       notFound: true,
     };
@@ -49,7 +50,6 @@ export async function getStaticProps({ locale }) {
 
   return {
     props: {
-      page,
       sections,
       siteMetadata,
       authors,

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -217,7 +217,7 @@ export default function EditAuthor({
                     awsConfig={awsConfig}
                     slug={slug}
                     image={bioImage}
-                    setBioImage={setBioImage}
+                    setter={setBioImage}
                     setNotificationMessage={setNotificationMessage}
                     setNotificationType={setNotificationType}
                     setShowNotification={setShowNotification}

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -14,6 +14,7 @@ import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraGetAuthorById, hasuraUpdateAuthor } from '../../../lib/authors';
 import {
+  displayAuthorName,
   hasuraLocaliseText,
   slugify,
   validateAuthorName,
@@ -34,7 +35,9 @@ export default function EditAuthor({
   const [showNotification, setShowNotification] = useState(false);
   const [displayUpload, setDisplayUpload] = useState(true);
 
-  const [name, setName] = useState(author.name);
+  const [firstNames, setFirstNames] = useState(author.first_names);
+  const [lastName, setLastName] = useState(author.last_name);
+
   const [title, setTitle] = useState(
     hasuraLocaliseText(author.author_translations, 'title')
   );
@@ -68,9 +71,17 @@ export default function EditAuthor({
   };
 
   // slugifies the name and stores slug plus name values
-  function updateName(val) {
-    setName(val);
-    let slugifiedVal = slugify(val);
+  function updateFirstNames(val) {
+    setFirstNames(val);
+    let displayName = displayAuthorName(val, lastName);
+    let slugifiedVal = slugify(displayName);
+    setSlug(slugifiedVal);
+    setDisplayUpload(true);
+  }
+
+  function updateLastName(val) {
+    setLastName(val);
+    let slugifiedVal = slugify(displayAuthorName(firstNames, val));
     setSlug(slugifiedVal);
     setDisplayUpload(true);
   }
@@ -85,15 +96,16 @@ export default function EditAuthor({
     let published = true;
     ev.preventDefault();
 
-    let nameIsValid = validateAuthorName(name);
+    let nameIsValid = validateAuthorName(firstNames, lastName);
     if (!nameIsValid) {
       setNotificationMessage(
         'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
-          name
+          displayAuthorName(firstNames, lastName)
       );
       setShowNotification(true);
       setNotificationType('error');
-      setName('');
+      setFirstNames('');
+      setLastName('');
       setSlug('');
       setDisplayUpload(false);
       return false;
@@ -106,13 +118,15 @@ export default function EditAuthor({
       localeCode: currentLocale,
       bio: bio,
       title: title,
-      name: name,
+      first_names: firstNames,
+      last_name: lastName,
       published: published,
       slug: slug,
       staff: staff,
       twitter: twitter,
       photoUrl: bioImage,
     };
+
     const { errors, data } = await hasuraUpdateAuthor(params);
 
     if (errors) {
@@ -151,10 +165,16 @@ export default function EditAuthor({
 
         <form onSubmit={handleSubmit}>
           <TinyInputField
-            name="name"
-            value={name}
-            onChange={(ev) => updateName(ev.target.value)}
-            label="Name"
+            name="first_names"
+            value={firstNames}
+            onChange={(ev) => updateFirstNames(ev.target.value)}
+            label="First names"
+          />
+          <TinyInputField
+            name="last_name"
+            value={lastName}
+            onChange={(ev) => updateLastName(ev.target.value)}
+            label="Last name (staff page sorts by this value)"
           />
           <TinyInputField
             name="title"
@@ -183,7 +203,7 @@ export default function EditAuthor({
           />
           <TinyYesNoField
             name="staff"
-            value={staff}
+            value={staffYesNo}
             onChange={handleChange}
             labelYes="Staff"
             labelNo="Not Staff"

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -14,7 +14,11 @@ import Notification from '../../../components/tinycms/Notification';
 import Upload from '../../../components/tinycms/Upload';
 import { hasuraListLocales } from '../../../lib/articles.js';
 import { hasuraCreateAuthor } from '../../../lib/authors';
-import { validateAuthorName, slugify } from '../../../lib/utils.js';
+import {
+  displayAuthorName,
+  validateAuthorName,
+  slugify,
+} from '../../../lib/utils.js';
 
 const UploadContainer = tw.div`container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10`;
 
@@ -29,7 +33,8 @@ export default function AddAuthor({
   const [notificationType, setNotificationType] = useState('');
   const [showNotification, setShowNotification] = useState(false);
 
-  const [name, setName] = useState('');
+  const [firstNames, setFirstNames] = useState('');
+  const [lastName, setLastName] = useState('');
   const [title, setTitle] = useState('');
   const [twitter, setTwitter] = useState('');
   const [slug, setSlug] = useState('');
@@ -45,11 +50,18 @@ export default function AddAuthor({
   }
 
   // slugifies the name and stores slug plus name values
-  function updateName(val) {
-    setName(val);
-    let slugifiedVal = slugify(val);
+  function updateFirstNames(val) {
+    setFirstNames(val);
+    let displayName = displayAuthorName(val, lastName);
+    let slugifiedVal = slugify(displayName);
     setSlug(slugifiedVal);
+    setDisplayUpload(true);
+  }
 
+  function updateLastName(val) {
+    setLastName(val);
+    let slugifiedVal = slugify(displayAuthorName(firstNames, val));
+    setSlug(slugifiedVal);
     setDisplayUpload(true);
   }
 
@@ -58,15 +70,17 @@ export default function AddAuthor({
   async function handleSubmit(ev) {
     ev.preventDefault();
 
-    let nameIsValid = validateAuthorName(name);
+    let nameIsValid = validateAuthorName(firstNames, lastName);
     if (!nameIsValid) {
       setNotificationMessage(
         'Please use a real name of an actual person - editorial guidelines prohibit fake bylines: ' +
-          name
+          displayAuthorName(firstNames, lastName)
       );
       setShowNotification(true);
       setNotificationType('error');
-      setName('');
+      setFirstNames('');
+      setLastName('');
+
       setSlug('');
       setDisplayUpload(false);
       return false;
@@ -83,7 +97,8 @@ export default function AddAuthor({
       localeCode: currentLocale,
       bio: bio,
       title: title,
-      name: name,
+      first_names: firstNames,
+      last_name: lastName,
       published: published,
       slug: slug,
       staff: staffBool,
@@ -97,8 +112,8 @@ export default function AddAuthor({
       setNotificationType('success');
       setShowNotification(true);
     } else if (errors) {
-      console.log(errors);
-      setNotificationMessage(errors);
+      console.log('error creating author:', errors);
+      setNotificationMessage(JSON.stringify(errors));
       setNotificationType('error');
       setShowNotification(true);
     }
@@ -127,10 +142,16 @@ export default function AddAuthor({
 
         <form onSubmit={handleSubmit}>
           <TinyInputField
-            name="name"
-            value={name}
-            onChange={(ev) => updateName(ev.target.value)}
-            label="Name"
+            name="first_names"
+            value={firstNames}
+            onChange={(ev) => updateFirstNames(ev.target.value)}
+            label="First names"
+          />
+          <TinyInputField
+            name="last_name"
+            value={lastName}
+            onChange={(ev) => updateLastName(ev.target.value)}
+            label="Last name (staff page sorts by this value)"
           />
           <TinyInputField
             name="title"

--- a/pages/tinycms/authors/index.js
+++ b/pages/tinycms/authors/index.js
@@ -9,7 +9,7 @@ import {
   deleteSingleAuthor,
   hasuraListAllAuthors,
 } from '../../../lib/authors.js';
-import { hasuraLocaliseText } from '../../../lib/utils.js';
+import { displayAuthorName, hasuraLocaliseText } from '../../../lib/utils.js';
 
 const Table = tw.table`table-auto w-full`;
 const TableHead = tw.thead``;
@@ -99,7 +99,11 @@ export default function Authors({
     return (
       <TableRow key={author.id}>
         <TableCell>
-          <Link href={`/tinycms/authors/${author.id}`}>{author.name}</Link>
+          <Link href={`/tinycms/authors/${author.id}`}>
+            <a href={`/tinycms/authors/${author.id}`}>
+              {displayAuthorName(author.first_names, author.last_name)}
+            </a>
+          </Link>
         </TableCell>
         <TableCell tw="content-center">{staff}</TableCell>
         <TableCell>{title}</TableCell>

--- a/script/shared.js
+++ b/script/shared.js
@@ -1,4 +1,4 @@
-const fetch = require("node-fetch");
+const fetch = require('node-fetch');
 
 const INSERT_LOCALE = `mutation FrontendInsertLocale($code: String!, $name: String!) {
   insert_locales_one(object: {code: $code, name: $name}) {
@@ -14,7 +14,7 @@ function hasuraInsertLocale(params) {
     name: 'FrontendInsertLocale',
     variables: {
       code: params['code'],
-      name: params['name']
+      name: params['name'],
     },
   });
 }
@@ -132,7 +132,7 @@ const INSERT_ORG_LOCALES_MUTATION = `mutation FrontendInsertOrgLocales($objects:
   ) {
     affected_rows
   }
-}`
+}`;
 
 function hasuraInsertOrgLocales(params) {
   return fetchGraphQL({
@@ -140,7 +140,7 @@ function hasuraInsertOrgLocales(params) {
     adminSecret: params['adminSecret'],
     query: INSERT_ORG_LOCALES_MUTATION,
     name: 'FrontendInsertOrgLocales',
-    variables: {"objects": params['orgLocales']}
+    variables: { objects: params['orgLocales'] },
   });
 }
 
@@ -166,7 +166,7 @@ const HASURA_UPSERT_METADATA = `mutation FrontendUpsertMetadata($published: Bool
 }`;
 
 function hasuraUpsertMetadata(params) {
-  console.log("upsert metadata:", params);
+  console.log('upsert metadata:', params);
   return fetchGraphQL({
     url: params['url'],
     adminSecret: params['adminSecret'],
@@ -176,7 +176,7 @@ function hasuraUpsertMetadata(params) {
       organization_id: params['organization_id'],
       data: params['data'],
       published: params['published'],
-      locale_code: params['locale_code']
+      locale_code: params['locale_code'],
     },
   });
 }
@@ -257,8 +257,8 @@ function hasuraInsertSections(params) {
     query: HASURA_INSERT_SECTIONS,
     name: 'FrontendInsertSections',
     variables: {
-      objects: params['objects']
-    }
+      objects: params['objects'],
+    },
   });
 }
 
@@ -313,7 +313,7 @@ function hasuraListAllLocales(params) {
     url: params['url'],
     adminSecret: params['adminSecret'],
     query: HASURA_LIST_ALL_LOCALES,
-    name: 'FrontendListAllLocales'
+    name: 'FrontendListAllLocales',
   });
 }
 const HASURA_LIST_ORG_LOCALES = `query FrontendListOrgLocales {
@@ -354,7 +354,6 @@ function hasuraListOrganizations(params) {
     name: 'FrontendListOrganizations',
   });
 }
-
 
 const HASURA_INSERT_PAGE_VIEW_DATA = `mutation FrontendInsertPageView($count: Int!, $date: date!, $path: String!) {
   insert_ga_page_views_one(object: {count: $count, date: $date, path: $path}, on_conflict: {constraint: ga_page_views_organization_id_date_path_key, update_columns: count}) {
@@ -661,7 +660,7 @@ function hasuraDeleteAnalytics(params) {
     orgSlug: params['orgSlug'],
     query: HASURA_DELETE_ANALYTICS,
     name: 'FrontendDeleteAnalytics',
-  })
+  });
 }
 
 const HASURA_GET_ARTICLES_RSS = `query FrontendGetArticlesRSS($locale_code: String!) {
@@ -679,7 +678,8 @@ const HASURA_GET_ARTICLES_RSS = `query FrontendGetArticlesRSS($locale_code: Stri
     }
     author_articles {
       author {
-        name
+        first_names
+        last_name
         photoUrl
         slug
         twitter
@@ -724,11 +724,11 @@ async function fetchGraphQL(params) {
   if (params.hasOwnProperty('orgSlug')) {
     orgSlug = params['orgSlug'];
     requestHeaders = {
-      'TNC-Organization': orgSlug
+      'TNC-Organization': orgSlug,
     };
   } else if (params.hasOwnProperty('adminSecret')) {
     requestHeaders = {
-      "x-hasura-admin-secret": params['adminSecret']
+      'x-hasura-admin-secret': params['adminSecret'],
     };
   }
 
@@ -788,5 +788,5 @@ module.exports = {
   hasuraInsertDonorReadingFrequency,
   hasuraGetArticlesRss,
   fetchGraphQL,
-  sanitizePath
-}
+  sanitizePath,
+};


### PR DESCRIPTION
Closes #804 
Closes #805 

@TylerFisher - I took the staff listing out of the About page and added it to a new page located at `/staff`.

This PR has been updated to handle first and last names for authors separately and sort the staff listing by last name A-Z. I updated most of the author names in the tinycms along the way. It also includes author photos in the staff listing.