### PR TITLE
Display a house ad if advertising store is turned on and no ads in API

### DIFF
--- a/components/ads/AdPromotion.js
+++ b/components/ads/AdPromotion.js
@@ -11,7 +11,7 @@ const AdPromotionWrapper = styled.div(({ textColor, backgroundColor }) => ({
 }));
 
 const AdPromotionHed = tw.h4`text-2xl font-bold tracking-tight leading-5 mb-2`;
-const AdPromotionDek = tw.p`mb-6`;
+const AdPromotionDek = tw.div`mb-6`;
 
 export default function AdPromotionBlock({ metadata }) {
   const [textColor, setTextColor] = useState(null);
@@ -21,8 +21,8 @@ export default function AdPromotionBlock({ metadata }) {
     let bgc;
     let tc;
     if (metadata.color === 'custom') {
-      bgc = metadata.primaryColor;
-      tc = determineTextColor(metadata.primaryColor);
+      bgc = metadata.secondaryColor;
+      tc = determineTextColor(metadata.secondaryColor);
     } else if (Colors[metadata.color]) {
       tc = Colors[metadata.color].PromoBlockText;
       bgc = Colors[metadata.color].PromoBlockBackground;
@@ -33,9 +33,11 @@ export default function AdPromotionBlock({ metadata }) {
 
   return (
     <AdPromotionWrapper textColor={textColor} backgroundColor={backgroundColor}>
-      <AdPromotionHed>Advertise with us</AdPromotionHed>
-      <AdPromotionDek>Click here to contact us.</AdPromotionDek>
-      <Advertise metadata={metadata} label="Advertise" />
+      <AdPromotionHed>{metadata.advertisingHed}</AdPromotionHed>
+      <AdPromotionDek
+        dangerouslySetInnerHTML={{ __html: metadata.advertisingDek }}
+      />
+      <Advertise metadata={metadata} label={metadata.advertisingCTA} />
     </AdPromotionWrapper>
   );
 }

--- a/components/nav/Advertise.js
+++ b/components/nav/Advertise.js
@@ -6,7 +6,7 @@ import Typography from '../common/Typography';
 import Colors from '../common/Colors';
 
 const AdvertiseLink = styled.a(({ meta }) => ({
-  ...tw`items-center flex font-bold leading-none px-5 ml-5 order-2 lg:ml-0 lg:order-none`,
+  ...tw`inline-flex text-base font-bold cursor-pointer items-center px-5 hover:underline`,
   fontFamily: Typography[meta.theme].AdvertiseLink,
   backgroundColor:
     meta.color === 'custom'
@@ -25,7 +25,7 @@ const Advertise = ({ label, metadata }) => {
     trackEvent({
       action: 'Clicked',
       category: 'Advertise',
-      label: 'Global Nav',
+      label: 'Article promotion',
       non_interaction: false,
     });
   };
@@ -34,10 +34,9 @@ const Advertise = ({ label, metadata }) => {
       style={{
         minHeight: '2.375rem',
       }}
-      className="site__cta button Advertise"
       onClick={trackClick}
       meta={metadata}
-      href="https://store.tryletterhead.com/catalyst-test"
+      href={process.env.NEXT_PUBLIC_LETTERHEAD_ADVERTISING_STORE}
     >
       {label}
     </AdvertiseLink>

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -3,6 +3,7 @@ import tw, { css, styled } from 'twin.macro';
 import DonationBlock from '../plugins/DonationBlock';
 import NewsletterBlock from '../plugins/NewsletterBlock';
 import HomepagePromoBar from '../homepage/HomepagePromoBar';
+import AdPromotion from '../ads/AdPromotion';
 import DonationOptionsBlock from '../plugins/DonationOptionsBlock';
 import ControlledInput from './ControlledInput';
 import Upload from './Upload';
@@ -13,6 +14,7 @@ const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
 const SeoContainer = tw.div``;
 const DesignContainer = tw.div`grid grid-cols-2 gap-4`;
 const MembershipContainer = tw.div`grid grid-cols-2 gap-8`;
+const AdvertisingContainer = tw.div`grid grid-cols-2 gap-8`;
 const NewsletterContainer = tw.div`grid grid-cols-2 gap-8`;
 const HomepagePromoContainer = tw.div`grid grid-cols-2 gap-8`;
 const DonationOptionsEditor = tw.div`grid grid-cols-3 gap-4`;
@@ -253,6 +255,19 @@ export default function SiteInfoSettings(props) {
     props.parsedData['newsletterDek']
   );
 
+  const [advertisingHed, setAdvertisingHed] = useState(
+    props.parsedData['advertisingHed']
+  );
+  const [advertisingDek, setAdvertisingDek] = useState(
+    props.parsedData['advertisingDek']
+  );
+  const [staticAdvertisingDek, setStaticAdvertisingDek] = useState(
+    props.parsedData['advertisingDek']
+  );
+  const [advertisingCTA, setAdvertisingCTA] = useState(
+    props.parsedData['advertisingCTA']
+  );
+
   const [logo, setLogo] = useState(props.parsedData['logo']);
   const [favicon, setFavicon] = useState(props.parsedData['favicon']);
   const [defaultSocialImage, setDefaultSocialImage] = useState(
@@ -314,6 +329,15 @@ export default function SiteInfoSettings(props) {
     }));
   };
 
+  const handleAdvertisingDekChange = (value) => {
+    setAdvertisingDek(value);
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['advertisingDek']: value,
+    }));
+  };
+
   useEffect(() => {
     setTimeZone(props.parsedData['timeZone']);
     setSiteTwitter(props.parsedData['siteTwitter']);
@@ -347,13 +371,19 @@ export default function SiteInfoSettings(props) {
       setStaticSupportDek(props.parsedData['supportDek']);
     }
     setSupportCTA(props.parsedData['supportCTA']);
+    setAdvertisingHed(props.parsedData['advertisingHed']);
+    setAdvertisingDek(props.parsedData['advertisingDek']);
+    if (!staticAdvertisingDek) {
+      setStaticAdvertisingDek(props.parsedData['advertisingDek']);
+    }
+    setAdvertisingCTA(props.parsedData['advertisingCTA']);
     setPrimaryColor(props.parsedData['primaryColor']);
     setSecondaryColor(props.parsedData['secondaryColor']);
     setMembershipDek(props.parsedData['membershipDek']);
 
     setMembershipHed(props.parsedData['membershipHed']);
-    if (props.parsedData['newsletterDek']) {
-      setNewsletterDek(props.parsedData['newsletterDek']);
+    if (!staticNewsletterDek) {
+      setStaticNewsletterDek(props.parsedData['newsletterDek']);
     }
     setNewsletterHed(props.parsedData['newsletterHed']);
     setNewsletterRedirect(props.parsedData['newsletterRedirect']);
@@ -827,6 +857,52 @@ export default function SiteInfoSettings(props) {
           <DonationBlock metadata={props.parsedData} tinycms={true} />
         </div>
       </MembershipContainer>
+
+      <AdvertisingContainer ref={props.advertisingRef} id="advertising">
+        <SettingsHeader tw="col-span-3 mt-5 mb-0 leading-none">
+          Advertising promotion block
+        </SettingsHeader>
+        <p tw="col-span-3 mt-0 mb-2">
+          <em>
+            Note: this promotion block will only appear if you have launched
+            your Letterhead advertising store.
+          </em>
+        </p>
+
+        <div tw="col-span-1">
+          <label htmlFor="heading">
+            <span tw="w-full mt-1 font-bold">Heading</span>
+            <ControlledInput
+              type="text"
+              name="advertisingHed"
+              value={advertisingHed}
+              onChange={props.handleChange}
+            />
+          </label>
+          <label htmlFor="description">
+            <span tw="mt-1 font-bold">Description</span>
+            <TinyEditor
+              tinyApiKey={props.tinyApiKey}
+              setValue={handleAdvertisingDekChange}
+              value={staticAdvertisingDek}
+            />
+          </label>
+          <label htmlFor="CTA">
+            <span tw="mt-1 font-bold">CTA</span>
+            <ControlledInput
+              type="text"
+              name="advertisingCTA"
+              value={advertisingCTA}
+              onChange={props.handleChange}
+            />
+          </label>
+        </div>
+        <div tw="col-span-1">
+          <span tw="mt-1 font-bold">Preview</span>
+
+          <AdPromotion metadata={props.parsedData} tinycms={true} />
+        </div>
+      </AdvertisingContainer>
 
       <DonationOptionsEditor ref={props.paymentRef} id="payment-options">
         <SettingsHeader tw="col-span-3 mt-5">Payment options</SettingsHeader>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,7 +269,7 @@ export const renderBody = (translations, ads, isAmp, metadata) => {
         break;
     }
 
-    if (!metadata.shortName === 'Tiny News Curriculum') {
+    if (process.env.NEXT_PUBLIC_LETTERHEAD_ADVERTISING_STORE) {
       // place an ad every n nodes until we run out of ads
       if (i > 0 && i % adPlacement === 0 && ads.length === 0 && adIndex === 0) {
         adIndex = adIndex + 1;

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -59,6 +59,7 @@ export default function Settings({
   const homepagePromoRef = useRef();
   const newsletterRef = useRef();
   const membershipRef = useRef();
+  const advertisingRef = useRef();
   const paymentRef = useRef();
   const seoRef = useRef();
   const [message, setMessage] = useState(null);
@@ -150,6 +151,13 @@ export default function Settings({
     } else if (window.location.hash && window.location.hash === '#membership') {
       if (membershipRef) {
         membershipRef.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else if (
+      window.location.hash &&
+      window.location.hash === '#advertising'
+    ) {
+      if (advertisingRef) {
+        advertisingRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     } else if (window.location.hash && window.location.hash === '#seo') {
       if (seoRef) {
@@ -320,6 +328,11 @@ export default function Settings({
                   </Link>
                 </li>
                 <li>
+                  <Link href="/tinycms/settings#advertising">
+                    <a>Advertising Block</a>
+                  </Link>
+                </li>
+                <li>
                   <Link href="/tinycms/settings#payment-options">
                     <a>Payment options</a>
                   </Link>
@@ -357,6 +370,7 @@ export default function Settings({
                 seoRef={seoRef}
                 newsletterRef={newsletterRef}
                 membershipRef={membershipRef}
+                advertisingRef={advertisingRef}
                 designRef={designRef}
                 homepagePromoRef={homepagePromoRef}
                 paymentRef={paymentRef}

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -497,13 +497,16 @@ async function createOrganization(opts) {
               donateBlockHed: 'Donate',
               secondaryColor: '#002c57',
               donationOptions:
-                '[{\n"amount": 5,\n"name": "Member",\n"description": "This is a description."\n},\n{\n"amount": 10,\n"name": "Supporter",\n"description": "This is a description."\n},\n{\n"amount": 20,\n"name": "Superuser",\n"description": "This is a description."\n}]',
+                '[{\n"amount": 5,\n"name": "Member",\n"description": "This is a description.",\n"cta": "Donate"\n},\n{\n"amount": 10,\n"name": "Supporter",\n"description": "This is a description.",\n"cta": "Donate"\n},\n{\n"amount": 20,\n"name": "Superuser",\n"description": "This is a description.",\n"cta": "Donate"\n}]',
               footerBylineLink: url,
               footerBylineName: name,
               searchDescription: 'Page description',
               twitterDescription: 'Twitter description',
               facebookDescription: 'Facebook description',
               commenting: 'on',
+              advertisingHed: `Advertise with ${name}`,
+              advertisingDek: 'Want to reach our engaged, connected audience? Advertise within our weekly newsletter!',
+              advertisingCTA: 'Buy an advertisement',
             };
 
             locales.map((locale) => {


### PR DESCRIPTION
This displays a house ad if the advertising store is turned on (via an env var: `NEXT_PUBLIC_LETTERHEAD_ADVERTISING_STORE`). The house ad language is configurable via the TinyCMS settings.

While setting this up, I also fixed #922.

Example:
<img width="718" alt="Screen Shot 2021-10-28 at 1 18 43 PM" src="https://user-images.githubusercontent.com/1077075/139304099-fe326f7c-3d6b-44e9-8436-436c4f5ca526.png">

