### PR TITLE
Bugfix: article preview 404 issue

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -344,6 +344,15 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query FrontendPreviewArticlePage($slug: Str
     published
     slug
   }
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
+  published_article_translations(where: {article: {slug: {_eq: $slug}}}) {
+    locale_code
+  }
   tags(where: {published: {_eq: true}}) {
     id
     slug

--- a/pages/preview/[category]/[slug].js
+++ b/pages/preview/[category]/[slug].js
@@ -10,7 +10,6 @@ import Article from '../../../components/Article.js';
 
 export default function PreviewArticle(props) {
   if (!props.article) {
-    console.log('no article prop: ', props);
     return (
       <div>
         <DefaultErrorPage statusCode={404} />
@@ -63,6 +62,8 @@ export async function getStaticProps(context) {
   let sectionArticles = [];
   let sections = [];
   let tags = [];
+  let locales = [];
+  let publishedLocales = [];
   let siteMetadata;
 
   const { errors, data } = await hasuraPreviewArticlePage({
@@ -78,10 +79,14 @@ export async function getStaticProps(context) {
       notFound: true,
     };
   } else {
+    locales = data.organization_locales;
+    publishedLocales = data.published_article_translations;
+
     tags = data.tags;
     for (var i = 0; i < tags.length; i++) {
       tags[i].title = hasuraLocaliseText(tags[i].tag_translations, 'title');
     }
+
     sections = data.categories;
     for (var j = 0; j < sections.length; j++) {
       sections[j].title = hasuraLocaliseText(
@@ -125,6 +130,8 @@ export async function getStaticProps(context) {
       article,
       sections,
       ads,
+      locales,
+      publishedLocales,
       siteMetadata,
       sectionArticles,
       tags,


### PR DESCRIPTION
Closes #848

This PR fixes the preview article page 404 issue. This bug was due to the preview article queries missing data, the graphql lookup is now updated to include all required info and the page renders fine locally. 

I waited for this PR branch to be deployed and tested there - articles now preview successfully. Example link: https://next-tinynewsdemo-3zzhi9xqy-news-catalyst.vercel.app/api/preview?secret=XXXXXX&slug=franny-lous-porch&locale=en-US which redirects to https://next-tinynewsdemo-3zzhi9xqy-news-catalyst.vercel.app/en-US/preview/covid-19/franny-lous-porch