### PR TITLE
Stop auto changing slug when updating existing section

### DIFF
--- a/pages/tinycms/sections/[id].js
+++ b/pages/tinycms/sections/[id].js
@@ -107,7 +107,7 @@ export default function EditSection({
           <TinyInputField
             name="title"
             value={title}
-            onChange={(ev) => updateTitleAndSlug(ev.target.value)}
+            onChange={(ev) => setTitle(ev.target.value)}
             label="Title"
           />
           {slug && (


### PR DESCRIPTION
Relates to #893 

* adding a new section should generate a slug
* updating an existing section should retain the current slug to avoid breaking links