### PR TITLE
Fix grid settings for editing newsletter/membership promotions. Closes #795

### DIFF
--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -604,7 +604,7 @@ export default function SiteInfoSettings(props) {
           Newsletter promotion block
         </SettingsHeader>
 
-        <div tw="col-span-2">
+        <div tw="col-span-1">
           <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
             <ControlledInput
@@ -636,7 +636,7 @@ export default function SiteInfoSettings(props) {
           Membership promotion block
         </SettingsHeader>
 
-        <div tw="col-span-2">
+        <div tw="col-span-1">
           <label htmlFor="heading">
             <span tw="w-full mt-1 font-bold">Heading</span>
             <ControlledInput


### PR DESCRIPTION
Now, submitting longer text into the newsletter/membership description fields won't cause the preview of the cards to expand endlessly.