### PR TITLE
Bugfix: don't log newsletter impression on every scroll-into-view

### DIFF
--- a/components/plugins/NewsletterSubscribe.js
+++ b/components/plugins/NewsletterSubscribe.js
@@ -27,16 +27,21 @@ const NewsletterSubscribe = ({ articleTitle, metadata }) => {
   const [status, setStatus] = useState(null);
   const [message, setMessage] = useState(null);
 
+  const [
+    trackedNewsletterImpression,
+    setTrackedNewsletterImpression,
+  ] = useState(false);
   const [redirectURL, setRedirectURL] = useState(metadata.newsletterRedirect);
 
   useEffect(() => {
-    if (inView) {
+    if (inView && !trackedNewsletterImpression) {
       trackEvent({
         action: 'newsletter modal impression 1',
         category: 'NTG newsletter',
         label: articleTitle,
         non_interaction: true,
       });
+      setTrackedNewsletterImpression(true);
     }
 
     let bgc;


### PR DESCRIPTION
Closes #899 

Similar to how the article scroll percentage events are tracked, this stores whether the newsletter impression has been  tracked on a given page, so it is only logged to GA once instead of on every time the component scrolls into view.