### PR TITLE
Fix for GA data importer jobs

### DIFF
--- a/.github/workflows/import-data-from-ga-ang-diaryo.yml
+++ b/.github/workflows/import-data-from-ga-ang-diaryo.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Ang Diaryo
 'on':
   schedule:
     - cron: 5 9 * * *

--- a/.github/workflows/import-data-from-ga-austin-vida.yml
+++ b/.github/workflows/import-data-from-ga-austin-vida.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Austin Vida
 'on':
   schedule:
     - cron: 5 9 * * *

--- a/.github/workflows/import-data-from-ga-black-by-god.yml
+++ b/.github/workflows/import-data-from-ga-black-by-god.yml
@@ -4,7 +4,7 @@ name: GA Data Importer Black By God
     - cron: 5 9 * * *
   push:
     branches:
-      - main
+      - bugfix/ga-data-import-failing-jobs
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-black-by-god.yml
+++ b/.github/workflows/import-data-from-ga-black-by-god.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Black By God
 'on':
   schedule:
     - cron: 5 9 * * *

--- a/.github/workflows/import-data-from-ga-five-wards-media.yml
+++ b/.github/workflows/import-data-from-ga-five-wards-media.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Five Wards Media
 'on':
   schedule:
     - cron: 5 9 * * *

--- a/.github/workflows/import-data-from-ga-spotlight-schools.yml
+++ b/.github/workflows/import-data-from-ga-spotlight-schools.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Spotlight Schools
 'on':
   schedule:
     - cron: 5 9 * * *

--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -1,4 +1,4 @@
-name: GA Data Importer
+name: GA Data Importer Oaklyn
 on:
   schedule:
     - cron: '5 9 * * *'

