### PR TITLE
bugfix: displaying author's last name

### DIFF
--- a/components/articles/ArticleFooterAuthor.js
+++ b/components/articles/ArticleFooterAuthor.js
@@ -69,7 +69,7 @@ export default function ArticleFooterAuthor({
           </span>
         </div>
         <AuthorTitle>{authorTitle}</AuthorTitle>
-        <p>{authorBio}</p>
+        <p dangerouslySetInnerHTML={{ __html: authorBio }} />
       </AuthorMeta>
     </AuthorWrapper>
   );

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -54,8 +54,8 @@ export default function EditAuthor({
   const [authorId, setAuthorId] = useState(author.id);
   const [staffYesNo, setStaffYesNo] = useState('no');
 
-  const handleEditorChange = (e) => {
-    setBio(e.target.getContent());
+  const handleEditorChange = (value) => {
+    setBio(value);
   };
 
   useEffect(() => {

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -73,7 +73,7 @@ export default function EditAuthor({
       setFirstNames(author.first_names);
     }
     if (author.last_name) {
-      setLastName(author.last_names);
+      setLastName(author.last_name);
     }
   }, [author]);
 

--- a/pages/tinycms/authors/[id].js
+++ b/pages/tinycms/authors/[id].js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
+import Link from 'next/link';
 import AdminLayout from '../../../components/AdminLayout';
 import AdminNav from '../../../components/nav/AdminNav';
 import tw from 'twin.macro';
@@ -21,6 +22,7 @@ import {
 } from '../../../lib/utils.js';
 
 const UploadContainer = tw.div`container mx-auto min-w-0 flex-auto px-4 sm:px-6 xl:px-8 pt-10`;
+const ArticleAuthorLink = tw.a`font-bold cursor-pointer hover:underline`;
 
 export default function EditAuthor({
   apiUrl,
@@ -180,7 +182,15 @@ export default function EditAuthor({
 
       <FormContainer>
         <FormHeader title="Edit Author" />
-
+        {slug && (
+          <div tw="relative">
+            <p tw="absolute right-0">
+              <Link href={`/authors/${slug}`} key={`${slug}`} passHref>
+                <ArticleAuthorLink>View on site</ArticleAuthorLink>
+              </Link>
+            </p>
+          </div>
+        )}
         <form onSubmit={handleSubmit}>
           <TinyInputField
             name="first_names"

--- a/pages/tinycms/authors/add.js
+++ b/pages/tinycms/authors/add.js
@@ -44,8 +44,8 @@ export default function AddAuthor({
   const [bioImage, setBioImage] = useState('');
   const [displayUpload, setDisplayUpload] = useState(false);
 
-  const handleEditorChange = (e) => {
-    setBio(e.target.getContent());
+  const handleEditorChange = (value) => {
+    setBio(value);
   };
 
   // slugifies the name and stores slug plus name values


### PR DESCRIPTION
Closes #888 

There was a typo on the author last name field in the edit form preventing it from ever being filled out. I fixed that. While I was working on the edit author page, I added a link to view the author index on the site as it seems useful.

The author index page is displaying both first and last names. I think part of the problem was also that I hadn't updated every existing author record after I split the single name field into two (first names + last name), so some authors were lacking both values. I went through all of the Oaklyn authors and made sure both fields were present.