### PR TITLE
Disables links in preview blocks in the tinycms settings

### DIFF
--- a/components/homepage/HomepagePromoBar.js
+++ b/components/homepage/HomepagePromoBar.js
@@ -33,17 +33,19 @@ const BlockDek = styled.div(({ meta }) => ({
   ...tw`text-base mb-3`,
   fontFamily: Typography[meta.theme || 'styleone'].HomepagePromoBlockDek,
 }));
-const BlockCTA = styled.a(({ meta }) => ({
+const BlockCTA = styled.a(({ meta, tinycms }) => ({
   ...tw`text-base font-bold cursor-pointer hover:underline`,
   fontFamily: Typography[meta.theme || 'styleone'].HomepagePromoBlockCTA,
+  pointerEvents: tinycms ? 'none' : '',
   color:
     meta.color === 'custom'
       ? meta.primaryColor
       : Colors[meta.color ? meta.color : 'colorone'].CTABackground,
 }));
-const DonateBlockCTA = styled.a(({ meta }) => ({
+const DonateBlockCTA = styled.a(({ meta, tinycms }) => ({
   ...tw`inline-flex text-base font-bold cursor-pointer items-center px-5 hover:underline`,
   fontFamily: Typography[meta.theme || 'styleone'].HomepagePromoBlockCTA,
+  pointerEvents: tinycms ? 'none' : '',
   color:
     meta.color === 'custom'
       ? determineTextColor(meta.primaryColor)
@@ -54,7 +56,8 @@ const DonateBlockCTA = styled.a(({ meta }) => ({
       : Colors[meta.color || 'colorone'].CTABackground,
 }));
 
-export default function HomepagePromoBar({ metadata }) {
+export default function HomepagePromoBar({ metadata, tinycms }) {
+  console.log('homepage promo bar tinycms:', tinycms);
   return (
     <SectionLayout meta={metadata}>
       <SectionContainer>
@@ -65,7 +68,9 @@ export default function HomepagePromoBar({ metadata }) {
             dangerouslySetInnerHTML={{ __html: metadata.aboutDek }}
           />
           <Link href="/about" passHref>
-            <BlockCTA meta={metadata}>{metadata.aboutCTA}</BlockCTA>
+            <BlockCTA meta={metadata} tinycms={tinycms}>
+              {metadata.aboutCTA}
+            </BlockCTA>
           </Link>
         </LeftBlock>
         <RightBlock>
@@ -80,6 +85,7 @@ export default function HomepagePromoBar({ metadata }) {
                 minHeight: '2.375rem',
               }}
               meta={metadata}
+              tinycms={tinycms}
             >
               {metadata.supportCTA}
             </DonateBlockCTA>

--- a/components/plugins/DonationBlock.js
+++ b/components/plugins/DonationBlock.js
@@ -21,14 +21,17 @@ const DonationDek = styled.div(({ meta }) => ({
   ...tw`mb-6`,
   fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
 }));
-const DonateLink = styled.a(({ textColor, backgroundColor, meta }) => ({
-  ...tw`py-2 px-4 font-bold cursor-pointer hover:underline`,
-  backgroundColor: backgroundColor,
-  color: textColor,
-  fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockCTA,
-}));
+const DonateLink = styled.a(
+  ({ textColor, backgroundColor, meta, tinycms }) => ({
+    ...tw`py-2 px-4 font-bold cursor-pointer hover:underline`,
+    backgroundColor: backgroundColor,
+    pointerEvents: tinycms ? 'none' : '',
+    color: textColor,
+    fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockCTA,
+  })
+);
 
-export default function DonationBlock({ metadata }) {
+export default function DonationBlock({ metadata, tinycms }) {
   const [textColor, setTextColor] = useState(null);
   const [backgroundColor, setBackgroundColor] = useState(null);
   const { trackEvent } = useAnalytics();
@@ -69,6 +72,7 @@ export default function DonationBlock({ metadata }) {
           backgroundColor={textColor}
           meta={metadata}
           onClick={trackClick}
+          tinycms={tinycms}
           style={{
             minHeight: '2.375rem',
           }}

--- a/components/plugins/DonationOptionsBlock.js
+++ b/components/plugins/DonationOptionsBlock.js
@@ -23,14 +23,21 @@ const CardDonationDescription = styled.div(({ meta }) => ({
   fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
 }));
 const CardFooter = tw.footer`border-t border-gray-200 mt-4`;
-const DonateFooterLink = styled.a(({ meta, backgroundColor, textColor }) => ({
-  ...tw`items-center justify-center flex font-bold w-full py-4 h-full`,
-  fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
-  color: textColor,
-  backgroundColor: backgroundColor,
-}));
+const DonateFooterLink = styled.a(
+  ({ meta, backgroundColor, textColor, tinycms }) => ({
+    ...tw`items-center justify-center flex font-bold w-full py-4 h-full`,
+    fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
+    color: textColor,
+    pointerEvents: tinycms ? 'none' : '',
+    backgroundColor: backgroundColor,
+  })
+);
 
-export default function DonationOptionsBlock({ metadata, wrap = true }) {
+export default function DonationOptionsBlock({
+  metadata,
+  tinycms,
+  wrap = true,
+}) {
   const [textColor, setTextColor] = useState(null);
   const [backgroundColor, setBackgroundColor] = useState(null);
 
@@ -87,6 +94,7 @@ export default function DonationOptionsBlock({ metadata, wrap = true }) {
             meta={metadata}
             backgroundColor={backgroundColor}
             textColor={textColor}
+            tinycms={tinycms}
           >
             {option.cta}
           </DonateFooterLink>

--- a/components/plugins/NewsletterBlock.js
+++ b/components/plugins/NewsletterBlock.js
@@ -20,7 +20,7 @@ const NewsletterDek = styled.div(({ meta }) => ({
   fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
 }));
 
-export default function NewsletterBlock({ metadata, headline }) {
+export default function NewsletterBlock({ metadata, headline, tinycms }) {
   const [textColor, setTextColor] = useState(null);
   const [backgroundColor, setBackgroundColor] = useState(null);
 
@@ -46,7 +46,11 @@ export default function NewsletterBlock({ metadata, headline }) {
         dangerouslySetInnerHTML={{ __html: metadata.newsletterDek }}
       />
       <br />
-      <NewsletterSubscribe metadata={metadata} articleTitle={headline} />
+      <NewsletterSubscribe
+        metadata={metadata}
+        articleTitle={headline}
+        tinycms={tinycms}
+      />
     </NewsletterWrapper>
   );
 }

--- a/components/plugins/NewsletterSubscribe.js
+++ b/components/plugins/NewsletterSubscribe.js
@@ -7,15 +7,16 @@ import Colors from '../common/Colors';
 
 const Group = tw.div`relative`;
 const Input = tw.input`block w-full border-b border-gray-500 opacity-70 text-black font-bold`;
-const Submit = styled.input(({ textColor, backgroundColor }) => ({
+const Submit = styled.input(({ textColor, backgroundColor, tinycms }) => ({
   ...tw`block absolute cursor-pointer rounded-full font-bold leading-none w-8 h-8 pl-2 right-2 z-10`,
   backgroundColor: backgroundColor,
   color: textColor,
+  pointerEvents: tinycms ? 'none' : '',
 }));
 
 const url = '/api/subscribe';
 
-const NewsletterSubscribe = ({ articleTitle, metadata }) => {
+const NewsletterSubscribe = ({ articleTitle, metadata, tinycms }) => {
   const { trackEvent } = useAnalytics();
   const [ref, inView] = useInView({ triggerOnce: true });
 
@@ -162,6 +163,7 @@ const NewsletterSubscribe = ({ articleTitle, metadata }) => {
                 }}
                 textColor={textColor}
                 backgroundColor={backgroundColor}
+                tinycms={tinycms}
               />
             </Group>
           )}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -746,7 +746,7 @@ export default function SiteInfoSettings(props) {
       </HomepagePromoContainer>
       <div>
         <span tw="mt-1 font-bold">Preview</span>
-        <HomepagePromoBar metadata={props.parsedData} />
+        <HomepagePromoBar metadata={props.parsedData} tinycms={true} />
       </div>
       <NewsletterContainer ref={props.newsletterRef} id="newsletter">
         <SettingsHeader tw="col-span-3 mt-5">
@@ -784,7 +784,7 @@ export default function SiteInfoSettings(props) {
         <div tw="col-span-1">
           <span tw="mt-1 font-bold">Preview</span>
 
-          <NewsletterBlock metadata={props.parsedData} />
+          <NewsletterBlock metadata={props.parsedData} tinycms={true} />
         </div>
       </NewsletterContainer>
 
@@ -824,7 +824,7 @@ export default function SiteInfoSettings(props) {
         <div tw="col-span-1">
           <span tw="mt-1 font-bold">Preview</span>
 
-          <DonationBlock metadata={props.parsedData} />
+          <DonationBlock metadata={props.parsedData} tinycms={true} />
         </div>
       </MembershipContainer>
 
@@ -887,7 +887,7 @@ export default function SiteInfoSettings(props) {
 
       <DonationOptionsContainer>
         <span tw="mt-1 font-bold">Preview</span>
-        <DonationOptionsBlock metadata={props.parsedData} />
+        <DonationOptionsBlock metadata={props.parsedData} tinycms={true} />
       </DonationOptionsContainer>
 
       <SeoContainer ref={props.seoRef}>


### PR DESCRIPTION
Closes #915 

Each of these components now takes a `tinycms` flag - if set, the link gets a `pointer-events: none` applied to it.