### PR TITLE
fix for cypress failing tags test

### DIFF
--- a/cypress/integration/tinycms_tags_spec.js
+++ b/cypress/integration/tinycms_tags_spec.js
@@ -1,12 +1,20 @@
 // import { cypressDeleteAuthors } from "../../lib/authors"
 
 describe('tinycms tags', () => {
-  it('renders the list', () => {
+  it('renders the list and updates the first tag', () => {
     cy.visit('/tinycms/tags');
     cy.get('h1').contains('Tags');
     // has at least one header
     cy.get('table thead tr th');
     cy.get('th').contains('Name');
+
+    cy.get('table>tbody>tr:first>td>a')
+      .click()
+      .then(() => {
+        cy.get('input[name="title"').clear().type('Updated Tag');
+        cy.get('form').submit();
+        cy.get('strong').contains('Success!');
+      });
   });
 
   it('adds a new tag', () => {
@@ -18,17 +26,6 @@ describe('tinycms tags', () => {
     cy.get('form')
       .submit()
       .then(() => {
-        cy.get('strong').contains('Success!');
-      });
-  });
-
-  it('updates an existing tag', () => {
-    cy.visit('/tinycms/tags');
-    cy.get('table>tbody>tr:first>td>a')
-      .click()
-      .then(() => {
-        cy.get('input[name="title"').clear().type('Updated Tag');
-        cy.get('form').submit();
         cy.get('strong').contains('Success!');
       });
   });


### PR DESCRIPTION


Closes #868 

Weird, I don't understand what the issue is. That one "Update tags" cypress test keeps failing with a strange error. However, combining the list and update cypress tests works fine. As the update needs to list first anyway, this seems reasonable to me, and runs faster overall than using two separate setups anyway.