### PR TITLE
Bugfix/minor display bugs

### DIFF
--- a/components/articles/ArticleFooterAuthor.js
+++ b/components/articles/ArticleFooterAuthor.js
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import tw, { styled } from 'twin.macro';
-import { renderAuthor } from '../../lib/utils';
+import { renderAuthor, hasuraLocaliseText } from '../../lib/utils';
 import Typography from '../common/Typography';
 
 const AuthorWrapper = styled.div(({ last }) => [
@@ -13,8 +13,9 @@ const AuthorMeta = styled.div(({ meta }) => ({
   ...tw`flex flex-col flex-nowrap flex-grow ml-3 pb-5`,
   fontFamily: Typography[meta.theme].ArticleMetaTop,
 }));
-const AuthorNameWrapper = tw.span`text-base`;
+const AuthorNameWrapper = tw.span`text-lg`;
 const AuthorContact = tw.a`text-xs font-normal cursor-pointer bg-no-repeat ml-2 pl-4`;
+const AuthorTitle = tw.p`mb-4 italic`;
 
 export default function ArticleFooterAuthor({
   author,
@@ -24,6 +25,8 @@ export default function ArticleFooterAuthor({
   metadata,
 }) {
   let authorPhoto = author.photoUrl;
+  let authorTitle = hasuraLocaliseText(author.author_translations, 'title');
+  let authorBio = hasuraLocaliseText(author.author_translations, 'bio');
   return (
     <AuthorWrapper last={last}>
       {authorPhoto && (
@@ -65,7 +68,8 @@ export default function ArticleFooterAuthor({
             )}
           </span>
         </div>
-        <p>{author.bio}</p>
+        <AuthorTitle>{authorTitle}</AuthorTitle>
+        <p>{authorBio}</p>
       </AuthorMeta>
     </AuthorWrapper>
   );

--- a/components/homepage/ArticleStream.js
+++ b/components/homepage/ArticleStream.js
@@ -96,7 +96,7 @@ export default function ArticleStream({
           <BlockList>{articleStream}</BlockList>
         </Block>
         <PromotionContainer>
-          <PromotionBlock metadata={metadata} prefer="donation" />
+          <PromotionBlock metadata={metadata} prefer="newsletter" />
         </PromotionContainer>
       </SectionContainer>
     </SectionLayout>

--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -5,12 +5,8 @@ export default function TextNode({ node }) {
   const processChild = function (child, nextChild) {
     let supportedPunctuation = [',', '.', '?', '!', ';', ':'];
     let delimiterSpaceChar = ' ';
-    // if this is a link and the next node/child starts with one of the punctuation marks above, don't add a space
-    if (
-      child.link &&
-      nextChild &&
-      supportedPunctuation.includes(nextChild.content[0])
-    ) {
+    // if the next node/child starts with one of the punctuation marks above, don't add a space
+    if (nextChild && supportedPunctuation.includes(nextChild.content[0])) {
       delimiterSpaceChar = '';
     }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -395,6 +395,7 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
           slug
           author_translations(where: {locale_code: {_eq: $locale_code}}) {
             title
+            bio
           }
         }
       }


### PR DESCRIPTION
Three small things I found:

- Title and bio weren't displaying for authors at the bottom of articles. I had to fix the query and access the translation correctly.
- The delimiter detection we did for links appears with all types of formatted text: bold, italic, underline, etc. So I removed the check for links. If there are two nodes side by side, and the second one starts with a punctuation mark, we shouldn't use a space.
- The homepage should prefer the newsletter promotion card, just like articles.