### PR TITLE
Constrain images to 1200px wide max

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ module.exports = {
       'tnc-test-upload-bucket.s3.us-east-1.amazonaws.com',
       'ucarecdn.com',
     ],
+    deviceSizes: [640, 750, 828, 1080, 1200],
   },
   i18n: {
     locales: process.env.LOCALES.split(','),


### PR DESCRIPTION
In order to keep images (esp. from Reuters) from getting served at enormous sizes and dragging down the load time, I restrained the device widths to 1200px. No image that we put on the site needs to be wider than that. https://nextjs.org/docs/basic-features/image-optimization#device-sizes