--- a/lib/authors.js
+++ b/lib/authors.js
@@ -25,7 +25,7 @@ const HASURA_LIST_AUTHORS = `query FrontendListAuthors {
   }`;
 
 const HASURA_INSERT_AUTHOR = `mutation FrontendInsertAuthor($bio: String, $first_names: String, $last_name: String, $locale_code: String, $title: String, $photoUrl: String, $published: Boolean, $slug: String, $staff: Boolean, $twitter: String) {
-  insert_authors(objects: {first_names: $first_names, last_name: $last_name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_key, update_columns: [first_names, last_name, slug, twitter, staff, published, photoUrl]}) {
+  insert_authors(objects: {first_names: $first_names, last_name: $last_name, author_translations: {data: {bio: $bio, locale_code: $locale_code, title: $title}, on_conflict: {constraint: author_translations_pkey, update_columns: [bio, locale_code, title]}}, photoUrl: $photoUrl, published: $published, slug: $slug, staff: $staff, twitter: $twitter}, on_conflict: {constraint: authors_slug_organization_id_key, update_columns: [first_names, last_name, slug, twitter, staff, published, photoUrl]}) {
     returning {
       first_names
       last_name

--- a/script/bootstrap.js
+++ b/script/bootstrap.js
@@ -42,7 +42,7 @@ let organizationID;
 
 // encrypts a secret for GH environment variable setting
 function encryptSecret(key, value) {
-  // console.log("encrypting", key, value);
+  // console.log('encrypting', key, value);
   // Convert the message and key to Uint8Array's (Buffer implements that interface)
   const messageBytes = Buffer.from(value);
   const keyBytes = Buffer.from(key, 'base64');
@@ -169,9 +169,11 @@ async function createGitHubEnv(slug) {
 
     for await (let secretName of secrets) {
       let plainValue = currentEnv.parsed[secretName];
-      // console.log(`\t* setting secret: ${secretName} ${plainValue}`);
 
       let encryptedValue = encryptSecret(pubKey, plainValue);
+      console.log(
+        `\t* setting secret ${secretName} - plain value = '${plainValue}' encrypted as '${encryptedValue}'`
+      );
 
       const secretResult = await octokit.rest.actions.createOrUpdateEnvironmentSecret(
         {
@@ -187,7 +189,13 @@ async function createGitHubEnv(slug) {
         secretResult.status >= 200 &&
         secretResult.status < 300
       ) {
-        console.log(`\t* created secret: ${secretName}`);
+        console.log(`\t* done creating secret: ${secretName}`);
+      } else {
+        console.error(
+          `\t* error creating secret ${secretName}: ${JSON.stringify(
+            secretResult
+          )}`
+        );
       }
     }
   } catch (err) {
@@ -505,7 +513,8 @@ async function createOrganization(opts) {
               facebookDescription: 'Facebook description',
               commenting: 'on',
               advertisingHed: `Advertise with ${name}`,
-              advertisingDek: 'Want to reach our engaged, connected audience? Advertise within our weekly newsletter!',
+              advertisingDek:
+                'Want to reach our engaged, connected audience? Advertise within our weekly newsletter!',
               advertisingCTA: 'Buy an advertisement',
             };
 

--- a/script/ga.js
+++ b/script/ga.js
@@ -23,7 +23,12 @@ async function getData(params) {
     '\n'
   );
 
-  // console.log("authenticating with google:", credsEmail, credsPrivateKey, scopes);
+  console.log(
+    'authenticating with google:',
+    credsEmail,
+    credsPrivateKey,
+    scopes
+  );
   const auth = new google.auth.JWT(credsEmail, null, credsPrivateKey, scopes);
   const analyticsreporting = google.analyticsreporting({ version: 'v4', auth });
   let startDate = params['startDate'];
@@ -626,7 +631,6 @@ program
     try {
       importDataFromGA(opts);
     } catch (e) {
-      console.log('CAUGHT ERROR IMPORTING DATA:', e);
       core.setFailed(`Action failed with error ${e}`);
     }
   });

--- a/script/ga.js
+++ b/script/ga.js
@@ -588,8 +588,6 @@ async function importDataFromGA(params) {
   } catch (e) {
     console.log('error getting data from GA:', e);
     core.setFailed(`Action failed with error ${e}`);
-
-    // throw e;
   }
 
   if (!rows || (rows && rows.length <= 0)) {

--- a/script/ga.js
+++ b/script/ga.js
@@ -587,7 +587,9 @@ async function importDataFromGA(params) {
     });
   } catch (e) {
     console.log('error getting data from GA:', e);
-    throw e;
+    core.setFailed(`Action failed with error ${e}`);
+
+    // throw e;
   }
 
   if (!rows || (rows && rows.length <= 0)) {

--- a/script/ga.js
+++ b/script/ga.js
@@ -626,6 +626,7 @@ program
     try {
       importDataFromGA(opts);
     } catch (e) {
+      console.log('CAUGHT ERROR IMPORTING DATA:', e);
       core.setFailed(`Action failed with error ${e}`);
     }
   });


### PR DESCRIPTION
Closes #944 

There were two things going on with the failing GA data importer jobs:

1. the script was reporting the error but not actually failing the GH action, because of an issue with catching and throwing errors in an async nodejs function and my brain. I fixed this by reporting the exit status right away using the GH Action documented approach instead of trying to be fancy and re-throw the error & report later.
2. each of the bootstrapped orgs had the environment-specific secrets setup in GitHub, but these secrets seemed to be blank for some reason. I have no idea why. I suspect something went wrong during the `bootstrap` command run for each with parsing the current (`.env.local`) environment file, which is used to set the encrypted value for each env secret.

I'm not 100% sure about why each org had a GH env full of secrets that were somehow set incorrectly, but I went into each and made sure the GA related ones required for the data import scripts are set properly. This took me about 90 seconds so it's not a big deal. I'd like to figure out what happened though, so I'll open another issue about debugging `bootstrap` :) 

Oh, and I noticed that all the data importer jobs had the same name, which made debugging them a bit more annoying, so I added the organization name to each job title.