### PR TITLE
bugfix: section lookup needs to filter translations for current locale

### DIFF
--- a/lib/section.js
+++ b/lib/section.js
@@ -65,7 +65,7 @@ const HASURA_INSERT_SECTION = `mutation insert_single_category($locale_code: Str
   }
 }`;
 
-const HASURA_GET_SECTION_BY_ID = `query FrontendGetSectionByID($id: Int!) {
+const HASURA_GET_SECTION_BY_ID = `query FrontendGetSectionByID($id: Int!, $locale_code: String!) {
   organization_locales {
     locale {
       code
@@ -74,7 +74,7 @@ const HASURA_GET_SECTION_BY_ID = `query FrontendGetSectionByID($id: Int!) {
   categories_by_pk(id: $id) {
     id
     published
-    category_translations {
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
     }
     slug
@@ -208,6 +208,7 @@ export function hasuraGetSectionById(params) {
     name: 'FrontendGetSectionByID',
     variables: {
       id: params['id'],
+      locale_code: params['locale_code'],
     },
   });
 }

--- a/pages/tinycms/sections/[id].js
+++ b/pages/tinycms/sections/[id].js
@@ -141,6 +141,7 @@ export async function getServerSideProps(context) {
     url: apiUrl,
     orgSlug: apiToken,
     id: context.params.id,
+    locale_code: context.locale,
   });
   if (errors) {
     throw errors;


### PR DESCRIPTION
While looking into #893 I realized that the "Edit Section" page of the TinyCMS was returning all translations instead of limiting to the current locale, which resulted in the arbitrary first element of the list of translations being used to fill in the form. For instance, sometimes the English edit page was showing me the Spanish section title 🤯

This PR fixes the problem by adding a `where` clause to the section lookup query used on this page, filtering the section's translations to the current locale only.

I also sorted the tinycms section index page by title (it was arbitrary before), added the number of articles in each one, and included a link to view the public facing category index page from both the index and the edit page.