### PR TITLE
Custom favicon

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -30,6 +30,7 @@ export default function Layout({
 
   const metaValues = {
     canonical: meta['canonicalUrl'] || meta['siteUrl'],
+    favicon: meta['favicon'],
     siteName: meta['shortName'],
     searchTitle: meta['searchTitle'],
     searchDescription: meta['searchDescription'],
@@ -113,7 +114,7 @@ export default function Layout({
     <>
       <Head>
         <title>{pageTitle}</title>
-        <link rel="icon" href="/favicon.ico" />
+        {metaValues.favicon && <link rel="icon" href={metaValues.favicon} />}
         <meta property="description" content={metaValues.searchDescription} />
         {tagList}
         <link rel="canonical" href={metaValues.canonical} />

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -240,6 +240,7 @@ export default function SiteInfoSettings(props) {
   );
 
   const [logo, setLogo] = useState(props.parsedData['logo']);
+  const [favicon, setFavicon] = useState(props.parsedData['favicon']);
   const [defaultSocialImage, setDefaultSocialImage] = useState(
     props.parsedData['defaultSocialImage']
   );
@@ -339,6 +340,7 @@ export default function SiteInfoSettings(props) {
         : null
     );
     setLogo(props.parsedData['logo']);
+    setFavicon(props.parsedData['favicon']);
     setDefaultSocialImage(props.parsedData['defaultSocialImage']);
   }, [props.parsedData]);
 
@@ -395,6 +397,22 @@ export default function SiteInfoSettings(props) {
             setNotificationType={props.setNotificationType}
             setShowNotification={props.setShowNotification}
             folderName="logos"
+          />
+        </label>
+        <label htmlFor="logo">
+          <span tw="mt-1 font-bold">Favicon</span>
+          <Upload
+            awsConfig={props.awsConfig}
+            slug={shortName}
+            image={favicon}
+            imageKey="favicon"
+            updateParsedData={props.updateParsedData}
+            parsedData={props.parsedData}
+            setter={setFavicon}
+            setNotificationMessage={props.setNotificationMessage}
+            setNotificationType={props.setNotificationType}
+            setShowNotification={props.setShowNotification}
+            folderName="favicon"
           />
         </label>
       </SiteInfoFieldsContainer>


### PR DESCRIPTION
Closes #829

Adds a file upload for setting a favicon to the site info settings in the tinycms, next to the logo uploader. Also wires up the layout component to use this image if it's set.