### PR TITLE
static pages now handle main image in content

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -2,6 +2,7 @@ import tw from 'twin.macro';
 import Link from 'next/link';
 import Layout from './Layout';
 import ReadInOtherLanguage from './articles/ReadInOtherLanguage';
+import StaticMainImage from './articles/StaticMainImage';
 import { renderBody } from '../lib/utils.js';
 import {
   ArticleTitle,
@@ -46,6 +47,8 @@ export default function AboutPage({
               </SectionContainer>
             </SectionLayout>
           )}
+          <StaticMainImage isAmp={isAmp} page={page} />
+
           <div className="section post__body rich-text" key="body">
             <PostText>
               <PostTextContainer>{body}</PostTextContainer>

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -21,6 +21,7 @@ export default function StaffPage({ sections, siteMetadata, authors, isAmp }) {
           <div key="title" className="section post__header">
             <ArticleTitle meta={siteMetadata}>Staff</ArticleTitle>
           </div>
+
           <div className="section post__body rich-text" key="body">
             <PostText>
               <PostTextContainer>

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -9,6 +9,7 @@ import {
   Block,
 } from './common/CommonStyles.js';
 import ReadInOtherLanguage from '../components/articles/ReadInOtherLanguage';
+import StaticMainImage from '../components/articles/StaticMainImage';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
@@ -39,6 +40,9 @@ export default function StaticPage({
         <ArticleTitle meta={siteMetadata} tw="text-center">
           {localisedPage.headline}
         </ArticleTitle>
+
+        <StaticMainImage isAmp={isAmp} page={page} />
+
         <PostText>
           <PostTextContainer>{body}</PostTextContainer>
         </PostText>

--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -51,6 +51,7 @@ export default function ArticleHeader({
   let headline;
   let postUrl;
   let searchDescription;
+  let articleContent;
 
   if (article && article.category) {
     categoryTitle = hasuraLocaliseText(
@@ -62,6 +63,11 @@ export default function ArticleHeader({
     searchDescription = hasuraLocaliseText(
       article.article_translations,
       'search_description'
+    );
+
+    articleContent = hasuraLocaliseText(
+      article.article_translations,
+      'content'
     );
   }
 
@@ -110,7 +116,9 @@ export default function ArticleHeader({
         <ArticleFeaturedMedia>
           <FeaturedMediaFigure>
             <FeaturedMediaWrapper>
-              {mainImage && <MainImage article={article} isAmp={isAmp} />}
+              {mainImage && (
+                <MainImage articleContent={articleContent} isAmp={isAmp} />
+              )}
             </FeaturedMediaWrapper>
             <FeaturedMediaCaption>
               {mainImage ? mainImage.imageAlt : null}

--- a/components/articles/MainImage.js
+++ b/components/articles/MainImage.js
@@ -1,12 +1,6 @@
 import Image from 'next/image';
-import { hasuraLocaliseText } from '../../lib/utils';
 
-export default function MainImage({ article, isAmp }) {
-  let articleContent = hasuraLocaliseText(
-    article.article_translations,
-    'content'
-  );
-
+export default function MainImage({ articleContent, isAmp }) {
   const mainImageNode = articleContent.find(
     (node) => node.type === 'mainImage'
   );

--- a/components/articles/StaticMainImage.js
+++ b/components/articles/StaticMainImage.js
@@ -1,0 +1,46 @@
+import tw from 'twin.macro';
+import MainImage from './MainImage.js';
+import { hasuraLocaliseText } from '../../lib/utils.js';
+
+const StaticFeaturedMedia = tw.div`flex flex-col flex-nowrap items-center w-full`;
+const StaticFeaturedMediaFigure = tw.figure`flex flex-row flex-wrap w-full`;
+const StaticFeaturedMediaWrapper = tw.div`w-full`;
+const StaticFeaturedMediaCaption = tw.figcaption`text-sm text-gray-700 pt-1 inline-block`;
+
+export default function StaticMainImage({ page, isAmp }) {
+  // main image handling
+  let mainImageNode;
+  let mainImage = null;
+  let pageContent = hasuraLocaliseText(page.page_translations, 'content');
+  if (
+    pageContent !== undefined &&
+    pageContent !== null &&
+    typeof pageContent !== 'string'
+  ) {
+    try {
+      mainImageNode = pageContent.find((node) => node.type === 'mainImage');
+
+      if (mainImageNode) {
+        mainImage = mainImageNode.children[0];
+        siteMetadata['coverImage'] = mainImage.imageUrl;
+      }
+    } catch (err) {
+      console.log('error finding main image: ', err);
+    }
+  }
+
+  return (
+    <StaticFeaturedMedia>
+      <StaticFeaturedMediaFigure>
+        <StaticFeaturedMediaWrapper>
+          {mainImage && (
+            <MainImage articleContent={pageContent} isAmp={isAmp} />
+          )}
+        </StaticFeaturedMediaWrapper>
+        <StaticFeaturedMediaCaption>
+          {mainImage ? mainImage.imageAlt : null}
+        </StaticFeaturedMediaCaption>
+      </StaticFeaturedMediaFigure>
+    </StaticFeaturedMedia>
+  );
+}

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -4,6 +4,7 @@ import { hasuraGetPage } from '../lib/articles.js';
 import { hasuraLocaliseText } from '../lib/utils';
 import Layout from '../components/Layout';
 import ReadInOtherLanguage from '../components/articles/ReadInOtherLanguage';
+import StaticMainImage from '../components/articles/StaticMainImage';
 import { renderBody } from '../lib/utils.js';
 import DonationOptionsBlock from '../components/plugins/DonationOptionsBlock.js';
 import {
@@ -36,6 +37,7 @@ export default function Donate({
           <ArticleTitle meta={siteMetadata} tw="text-center">
             {localisedPage.headline}
           </ArticleTitle>
+          <StaticMainImage isAmp={isAmp} page={page} />
           <PostText>
             <PostTextContainer>{body}</PostTextContainer>
           </PostText>

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -83,12 +83,13 @@ export async function getServerSideProps(context) {
   let sections;
   let siteMetadata = {};
   let locales = [];
+  let locale = context.locale;
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
     orgSlug: apiToken,
     slug: 'thank-you',
-    localeCode: context.locale,
+    localeCode: locale,
   });
   if (errors || !data) {
     return {
@@ -132,7 +133,7 @@ export async function getServerSideProps(context) {
       siteMetadata,
       locales,
       locale,
+      revalidate: 1,
     },
-    revalidate: 1,
   };
 }


### PR DESCRIPTION
Closes #820 

This updates both the generic `StaticPage` component for arbitrary pages served under `/static/$slug` urls and the `About`, `Donate` and `Thank You` pages. A new component handles most of the main image logic for these pages, and in turn calls the existing `MainImage` component. I had to make a small change to that `MainImage` component here to allow it to work more generally for both articles and pages.

Tested with `dev` and `build` for both oaklyn and test-diaryo.