### PR TITLE
Revalidate hardcoded static pages

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -66,5 +66,6 @@ export async function getStaticProps({ locale }) {
       locales,
       locale,
     },
+    revalidate: 1,
   };
 }

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -118,5 +118,6 @@ export async function getStaticProps({ locale }) {
       locales,
       locale,
     },
+    revalidate: 1,
   };
 }

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -133,5 +133,6 @@ export async function getServerSideProps(context) {
       locales,
       locale,
     },
+    revalidate: 1,
   };
 }


### PR DESCRIPTION
In testing with Amethyst today, I found that the about page (and other hardcoded static pages) don't revalidate, meaning you have to wait for the full rebuild to see changes.