### PR TITLE
Use priority=true on above-the-fold images for better page load experience

### DIFF
--- a/components/articles/MainImage.js
+++ b/components/articles/MainImage.js
@@ -29,6 +29,7 @@ export default function MainImage({ articleContent, isAmp }) {
           height={(mainImage.height / mainImage.width) * 1080}
           alt={mainImage.imageAlt}
           className="image"
+          priority={true}
         />
       )}
     </>

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -39,6 +39,7 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
           height={(mainImage.height / mainImage.width) * 1080}
           alt={mainImage.imageAlt}
           className="image"
+          priority={true}
         />
       )}
     </AssetThumbnail>

--- a/components/nav/GlobalNav.js
+++ b/components/nav/GlobalNav.js
@@ -65,6 +65,7 @@ export default function GlobalNav({ metadata, sections, isAmp }) {
               objectFit="contain"
               objectPosition="left"
               alt={title}
+              priority={true}
             />
           )}
         </Logo>


### PR DESCRIPTION
It was bothering me while clicking around our sites that the lead image would take a while to load because of next's lazy loading, which is generally good. Turns out there's a `priority=true` parameter for preloading images. I've done that for any image that would appear above the fold.