### PR TITLE
TinyCMS Sections: handling of slugs

### DIFF
--- a/components/nav/AdminNav.js
+++ b/components/nav/AdminNav.js
@@ -52,6 +52,7 @@ export default function NewAdminNav(props) {
                 <LocaleSwitcher
                   currentLocale={props.currentLocale}
                   locales={props.locales}
+                  id={props.id}
                 />
               )}
               <Link href="/tinycms/analytics" passHref>

--- a/components/tinycms/Notification.js
+++ b/components/tinycms/Notification.js
@@ -6,7 +6,7 @@ export default function Notification(props) {
     messages = [props.message];
   }
   let alertBox;
-  console.log('props:', props);
+
   if (props.notificationType === 'success') {
     alertBox = (
       <div tw="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative">

--- a/pages/tinycms/sections/[id].js
+++ b/pages/tinycms/sections/[id].js
@@ -16,7 +16,6 @@ import {
 import AdminNav from '../../../components/nav/AdminNav';
 import Notification from '../../../components/tinycms/Notification';
 import { hasuraLocaliseText } from '../../../lib/utils';
-import { slugify } from '../../../lib/utils';
 
 export default function EditSection({
   apiUrl,
@@ -35,11 +34,6 @@ export default function EditSection({
   );
   const [slug, setSlug] = useState(section.slug);
   const [published, setPublished] = useState(section.published);
-
-  function updateTitleAndSlug(value) {
-    setTitle(value);
-    setSlug(slugify(value));
-  }
 
   function handlePublished(event) {
     const value =
@@ -90,6 +84,7 @@ export default function EditSection({
         locales={locales}
         homePageEditor={false}
         showConfigOptions={true}
+        id={sectionId}
       />
 
       {showNotification && (
@@ -110,9 +105,17 @@ export default function EditSection({
             onChange={(ev) => setTitle(ev.target.value)}
             label="Title"
           />
-          {slug && (
+          {currentLocale === 'en-US' && (
+            <TinyInputField
+              name="slug"
+              value={slug}
+              onChange={(ev) => setSlug(ev.target.value)}
+              label="URL Slug"
+            />
+          )}
+          {currentLocale !== 'en-US' && (
             <label>
-              <UrlSlugLabel>URL Slug</UrlSlugLabel>
+              <UrlSlugLabel>URL Slug (edit in English)</UrlSlugLabel>
               <UrlSlugValue>{slug}</UrlSlugValue>
             </label>
           )}


### PR DESCRIPTION
Closes #893 (finally, I think!)

This should do it for the section slug handling:

1. The section slug is editable in english in the TinyCMS
2. in the Edit Section form, it's a regular text input field, the value is not derived automatically from the title 
3. in the Add Section form, it's automatically derived from the title
4. The section slug, once set, cannot be edited in other languages
5. Changing the slug in english changes it for all languages (they all use the same value for the slug, the title is translated)

What may prevent this PR from being the end of the story: 

* should saving the "edit section" form after changing the "slug" value kick off a site rebuild?
* should this also trigger a lookup of all articles in the section, and store the new article slug + section slug as entries in the article_slug_versions table?

