### PR TITLE
retrieve and prefer custom canonical url if set on articles

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -56,6 +56,11 @@ export default function Layout({
     siteTwitter: meta['siteTwitter'],
   };
 
+  // override default canonical url if there's one specified on the article
+  if (article && article.canonical_url) {
+    metaValues['canonical'] = article.canonical_url;
+  }
+
   let pageTitle = meta['homepageTitle'];
 
   let author;

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -336,6 +336,7 @@ const HASURA_PREVIEW_ARTICLE_PAGE = `query FrontendPreviewArticlePage($slug: Str
         title
       }
     }
+    canonical_url
     slug
     author_articles {
       author {
@@ -426,6 +427,7 @@ const HASURA_ARTICLE_PAGE_SLUG_VERSION = `query FrontendArticlePageSlugVersion($
           title
         }
       }
+      canonical_url
       slug
       author_articles {
         author {


### PR DESCRIPTION
Closes https://github.com/news-catalyst/google-app-scripts/issues/365

Uses the article-specific canonical url, if set, in the `Layout` component. Queries for the public and preview article pages are updated to include this value.