### PR TITLE
Fix for 404 when previewing static pages

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -48,7 +48,11 @@ export default function AboutPage({
               </SectionContainer>
             </SectionLayout>
           )}
-          <StaticMainImage isAmp={isAmp} page={page} />
+          <StaticMainImage
+            isAmp={isAmp}
+            page={page}
+            siteMetadata={siteMetadata}
+          />
 
           <div className="section post__body rich-text" key="body">
             <PostText>

--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -36,7 +36,7 @@ export default function AboutPage({
               {localisedPage.headline}
             </ArticleTitle>
           </div>
-          {locales.length > 1 && (
+          {locales && locales.length > 1 && (
             <SectionLayout>
               <SectionContainer>
                 <Block>

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -41,7 +41,11 @@ export default function StaticPage({
           {localisedPage.headline}
         </ArticleTitle>
 
-        <StaticMainImage isAmp={isAmp} page={page} />
+        <StaticMainImage
+          isAmp={isAmp}
+          page={page}
+          siteMetadata={siteMetadata}
+        />
 
         <PostText>
           <PostTextContainer>{body}</PostTextContainer>

--- a/components/articles/StaticMainImage.js
+++ b/components/articles/StaticMainImage.js
@@ -7,7 +7,7 @@ const StaticFeaturedMediaFigure = tw.figure`flex flex-row flex-wrap w-full`;
 const StaticFeaturedMediaWrapper = tw.div`w-full`;
 const StaticFeaturedMediaCaption = tw.figcaption`text-sm text-gray-700 pt-1 inline-block`;
 
-export default function StaticMainImage({ page, isAmp }) {
+export default function StaticMainImage({ page, isAmp, siteMetadata }) {
   // main image handling
   let mainImageNode;
   let mainImage = null;

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -813,42 +813,82 @@ const HASURA_GET_PAGE = `query FrontendGetPage($slug: String!, $locale_code: Str
 }`;
 
 const HASURA_GET_PAGE_PREVIEW = `query FrontendGetPagePreview($slug: String!, $locale_code: String!) {
-  pages(where: {slug: {_eq: $slug}, page_translations: {locale_code: {_eq: $locale_code}}}) {
-    id
-    author_pages {
-      author {
-        id
-        first_names
-        last_name
-        slug
-        author_translations(where: {locale_code: {_eq: $locale_code}}) {
-          title
+  page_slug_versions(where: {slug: {_eq: $slug}, page: {page_translations: {locale_code: {_eq: $locale_code}}}}) {
+    slug
+    page {
+      id
+      author_pages {
+        author {
+          id
+          first_names
+          last_name
+          slug
+          photoUrl
+          author_translations(where: {locale_code: {_eq: $locale_code}}) {
+            title
+          }
         }
       }
+      page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        content
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        last_published_at
+        locale_code
+        locale {
+          code
+          name
+        }
+        published
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
+      slug
     }
-    page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
-      content
-      facebook_description
-      facebook_title
-      first_published_at
-      headline
-      last_published_at
-      published
-      search_description
-      search_title
-      twitter_description
-      twitter_title
-    }
+  }
+  authors(order_by: {last_name: asc}) {
+    id
+    first_names
+    last_name
+    created_at
     slug
+    staff
+    twitter
+    photoUrl
+    published
+    author_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+      bio
+    }
   }
   categories(where: {category_translations: {locale_code: {_eq: $locale_code}}}) {
     slug
+    published
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
     }
   }
-  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}}) {
-    site_metadata_translations {
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
+  pages(where: {slug: {_eq: $slug}, page_translations: {}}) {
+    page_translations {
+      locale {
+        code
+        name
+      }
+      id
+    }
+  }
+  site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
+    site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data
     }
   }

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -37,7 +37,11 @@ export default function Donate({
           <ArticleTitle meta={siteMetadata} tw="text-center">
             {localisedPage.headline}
           </ArticleTitle>
-          <StaticMainImage isAmp={isAmp} page={page} />
+          <StaticMainImage
+            isAmp={isAmp}
+            page={page}
+            siteMetadata={siteMetadata}
+          />
           <PostText>
             <PostTextContainer>{body}</PostTextContainer>
           </PostText>

--- a/pages/preview/about.js
+++ b/pages/preview/about.js
@@ -58,7 +58,7 @@ export async function getStaticProps(context) {
 
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
-    for (var i = 0; i < sections.length; i++) {
+    for (i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
         sections[i].category_translations,
         'title'

--- a/pages/preview/about.js
+++ b/pages/preview/about.js
@@ -24,6 +24,7 @@ export async function getStaticProps(context) {
   let page = {};
   let sections;
   let siteMetadata = {};
+  let locales = [];
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
@@ -37,8 +38,25 @@ export async function getStaticProps(context) {
     };
     // throw errors;
   } else {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
+
+    var allPageLocales = data.pages[0].page_translations;
+    var distinctLocaleCodes = [];
+    var distinctLocales = [];
+    for (var i = 0; i < allPageLocales.length; i++) {
+      if (!distinctLocaleCodes.includes(allPageLocales[i].locale.code)) {
+        distinctLocaleCodes.push(allPageLocales[i].locale.code);
+        distinctLocales.push(allPageLocales[i]);
+      }
+    }
+    locales = distinctLocales;
+
     sections = data.categories;
-    page = data.pages[0];
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
@@ -53,6 +71,8 @@ export async function getStaticProps(context) {
       page,
       sections,
       siteMetadata,
+      locales,
+      locale,
     },
   };
 }

--- a/pages/preview/static/[slug].js
+++ b/pages/preview/static/[slug].js
@@ -8,7 +8,13 @@ import {
 import { hasuraLocaliseText } from '../../../lib/utils';
 import StaticPage from '../../../components/StaticPage';
 
-export default function Static({ page, sections, siteMetadata }) {
+export default function Static({
+  page,
+  sections,
+  siteMetadata,
+  locales,
+  locale,
+}) {
   const router = useRouter();
   const isAmp = useAmp();
 
@@ -28,6 +34,8 @@ export default function Static({ page, sections, siteMetadata }) {
       page={page}
       sections={sections}
       siteMetadata={siteMetadata}
+      locales={locales}
+      currentLocale={locale}
     />
   );
 }
@@ -72,6 +80,7 @@ export async function getStaticProps(context) {
   let page = {};
   let sections;
   let siteMetadata = {};
+  let locales = [];
 
   const { errors, data } = await hasuraGetPagePreview({
     url: apiUrl,
@@ -81,18 +90,30 @@ export async function getStaticProps(context) {
   });
 
   if (errors || !data) {
-    console.log('Failed finding page ', params);
-
     return {
       notFound: true,
     };
+    // throw errors;
   } else {
-    if (!data.pages || !data.pages[0]) {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      console.error('not found: data.page_slug_versions');
       return {
         notFound: true,
       };
     }
-    page = data.pages[0];
+    page = data.page_slug_versions[0].page;
+
+    var allPageLocales = data.pages[0].page_translations;
+    var distinctLocaleCodes = [];
+    var distinctLocales = [];
+    for (var i = 0; i < allPageLocales.length; i++) {
+      if (!distinctLocaleCodes.includes(allPageLocales[i].locale.code)) {
+        distinctLocaleCodes.push(allPageLocales[i].locale.code);
+        distinctLocales.push(allPageLocales[i]);
+      }
+    }
+    locales = distinctLocales;
+
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
     for (var i = 0; i < sections.length; i++) {
@@ -108,6 +129,8 @@ export async function getStaticProps(context) {
       page,
       sections,
       siteMetadata,
+      locales,
+      locale,
     },
   };
 }

--- a/pages/preview/static/[slug].js
+++ b/pages/preview/static/[slug].js
@@ -116,7 +116,7 @@ export async function getStaticProps(context) {
 
     sections = data.categories;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
-    for (var i = 0; i < sections.length; i++) {
+    for (i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocaliseText(
         sections[i].category_translations,
         'title'

--- a/pages/static/[slug].js
+++ b/pages/static/[slug].js
@@ -85,7 +85,7 @@ export async function getStaticProps({ locale, params }) {
     };
   } else {
     if (!data.page_slug_versions || !data.page_slug_versions[0]) {
-      console.log('No page slug versions found', data);
+      console.error('No page slug versions found', data);
       return {
         notFound: true,
       };


### PR DESCRIPTION
Closes #846 

The queries used for the preview versions of static pages were slightly out of sync with the public-facing versions of these pages, causing a 404. This updates the graphql so it matches, only returning the latest content whether published or not in preview mode.

Tested by altering the preview URL to work on localhost, then on [the deployed temporary site](https://next-tinynewsdemo-git-bugfix-preview-static-pages-news-catalyst.vercel.app/)