### PR TITLE
Landing page nav

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -11,6 +11,7 @@ import {
   SectionLayout,
   Block,
   Paragraph,
+  Anchor,
 } from './common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
@@ -58,9 +59,9 @@ export default function AboutPage({
             <PostText>
               <PostTextContainer>
                 {body}
-                <Paragraph tw="underline">
-                  <Link href="/staff">
-                    <a>Learn about our staff →</a>
+                <Paragraph>
+                  <Link href="/staff" passHref>
+                    <Anchor meta={siteMetadata}>Learn about our staff →</Anchor>
                   </Link>
                 </Paragraph>
               </PostTextContainer>

--- a/components/LandingPage.js
+++ b/components/LandingPage.js
@@ -1,16 +1,15 @@
+import Link from 'next/link';
 import tw from 'twin.macro';
-// import Markdown from 'markdown-to-jsx';
 import Layout from './Layout';
 import NewsletterBlock from './plugins/NewsletterBlock';
+import LandingPageNav from './nav/LandingPageNav';
 
 const Container = tw.div`flex items-center justify-center flex-col min-h-screen max-w-3xl mx-auto py-6 px-8`;
 const Title = tw.h1`text-6xl font-bold mb-8`;
 const Dek = tw.div`text-xl mb-6`;
-const DekP = tw.p`mb-5 leading-relaxed`;
-const DekA = tw.a`text-black cursor-pointer border-b border-blue-500`;
 const BlockWrapper = tw.div`w-full`;
 
-export default function LandingPage({ siteMetadata, sections }) {
+export default function LandingPage({ siteMetadata, sections, pages }) {
   let landingDek = siteMetadata.landingPageDek || siteMetadata.aboutDek;
   return (
     <Layout meta={siteMetadata} sections={sections} renderNav={false}>
@@ -20,6 +19,9 @@ export default function LandingPage({ siteMetadata, sections }) {
         <BlockWrapper>
           <NewsletterBlock metadata={siteMetadata} />
         </BlockWrapper>
+        {pages.length > 0 && (
+          <LandingPageNav pages={pages} metadata={siteMetadata} />
+        )}
       </Container>
       <style jsx global>{`
         .dek p {
@@ -30,10 +32,10 @@ export default function LandingPage({ siteMetadata, sections }) {
         .dek a {
           color: black;
           cursor: pointer;
-          border-bottom: 1px solid rgb(59, 130, 246);
+          border-bottom: 1px solid ${siteMetadata.primaryColor};
         }
         .dek {
-          margin-bottom: 1.5rem;
+          margin-bottom: 1.25rem;
         }
       `}</style>
     </Layout>

--- a/components/LandingPage.js
+++ b/components/LandingPage.js
@@ -19,7 +19,7 @@ export default function LandingPage({ siteMetadata, sections, pages }) {
         <BlockWrapper>
           <NewsletterBlock metadata={siteMetadata} />
         </BlockWrapper>
-        {pages.length > 0 && (
+        {pages && pages.length > 0 && (
           <LandingPageNav pages={pages} metadata={siteMetadata} />
         )}
       </Container>

--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -11,7 +11,10 @@ export const Paragraph = tw.p`text-lg mb-5 leading-relaxed`;
 export const H1 = tw.h1`font-bold text-3xl lg:text-4xl leading-tight mt-10 mb-4`;
 export const H2 = tw.h2`font-bold text-2xl leading-tight mt-10 mb-4`;
 export const H3 = tw.h3`font-bold text-xl leading-tight mt-10 mb-4`;
-export const Anchor = tw.a`text-black cursor-pointer border-b border-blue-500`;
+export const Anchor = styled.a(({ meta }) => ({
+  ...tw`text-black cursor-pointer border-b`,
+  borderColor: meta.primaryColor,
+}));
 export const SectionLayout = tw.section`flex mb-8`;
 export const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet lg:grid-cols-packageLayoutDesktop flex flex-row flex-wrap grid-rows-1 w-full px-5 mx-auto max-w-7xl`;
 export const Block = tw.div`w-full`;

--- a/components/nav/LandingPageNav.js
+++ b/components/nav/LandingPageNav.js
@@ -1,0 +1,58 @@
+import { Fragment } from 'react';
+import Link from 'next/link';
+import tw from 'twin.macro';
+import { hasuraLocaliseText } from '../../lib/utils.js';
+import { Anchor } from '../common/CommonStyles.js';
+
+const NavWrapper = tw.div`w-full`;
+const NavHeader = tw.h2`text-xl font-bold text-left mt-2`;
+const NavLinks = tw.div`mt-1`;
+const PageLinkWrapper = tw.span`md:mx-2 my-4 md:my-0 first:ml-0 last:mr-0 block md:inline`;
+const Divider = tw.span`hidden md:inline`;
+
+function PageLink({ page, metadata }) {
+  const specialSlugs = ['about', 'donate'];
+  const ignoredSlugs = ['thank-you'];
+  let link = null;
+
+  if (ignoredSlugs.includes(page.slug)) {
+    return <span />;
+  }
+
+  if (specialSlugs.includes(page.slug)) {
+    link = `/${page.slug}`;
+  } else {
+    link = `/static/${page.slug}`;
+  }
+
+  const headline = hasuraLocaliseText(page.page_translations, 'headline');
+
+  return (
+    <Link href={link} passHref>
+      <Anchor meta={metadata}>{headline}</Anchor>
+    </Link>
+  );
+}
+
+export default function LandingPageNav({ pages, metadata }) {
+  return (
+    <NavWrapper>
+      <NavHeader>Read more</NavHeader>
+      <NavLinks>
+        {pages.map((page, i) => (
+          <Fragment key={page.slug}>
+            <PageLinkWrapper>
+              <PageLink page={page} metadata={metadata} />
+            </PageLinkWrapper>
+            <Divider>{` | `}</Divider>
+          </Fragment>
+        ))}
+        <PageLinkWrapper>
+          <Link href="/staff" passHref>
+            <Anchor meta={metadata}>Staff</Anchor>
+          </Link>
+        </PageLinkWrapper>
+      </NavLinks>
+    </NavWrapper>
+  );
+}

--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -11,7 +11,7 @@ export default function BlockquoteNode({ node, metadata }) {
 
     if (child.link) {
       text = (
-        <Anchor key={child.link} href={child.link}>
+        <Anchor meta={metadata} key={child.link} href={child.link}>
           {text}
         </Anchor>
       );

--- a/components/nodes/ListNode.js
+++ b/components/nodes/ListNode.js
@@ -5,7 +5,7 @@ const UnorderedList = tw.ul`mb-4 list-outside list-disc`;
 const OrderedList = tw.ol`mb-4 list-outside list-decimal`;
 const ListItem = tw.li`mb-1 pl-2 ml-2 text-lg`;
 
-export default function ListNode({ node }) {
+export default function ListNode({ node, metadata }) {
   let items = [];
   node.items.map(function (item) {
     if (item.nestingLevel === 1) {
@@ -13,7 +13,7 @@ export default function ListNode({ node }) {
         <ListItem key={item.index} style={{ listStyle: 'none' }}>
           <UnorderedList>
             <ListItem>
-              <TextNode node={item} />
+              <TextNode metadata={metadata} node={item} />
             </ListItem>
           </UnorderedList>
         </ListItem>
@@ -25,7 +25,7 @@ export default function ListNode({ node }) {
             <ListItem style={{ listStyle: 'none' }}>
               <UnorderedList>
                 <ListItem>
-                  <TextNode node={item} />
+                  <TextNode metadata={metadata} node={item} />
                 </ListItem>
               </UnorderedList>
             </ListItem>
@@ -41,7 +41,7 @@ export default function ListNode({ node }) {
                 <ListItem style={{ listStyle: 'none' }}>
                   <UnorderedList>
                     <ListItem>
-                      <TextNode node={item} />
+                      <TextNode metadata={metadata} node={item} />
                     </ListItem>
                   </UnorderedList>
                 </ListItem>
@@ -53,7 +53,7 @@ export default function ListNode({ node }) {
     } else {
       items.push(
         <ListItem key={item.index}>
-          <TextNode node={item} />
+          <TextNode metadata={metadata} node={item} />
         </ListItem>
       );
     }

--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -1,7 +1,7 @@
 import tw from 'twin.macro';
 import { Paragraph, H1, H2, H3, Anchor } from '../common/CommonStyles';
 
-export default function TextNode({ node }) {
+export default function TextNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
     let supportedPunctuation = [',', '.', '?', '!', ';', ':'];
     let delimiterSpaceChar = ' ';
@@ -31,7 +31,7 @@ export default function TextNode({ node }) {
 
     if (child.link) {
       text = (
-        <Anchor key={child.link} href={child.link}>
+        <Anchor key={child.link} href={child.link} meta={metadata}>
           {text}
         </Anchor>
       );

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -226,6 +226,14 @@ const HASURA_HOMEPAGE_EDITOR = `query FrontendHomepageEditor($locale_code: Strin
       name
     }
   }
+  pages(where: {page_translations: {published: {_eq: true}, locale_code: {_eq: $locale_code}}}) {
+    slug
+    page_translations(where: {published: {_eq: true}}, distinct_on: locale_code) {
+      locale_code
+      published
+      headline
+    }
+  }
   site_metadatas(where: {site_metadata_translations: {locale_code: {_eq: $locale_code}}, published: {_eq: true}}) {
     site_metadata_translations(where: {locale_code: {_eq: $locale_code}}) {
       data
@@ -1244,6 +1252,7 @@ const HASURA_LIST_PAGE_SLUGS_PREVIEW = `query FrontendListPageSlugsPreview {
     page_translations(distinct_on: locale_code) {
       locale_code
       published
+      headline
     }
   }
 }`;
@@ -1254,6 +1263,7 @@ const HASURA_LIST_PAGE_SLUGS = `query FrontendListPageSlugs {
     page_translations(where: {published: {_eq: true}}, distinct_on: locale_code) {
       locale_code
       published
+      headline
     }
   }
 }`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,13 +251,13 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
         renderedNode = <HorizontalRuleNode node={node} key={i} />;
         break;
       case 'list':
-        renderedNode = <ListNode node={node} key={i} />;
+        renderedNode = <ListNode metadata={metadata} node={node} key={i} />;
         break;
       case 'text':
-        renderedNode = <TextNode node={node} key={i} />;
+        renderedNode = <TextNode metadata={metadata} node={node} key={i} />;
         break;
       case 'paragraph':
-        renderedNode = <TextNode node={node} key={i} />;
+        renderedNode = <TextNode metadata={metadata} node={node} key={i} />;
         break;
       case 'image':
         renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
@@ -338,13 +338,13 @@ export const renderNewsletterContent = (content, ads, isAmp, metadata) => {
     let renderedNode = null;
     switch (node.type) {
       case 'list':
-        renderedNode = <ListNode node={node} key={i} />;
+        renderedNode = <ListNode metadata={metadata} node={node} key={i} />;
         break;
       case 'text':
-        renderedNode = <TextNode node={node} key={i} />;
+        renderedNode = <TextNode metadata={metadata} node={node} key={i} />;
         break;
       case 'paragraph':
-        renderedNode = <TextNode node={node} key={i} />;
+        renderedNode = <TextNode metadata={metadata} node={node} key={i} />;
         break;
       case 'image':
         renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;

--- a/pages/authors/[slug].js
+++ b/pages/authors/[slug].js
@@ -81,7 +81,9 @@ export default function AuthorPage({
           <ProfileTwitter>
             <em>
               {twitterCall}
-              <Anchor href={twitterLink}>{authorTwitter}</Anchor>
+              <Anchor meta={siteMetadata} href={twitterLink}>
+                {authorTwitter}
+              </Anchor>
             </em>
           </ProfileTwitter>
         </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { hasuraStreamArticles } from '../lib/homepage.js';
 import { cachedContents } from '../lib/cached';
-import { hasuraGetHomepageEditor } from '../lib/articles.js';
+import {
+  hasuraGetHomepageEditor,
+  hasuraListAllPageSlugs,
+} from '../lib/articles.js';
 import { getArticleAds } from '../lib/ads.js';
 import { hasuraLocaliseText } from '../lib/utils.js';
 import Homepage from '../components/Homepage';
@@ -46,11 +49,14 @@ export async function getStaticProps({ locale }) {
     console.log('failed finding site metadata for ', locale, metadatas);
   }
 
+  let pages = data.pages;
+
   if (siteMetadata && siteMetadata.landingPage === 'on') {
     return {
       props: {
         locale,
         siteMetadata,
+        pages,
       },
       revalidate: 1,
     };


### PR DESCRIPTION
This adds a small nav section below the newsletter subscribe box to landing pages, so that we can easily promote things like about pages and contact pages without moving to the full site.
<img width="825" alt="Screen Shot 2021-10-11 at 1 21 55 PM" src="https://user-images.githubusercontent.com/1077075/136832103-5f29c13c-c8fe-403d-83a9-5b547f349827.png">


