### PR TITLE
filters out tinycms and article preview pages from analytics page views

### DIFF
--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -34,8 +34,12 @@ const PageViews = (props) => {
         }
       });
       var sortable = [];
+      var counter = 0;
       Object.keys(totalPV).forEach((path) => {
-        sortable.push([path, totalPV[path]]);
+        if (counter < 10) {
+          sortable.push([path, totalPV[path]]);
+        }
+        counter++;
       });
 
       sortable.sort(function (a, b) {
@@ -56,10 +60,10 @@ const PageViews = (props) => {
   return (
     <>
       <SubHeaderContainer ref={pageviewsRef}>
-        <SubHeader>Page Views</SubHeader>
+        <SubHeader>Top 10 Viewed Pages</SubHeader>
         <SubDek>
           This table shows your most frequently visited pages for your given
-          date range.
+          date range across the entire site.
         </SubDek>
       </SubHeaderContainer>
       <p tw="p-2">

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -156,7 +156,13 @@ export async function hasuraGetSessionDuration(params) {
 }
 
 const HASURA_GET_READING_DEPTH_PAGE_VIEWS = `query FrontendGetReadingDepthPageViews($date: date_comparison_exp) {
-  ga_reading_depth(where: {date: $date}) {
+  ga_reading_depth(where: {
+    _and: [
+      {date: $date},
+      { path: {_nilike: "/tinycms%"} },
+       { path: {_nilike: "/preview%"} },
+    ]
+  }) {
     date
     id
     organization_id
@@ -284,7 +290,13 @@ export async function hasuraGetNewsletterImpressions(params) {
 }
 
 const HASURA_GET_PAGE_VIEWS = `query FrontendGetPageViews($startDate: date!, $endDate: date!, $limit: Int) {
-  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}, limit: $limit) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {
+    _and: [
+      {date: {_gte: $startDate, _lte: $endDate}},
+      {path: {_nilike: "/tinycms%"}},
+      { path: {_nilike: "/preview%"} },
+    ]},
+    limit: $limit) {
     count
     date
     path


### PR DESCRIPTION
Closes #953 - limits the max number of rows on page views-related tables
Closes #963  - removes preview and tinycms data from these tables

Now I know how to chain graphql where clauses, including not-i-like queries, together:

```
where: {
  _and: [
    { date: $date },
    { path: { _nilike: '/tinycms%' } },
    { path: { _nilike: '/preview%' } },
  ];
}
```