### PR TITLE
Feature/handle blockquotes and hrs

### DIFF
--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -17,3 +17,4 @@ export const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet 
 export const Block = tw.div`w-full`;
 export const AddButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 export const DeleteButton = tw.button`bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded`;
+export const Blockquote = tw.blockquote`text-lg p-2 mx-6 bg-gray-100 mb-4 border-l-4 border-gray-400 italic`;

--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -17,5 +17,8 @@ export const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet 
 export const Block = tw.div`w-full`;
 export const AddButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 export const DeleteButton = tw.button`bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded`;
-export const Blockquote = tw.blockquote`text-lg p-2 mx-6 bg-gray-100 mb-4 border-l-4 border-gray-400 italic`;
-export const HorizontalRule = tw.hr`border-0 bg-gray-500 text-gray-500 h-px max-w-full my-4`;
+export const Blockquote = styled.blockquote(({ meta }) => ({
+  ...tw`text-lg pl-6 py-2 mb-5 border-l-4 italic`,
+  borderColor: meta.primaryColor,
+}));
+export const HorizontalRule = tw.hr`border-0 bg-gray-500 text-gray-500 h-px max-w-full my-8`;

--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -18,3 +18,4 @@ export const Block = tw.div`w-full`;
 export const AddButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 export const DeleteButton = tw.button`bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded`;
 export const Blockquote = tw.blockquote`text-lg p-2 mx-6 bg-gray-100 mb-4 border-l-4 border-gray-400 italic`;
+export const HorizontalRule = tw.hr`border-0 bg-gray-500 text-gray-500 h-px max-w-full my-4`;

--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -1,0 +1,33 @@
+import { Blockquote, Paragraph, Anchor } from '../common/CommonStyles';
+
+export default function BlockquoteNode({ node }) {
+  const processChild = function (child, nextChild) {
+    let text = (
+      <span key={child.index ? child.index : child.content}>
+        {child.content}
+      </span>
+    );
+
+    if (child.link) {
+      text = (
+        <Anchor key={child.link} href={child.link}>
+          {text}
+        </Anchor>
+      );
+    }
+
+    return text;
+  };
+
+  const children = node.children.map((child, i) =>
+    processChild(child, node.children[i + 1])
+  );
+
+  let quotedContent = (
+    <Blockquote>
+      <Paragraph>{children}</Paragraph>
+    </Blockquote>
+  );
+
+  return quotedContent;
+}

--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -1,6 +1,6 @@
 import { Blockquote, Paragraph, Anchor } from '../common/CommonStyles';
 
-export default function BlockquoteNode({ node }) {
+export default function BlockquoteNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
     let text = (
       <span key={child.index ? child.index : child.content}>
@@ -24,8 +24,8 @@ export default function BlockquoteNode({ node }) {
   );
 
   let quotedContent = (
-    <Blockquote>
-      <Paragraph>{children}</Paragraph>
+    <Blockquote meta={metadata}>
+      <p tw="text-lg leading-relaxed">{children}</p>
     </Blockquote>
   );
 

--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -1,3 +1,4 @@
+import tw from 'twin.macro';
 import { Blockquote, Paragraph, Anchor } from '../common/CommonStyles';
 
 export default function BlockquoteNode({ node, metadata }) {

--- a/components/nodes/HorizontalRuleNode.js
+++ b/components/nodes/HorizontalRuleNode.js
@@ -1,0 +1,5 @@
+import { HorizontalRule } from '../common/CommonStyles';
+
+export default function HorizontalRuleNode({ node }) {
+  return <HorizontalRule />;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import tw from 'twin.macro';
 import fetch from 'node-fetch';
 import { apdate, aptime } from 'journalize';
+import BlockquoteNode from '../components/nodes/BlockquoteNode.js';
 import EmbedNode from '../components/nodes/EmbedNode.js';
 import ImageNode from '../components/nodes/ImageNode.js';
 import ListNode from '../components/nodes/ListNode.js';
@@ -240,6 +241,9 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
   const serialize = (node, i) => {
     let renderedNode = null;
     switch (node.type) {
+      case 'blockquote':
+        renderedNode = <BlockquoteNode node={node} key={i} />;
+        break;
       case 'list':
         renderedNode = <ListNode node={node} key={i} />;
         break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -243,7 +243,9 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
     let renderedNode = null;
     switch (node.type) {
       case 'blockquote':
-        renderedNode = <BlockquoteNode node={node} key={i} />;
+        renderedNode = (
+          <BlockquoteNode node={node} key={i} metadata={metadata} />
+        );
         break;
       case 'hr':
         renderedNode = <HorizontalRuleNode node={node} key={i} />;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,7 @@ import ImageWithTextAd from '../components/ads/ImageWithTextAd.js';
 import { format } from 'date-fns';
 import { utcToZonedTime, format as tzFormat } from 'date-fns-tz';
 import AdPromotion from '../components/ads/AdPromotion.js';
+import HorizontalRuleNode from '../components/nodes/HorizontalRuleNode.js';
 
 const ORG_SLUG = process.env.ORG_SLUG;
 const HASURA_API_URL = process.env.HASURA_API_URL;
@@ -243,6 +244,9 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
     switch (node.type) {
       case 'blockquote':
         renderedNode = <BlockquoteNode node={node} key={i} />;
+        break;
+      case 'hr':
+        renderedNode = <HorizontalRuleNode node={node} key={i} />;
         break;
       case 'list':
         renderedNode = <ListNode node={node} key={i} />;


### PR DESCRIPTION
Related to https://github.com/news-catalyst/google-app-scripts/pull/343

Closes #839 
Closes #840

Adds two nodes to format the new element types in article contents: blockquote and hr.

I tested using [this Google Doc](https://docs.google.com/document/d/12sx_4_cwALC9pw0g3ZBrZffxipjm8HdiCAj65rcucYQ/edit?addon_dry_run=AAnXSK8I-FQmTupSDGNE-5RKbyQVBrox66Ze_2ZFq2W95sx58rsJui-wqa51876fz3O2Ze3Q1IjUA9qe41kW7ten0i9nj6eFZy0u6zCQxQruvhKGiG5DuDt9Y6sHtAtEUMLuHYvFgqLG) (latest code/script editor) and [this localhost article link](http://localhost:3000/articles/top-stories/fancy-formatting).