### PR TITLE
Updates unique constraint on inserting authors to new org-specific key

### DIFF
--- a/lib/authors.js
+++ b/lib/authors.js
@@ -25,7 +25,7 @@ const HASURA_LIST_AUTHORS = `query FrontendListAuthors {
   }`;
 
 const HASURA_INSERT_AUTHOR = `mutation FrontendInsertAuthor($bio: String, $first_names: String, $last_name: String, $locale_code: String, $title: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
-  insert_authors(objects: {first_names: $first_names, last_name: $last_name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_key, update_columns: [first_names, last_name, slug, twitter, staff, published, photoUrl]}) {
+  insert_authors(objects: {first_names: $first_names, last_name: $last_name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_organization_id_key, update_columns: [first_names, last_name, slug, twitter, staff, published, photoUrl]}) {
     returning {
       first_names
       last_name


### PR DESCRIPTION
Related to https://github.com/news-catalyst/hasura/issues/64

This just updates the constraint uses in the insert author mutation to use the new per-org unique key instead of the old global unique key.