### PR TITLE
use name, not property, on meta description

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -168,7 +168,7 @@ export default function Layout({
       <Head>
         <title>{pageTitle}</title>
         {metaValues.favicon && <link rel="icon" href={metaValues.favicon} />}
-        <meta property="description" content={metaValues.searchDescription} />
+        <meta name="description" content={metaValues.searchDescription} />
         {tagList}
         <link rel="canonical" href={metaValues.canonical} />
         {/* Twitter Card data */}


### PR DESCRIPTION
I was running some of our pages through Lighthouse and it complained that they didn't have a meta description. That's because we were using `<meta property="description">` instead of `<meta name="description>`