### PR TITLE
Don't show last updated date if same as first. Closes #822

### DIFF
--- a/components/articles/PublishDate.js
+++ b/components/articles/PublishDate.js
@@ -23,7 +23,9 @@ export default function PublishDate({ article, meta }) {
   if (
     article.article_translations &&
     article.article_translations[0] &&
-    article.article_translations[0].last_published_at !== null
+    article.article_translations[0].last_published_at !== null &&
+    article.article_translations[0].last_published_at !==
+      article.article_translations[0].first_published_at
   ) {
     lastPublishedOn = renderDate(
       article.article_translations[0].last_published_at


### PR DESCRIPTION
Compare Daniel de Jesús story, which has an updated time, vs. Kensington's Last Minute Gift Guide, which does not.