### PR TITLE
fixes json parse error by not trying to call parse on undefined values

### DIFF
--- a/components/plugins/DonationOptionsBlock.js
+++ b/components/plugins/DonationOptionsBlock.js
@@ -56,7 +56,7 @@ export default function DonationOptionsBlock({ metadata, wrap = true }) {
   try {
     parsedOptions = JSON.parse(metadata.donationOptions);
   } catch (e) {
-    console.error(e);
+    console.log(e);
   }
 
   const block = parsedOptions

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -258,10 +258,14 @@ export default function SiteInfoSettings(props) {
   const [defaultSocialImage, setDefaultSocialImage] = useState(
     props.parsedData['defaultSocialImage']
   );
+  let parsedDonationOptions;
+  try {
+    parsedDonationOptions = JSON.parse(props.parsedData['donationOptions']);
+  } catch (e) {
+    console.error('Failed to parse donation options json:', e);
+  }
   const [donationOptions, setDonationOptions] = useState(
-    props.parsedData['donationOptions']
-      ? JSON.parse(props.parsedData['donationOptions'])
-      : null
+    props.parsedData['donationOptions'] ? parsedDonationOptions : null
   );
 
   const handleAboutDekEditorChange = (value) => {
@@ -349,10 +353,14 @@ export default function SiteInfoSettings(props) {
     setFounderTwitter(props.parsedData['founderTwitter']);
     setFounderInstagram(props.parsedData['founderInstagram']);
     setFounderFacebook(props.parsedData['founderFacebook']);
+    let parsedDonationOptions;
+    try {
+      parsedDonationOptions = JSON.parse(props.parsedData['donationOptions']);
+    } catch (e) {
+      console.error('Failed to parse donation options json:', e);
+    }
     setDonationOptions(
-      props.parsedData['donationOptions']
-        ? JSON.parse(props.parsedData['donationOptions'])
-        : null
+      props.parsedData['donationOptions'] ? parsedDonationOptions : null
     );
     setLogo(props.parsedData['logo']);
     setFavicon(props.parsedData['favicon']);

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -262,7 +262,7 @@ export default function SiteInfoSettings(props) {
   try {
     parsedDonationOptions = JSON.parse(props.parsedData['donationOptions']);
   } catch (e) {
-    console.error('Failed to parse donation options json:', e);
+    console.log('Failed to parse donation options json:', e);
   }
   const [donationOptions, setDonationOptions] = useState(
     props.parsedData['donationOptions'] ? parsedDonationOptions : null
@@ -357,7 +357,7 @@ export default function SiteInfoSettings(props) {
     try {
       parsedDonationOptions = JSON.parse(props.parsedData['donationOptions']);
     } catch (e) {
-      console.error('Failed to parse donation options json:', e);
+      console.log('Failed to parse donation options json:', e);
     }
     setDonationOptions(
       props.parsedData['donationOptions'] ? parsedDonationOptions : null


### PR DESCRIPTION
While trying to recreate the issue in #872 I noticed a JSON parse error on the Harvey World Herald settings page (at least) that may be related. This fixes the JSON error.