### PR TITLE
bugfix: assign static values for all editors conditionally, fixes bla…

### DIFF
--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -327,6 +327,9 @@ export default function SiteInfoSettings(props) {
     setTwitterDescription(props.parsedData['twitterDescription']);
     setLandingPage(props.parsedData['landingPage']);
     setLandingPageDek(props.parsedData['landingPageDek']);
+    if (!staticLandingPageDek) {
+      setStaticLandingPageDek(props.parsedData['landingPageDek']);
+    }
     setCommenting(props.parsedData['commenting']);
     setShortName(props.parsedData['shortName']);
     setSiteUrl(props.parsedData['siteUrl']);
@@ -334,11 +337,15 @@ export default function SiteInfoSettings(props) {
     setTheme(props.parsedData['theme']);
     setAboutHed(props.parsedData['aboutHed']);
     setAboutDek(props.parsedData['aboutDek']);
-    setStaticAboutDek(props.parsedData['aboutDek']);
+    if (!staticAboutDek) {
+      setStaticAboutDek(props.parsedData['aboutDek']);
+    }
     setAboutCTA(props.parsedData['aboutCTA']);
     setSupportHed(props.parsedData['supportHed']);
     setSupportDek(props.parsedData['supportDek']);
-    setStaticSupportDek(props.parsedData['supportDek']);
+    if (!staticSupportDek) {
+      setStaticSupportDek(props.parsedData['supportDek']);
+    }
     setSupportCTA(props.parsedData['supportCTA']);
     setPrimaryColor(props.parsedData['primaryColor']);
     setSecondaryColor(props.parsedData['secondaryColor']);


### PR DESCRIPTION
…nk data issue while preserving cursor position

Closes #872 

This fixes the blank data issue in the landing dek - and the data issues generally in all the tinymce fields. 

1. each editor gets a static version of the data - the initial value, a copy of the stored state. this allows the state to be updated without losing cursor position
2. the static value is assigned once, only if it's null at render time. otherwise the useEffect will overwrite it when the state changes.

The reason the landing dek was blank and the others were present? I had missed the setup of the landing dek static value in the useEffect hook. 