### PR TITLE
Look up articles by past category slug versions

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -377,7 +377,17 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query FrontendPreviewArticlePage($slug: Str
 }`;
 
 const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($category_slug: String!, $locale_code: String!, $slug: String!) {
-  article_slug_versions(where: {slug: {_eq: $slug}, article: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}}) {
+  article_slug_versions(
+    where: {
+      slug: {_eq: $slug}, 
+      category_slug: {_eq: $category_slug}
+      article: {
+        article_translations: {
+          locale_code: {_eq: $locale_code}, 
+          published: {_eq: true}
+        }        
+      }
+    }) {
     article {
       article_translations(where: {published: {_eq: true}, locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
         id


### PR DESCRIPTION
Closes https://github.com/news-catalyst/google-app-scripts/issues/357

This is the last step in the above-linked issue: look up an article on the front-end by the current or past category slug.

This means the poetry test article, which has 2 entries in the `article_slug_versions` table:

<img width="774" alt="Screen Shot 2021-10-21 at 2 37 42 pm" src="https://user-images.githubusercontent.com/3397/138207266-6435e869-94e1-47e8-b89f-899e18ded9ea.png">

Will display on both of these URLs:

* http://localhost:3000/articles/top-stories-old/poetry-in-the-rain
* http://localhost:3000/articles/top-stories/poetry-in-the-rain