### PR TITLE
Hardcoded static pages need fallback to support new translations

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -1,11 +1,19 @@
 import { useAmp } from 'next/amp';
+import { useRouter } from 'next/router';
 import { hasuraGetPage } from '../lib/articles.js';
 import { hasuraLocaliseText } from '../lib/utils';
 import AboutPage from '../components/AboutPage';
 
 export default function About(props) {
   const isAmp = useAmp();
+  const router = useRouter();
 
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
   return <AboutPage {...props} isAmp={isAmp} />;
 }
 
@@ -31,6 +39,8 @@ export async function getStaticProps({ locale }) {
     // throw errors;
   } else {
     if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      console.log('Returning a 404 - page slug version not found:', data);
+      console.log(JSON.stringify(data.pages));
       return {
         notFound: true,
       };

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -1,5 +1,6 @@
 import { useAmp } from 'next/amp';
 import tw from 'twin.macro';
+import { useRouter } from 'next/router';
 import { hasuraGetPage } from '../lib/articles.js';
 import { hasuraLocaliseText } from '../lib/utils';
 import Layout from '../components/Layout';
@@ -25,6 +26,14 @@ export default function Donate({
   locale,
 }) {
   const isAmp = useAmp();
+  const router = useRouter();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
 
   // there will only be one translation returned for a given page + locale
   const localisedPage = page.page_translations[0];
@@ -77,12 +86,17 @@ export async function getStaticProps({ locale }) {
     localeCode: locale,
   });
   if (errors || !data) {
+    console.log('Returning a 404 - errors:', errors);
+    console.log('Returning a 404 - data:', data);
+
     return {
       notFound: true,
     };
     // throw errors;
   } else {
     if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      console.log('Returning a 404 - page slug version not found:', data);
+      console.log(JSON.stringify(data.pages));
       return {
         notFound: true,
       };

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -1,5 +1,6 @@
 import { useAmp } from 'next/amp';
 import tw from 'twin.macro';
+import { useRouter } from 'next/router';
 import { hasuraGetPage } from '../lib/articles.js';
 import { useAnalytics } from '../lib/hooks/useAnalytics.js';
 import { hasuraLocaliseText } from '../lib/utils';
@@ -26,9 +27,18 @@ export default function ThankYou({
   locale,
 }) {
   const isAmp = useAmp();
-
+  const router = useRouter();
   // sets a cookie if request comes from monkeypod.io marking this browser as a donor
   const { checkReferrer, trackEvent } = useAnalytics();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  if (router.isFallback) {
+    console.log('router.isFallback on thank you page');
+    return <div>Loading...</div>;
+  }
+
   // this will return true if the request came from monkeypod, false otherwise
   let isDonor = checkReferrer(referrer);
   if (isDonor) {
@@ -133,7 +143,6 @@ export async function getServerSideProps(context) {
       siteMetadata,
       locales,
       locale,
-      revalidate: 1,
     },
   };
 }


### PR DESCRIPTION
Closes #913 

I think the hardcoded pages for `about`, `donate` and `thank-you` lacking the `router.isFallback` prevents each route from rendering a new translation once published.

This PR adds the fallback handling to these three templates. The next.js docs say the fallback check will work for this scenario, I think: "If the page is not yet generated, this will be displayed initially until getStaticProps() finishes running"

I tested this locally by building the site and running with `npm run start` then publishing a tagalog version of thank you; the page went from 404 to rendering after I published without rebuilding or restarting.