### PR TITLE
Use logo on landing page if available

### DIFF
--- a/components/LandingPage.js
+++ b/components/LandingPage.js
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import tw from 'twin.macro';
 import Layout from './Layout';
 import NewsletterBlock from './plugins/NewsletterBlock';
@@ -8,13 +9,39 @@ const Container = tw.div`flex items-center justify-center flex-col min-h-screen 
 const Title = tw.h1`text-6xl font-bold mb-8`;
 const Dek = tw.div`text-xl mb-6`;
 const BlockWrapper = tw.div`w-full`;
+const LogoWrapper = tw.div`w-full h-auto mb-4`;
+const Logo = tw.div`w-full h-auto`;
 
 export default function LandingPage({ siteMetadata, sections, pages }) {
   let landingDek = siteMetadata.landingPageDek || siteMetadata.aboutDek;
+
+  let title;
+  let logo;
+  if (siteMetadata) {
+    title = siteMetadata['shortName'];
+    logo = siteMetadata['logo'];
+  }
+
+  let LogoComponent;
+  if (logo) {
+    const logoUrl = new URL(logo);
+
+    LogoComponent = (
+      <LogoWrapper>
+        <Logo>
+          <img
+            src={`https://assets.tinynewsco.org${logoUrl.pathname}`}
+            alt={title}
+          />
+        </Logo>
+      </LogoWrapper>
+    );
+  }
+
   return (
     <Layout meta={siteMetadata} sections={sections} renderNav={false}>
       <Container>
-        <Title>{siteMetadata.shortName}</Title>
+        {logo ? LogoComponent : <Title>{title}</Title>}
         <Dek className="dek" dangerouslySetInnerHTML={{ __html: landingDek }} />
         <BlockWrapper>
           <NewsletterBlock metadata={siteMetadata} />


### PR DESCRIPTION
A couple notes:

- I didn't use next/image because both the width and height are unknown, and I couldn't get all the styles to play correctly with how next/image makes you handle that.
- I am stripping the hostname off the URL and hardcoding `assets.tinynewsco.org`. I opened #873 to note we should put the Cloudfront-backed URL in the database, but I added this in case we launch Harvey World before that is implemented.