### PR TITLE
Support one-time donations, fix small style issues

### DIFF
--- a/components/plugins/DonationOptionsBlock.js
+++ b/components/plugins/DonationOptionsBlock.js
@@ -6,7 +6,7 @@ import { determineTextColor } from '../../lib/utils';
 import { useEffect, useState } from 'react';
 
 const OptionsBlockContainer = tw.div`md:flex md:grid-cols-3 md:gap-4`;
-const Card = tw.div`rounded overflow-hidden shadow-lg w-full border-gray-200 border my-8 md:my-0`;
+const Card = tw.div`rounded overflow-hidden shadow-lg w-full border-gray-200 border my-8 md:my-0 relative`;
 const CardHeader = tw.header`border-b border-gray-200 pb-4 mb-4`;
 const CardHeading = styled.h4(({ meta }) => ({
   ...tw`text-2xl leading-none font-bold text-center px-8 pt-4`,
@@ -18,14 +18,15 @@ const CardDonationAmount = styled.h5(({ meta }) => ({
   fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
 }));
 const PerMonth = tw.span`text-sm`;
+const OneTimePayment = tw.p`text-sm text-center`;
 const CardDonationDescription = styled.div(({ meta }) => ({
   ...tw`text-lg mt-8`,
   fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
 }));
-const CardFooter = tw.footer`border-t border-gray-200 mt-4`;
+const CardFooter = tw.footer`mt-4`;
 const DonateFooterLink = styled.a(
   ({ meta, backgroundColor, textColor, tinycms }) => ({
-    ...tw`items-center justify-center flex font-bold w-full py-4 h-full`,
+    ...tw`items-center justify-center flex font-bold w-full py-4 absolute bottom-0`,
     fontFamily: Typography[meta.theme || 'styleone'].PromotionBlockDek,
     color: textColor,
     pointerEvents: tinycms ? 'none' : '',
@@ -77,8 +78,11 @@ export default function DonationOptionsBlock({
           <div className="content">
             <CardDonationAmount meta={metadata}>
               ${option.amount}
-              <PerMonth>/month</PerMonth>
+              {option.paymentType === 'monthly' && <PerMonth>/month</PerMonth>}
             </CardDonationAmount>
+            {option.paymentType === 'one-time' && (
+              <OneTimePayment>One-time payment</OneTimePayment>
+            )}
             <CardDonationDescription meta={metadata}>
               {option.description}
             </CardDonationDescription>
@@ -90,7 +94,7 @@ export default function DonationOptionsBlock({
           }}
         >
           <DonateFooterLink
-            href={`${process.env.NEXT_PUBLIC_MONKEYPOD_URL}&option_id=${process.env.NEXT_PUBLIC_MONKEYPOD_UUID}&amount=${option.amount}`}
+            href={`${process.env.NEXT_PUBLIC_MONKEYPOD_URL}?option_id=${option.monkeypodId}`}
             meta={metadata}
             backgroundColor={backgroundColor}
             textColor={textColor}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -857,6 +857,28 @@ export default function SiteInfoSettings(props) {
                   />
                 </label>
               </div>
+              <div tw="mt-2 mb-8">
+                <label>
+                  <input
+                    type="radio"
+                    name={`donationOptions-${i}-paymentType`}
+                    value="monthly"
+                    checked={option.paymentType === 'monthly'}
+                    onChange={props.handleChange}
+                  />
+                  <span tw="p-2 mt-1 font-bold">Monthly</span>
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name={`donationOptions-${i}-paymentType`}
+                    value="one-time"
+                    checked={option.paymentType === 'one-time'}
+                    onChange={props.handleChange}
+                  />
+                  <span tw="p-2 mt-1 font-bold">One-time payment</span>
+                </label>
+              </div>
               <div tw="mt-2">
                 <label htmlFor={`donationOptions-${i}-description`}>
                   <span tw="mt-1 font-bold">Option Description</span>
@@ -877,6 +899,18 @@ export default function SiteInfoSettings(props) {
                     type="text"
                     name={`donationOptions-${i}-cta`}
                     value={option.cta}
+                    onChange={props.handleChange}
+                  />
+                </label>
+              </div>
+              <div tw="mt-2">
+                <label htmlFor={`donationOptions-${i}-monkeypodId`}>
+                  <span tw="mt-1 font-bold">Option MonkeyPod ID</span>
+                  <ControlledInput
+                    tw="w-full rounded-md border-solid border-gray-300"
+                    type="text"
+                    name={`donationOptions-${i}-monkeypodId`}
+                    value={option.monkeypodId}
                     onChange={props.handleChange}
                   />
                 </label>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -1,5 +1,5 @@
 import { useAmp } from 'next/amp';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 import { useRouter } from 'next/router';
 import { hasuraGetPage } from '../lib/articles.js';
 import { hasuraLocaliseText } from '../lib/utils';
@@ -17,6 +17,10 @@ import {
 } from '../components/common/CommonStyles.js';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+const WideContainer = styled.div(() => ({
+  ...tw`px-5 md:px-12 mx-auto w-full`,
+  maxWidth: '1280px',
+}));
 
 export default function Donate({
   page,
@@ -54,9 +58,11 @@ export default function Donate({
           <PostText>
             <PostTextContainer>{body}</PostTextContainer>
           </PostText>
-          <DonationOptionsBlock metadata={siteMetadata} wrap={true} />
         </article>
       </SectionContainer>
+      <WideContainer>
+        <DonationOptionsBlock metadata={siteMetadata} wrap={true} />
+      </WideContainer>
       {locales.length > 1 && (
         <SectionLayout>
           <SectionContainer>


### PR DESCRIPTION
This supports one-time donations instead of only monthly by adding a radio selection between the two options. This also means we have to provide the MonkeyPod option ID per donation option for deep linking to work correctly. 