### PR TITLE
Categorize page views in tinycms analytics

### DIFF
--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -34,8 +34,12 @@ const PageViews = (props) => {
         }
       });
       var sortable = [];
+      var counter = 0;
       Object.keys(totalPV).forEach((path) => {
-        sortable.push([path, totalPV[path]]);
+        if (counter < 10) {
+          sortable.push([path, totalPV[path]]);
+        }
+        counter++;
       });
 
       sortable.sort(function (a, b) {
@@ -56,10 +60,10 @@ const PageViews = (props) => {
   return (
     <>
       <SubHeaderContainer ref={pageviewsRef}>
-        <SubHeader>Page Views</SubHeader>
+        <SubHeader>Top 10 Viewed Pages</SubHeader>
         <SubDek>
           This table shows your most frequently visited pages for your given
-          date range.
+          date range across the entire site.
         </SubDek>
       </SubHeaderContainer>
       <p tw="p-2">

--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,7 +1,12 @@
 import React, { useEffect, useState, useRef } from 'react';
 import tw from 'twin.macro';
 // import { parsePageViews } from '../../../lib/utils';
-import { hasuraGetPageViews } from '../../../lib/analytics';
+import {
+  hasuraGetPageViews,
+  hasuraGetArticlePageViews,
+  hasuraGetCategoryPageViews,
+  hasuraGetAuthorPageViews,
+} from '../../../lib/analytics';
 
 const SubHeaderContainer = tw.div`pt-3 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
@@ -9,8 +14,18 @@ const SubDek = tw.p`max-w-3xl`;
 
 const PageViews = (props) => {
   const pageviewsRef = useRef();
+  const articleViewsRef = useRef();
+  const sectionViewsRef = useRef();
+  const authorViewsRef = useRef();
+
   const [sortedPageViews, setSortedPageViews] = useState([]);
   const [totalPageViews, setTotalPageViews] = useState({});
+  const [sortedArticlePageViews, setSortedArticlePageViews] = useState([]);
+  const [articlePageViews, setArticlePageViews] = useState({});
+  const [sortedCategoryPageViews, setSortedCategoryPageViews] = useState([]);
+  const [categoryPageViews, setCategoryPageViews] = useState({});
+  const [sortedAuthorPageViews, setSortedAuthorPageViews] = useState([]);
+  const [authorPageViews, setAuthorPageViews] = useState({});
 
   useEffect(() => {
     let pvParams = {
@@ -50,6 +65,103 @@ const PageViews = (props) => {
       setSortedPageViews(sortable);
     };
     fetchPageViews();
+
+    const fetchArticlePageViews = async () => {
+      const { errors, data } = await hasuraGetArticlePageViews(pvParams);
+
+      if (errors && !data) {
+        console.error(errors);
+      }
+      let totalPV = {};
+      data.ga_page_views.map((pv) => {
+        if (totalPV[pv.path]) {
+          totalPV[pv.path] += parseInt(pv.count);
+        } else {
+          totalPV[pv.path] = parseInt(pv.count);
+        }
+      });
+      var sortable = [];
+      var counter = 0;
+      Object.keys(totalPV).forEach((path) => {
+        if (counter < 10) {
+          sortable.push([path, totalPV[path]]);
+        }
+        counter++;
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
+      setArticlePageViews(totalPV);
+      setSortedArticlePageViews(sortable);
+    };
+    fetchArticlePageViews();
+
+    const fetchCategoryPageViews = async () => {
+      const { errors, data } = await hasuraGetCategoryPageViews(pvParams);
+
+      if (errors && !data) {
+        console.error(errors);
+      }
+      let totalPV = {};
+      data.ga_page_views.map((pv) => {
+        if (totalPV[pv.path]) {
+          totalPV[pv.path] += parseInt(pv.count);
+        } else {
+          totalPV[pv.path] = parseInt(pv.count);
+        }
+      });
+      var sortable = [];
+      var counter = 0;
+      Object.keys(totalPV).forEach((path) => {
+        if (counter < 10) {
+          sortable.push([path, totalPV[path]]);
+        }
+        counter++;
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
+      setCategoryPageViews(totalPV);
+      setSortedCategoryPageViews(sortable);
+    };
+    fetchCategoryPageViews();
+
+    const fetchAuthorPageViews = async () => {
+      const { errors, data } = await hasuraGetAuthorPageViews(pvParams);
+
+      if (errors && !data) {
+        console.error(errors);
+      }
+      let totalPV = {};
+      data.ga_page_views.map((pv) => {
+        if (totalPV[pv.path]) {
+          totalPV[pv.path] += parseInt(pv.count);
+        } else {
+          totalPV[pv.path] = parseInt(pv.count);
+        }
+      });
+      var sortable = [];
+      var counter = 0;
+      Object.keys(totalPV).forEach((path) => {
+        if (counter < 10) {
+          sortable.push([path, totalPV[path]]);
+        }
+        counter++;
+      });
+
+      sortable.sort(function (a, b) {
+        return b[1] - a[1];
+      });
+
+      setAuthorPageViews(totalPV);
+      setSortedAuthorPageViews(sortable);
+    };
+    fetchAuthorPageViews();
+
     if (window.location.hash && window.location.hash === '#pageviews') {
       if (pageviewsRef) {
         pageviewsRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -80,6 +192,105 @@ const PageViews = (props) => {
         </thead>
         <tbody>
           {sortedPageViews.map((item, i) => (
+            <tr key={`page-view-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[0]}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[1]}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <SubHeaderContainer ref={articleViewsRef}>
+        <SubHeader>Most Viewed Articles</SubHeader>
+        <SubDek>
+          This table shows your most frequently visited articles (only) for the
+          given date range.
+        </SubDek>
+      </SubHeaderContainer>
+      <p tw="p-2">
+        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+        {props.endDate.format('dddd, MMMM Do YYYY')}
+      </p>
+
+      <table tw="w-full table-auto">
+        <thead>
+          <tr>
+            <th tw="px-4">Path</th>
+            <th tw="px-4">Views</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedArticlePageViews.map((item, i) => (
+            <tr key={`page-view-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[0]}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[1]}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <SubHeaderContainer ref={sectionViewsRef}>
+        <SubHeader>Most Viewed Section Indexes</SubHeader>
+        <SubDek>
+          This table shows your most frequently visited section index pages for
+          the given date range.
+        </SubDek>
+      </SubHeaderContainer>
+      <p tw="p-2">
+        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+        {props.endDate.format('dddd, MMMM Do YYYY')}
+      </p>
+
+      <table tw="w-full table-auto">
+        <thead>
+          <tr>
+            <th tw="px-4">Path</th>
+            <th tw="px-4">Views</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedCategoryPageViews.map((item, i) => (
+            <tr key={`page-view-row-${i}`}>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[0]}
+              </td>
+              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                {item[1]}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <SubHeaderContainer ref={authorViewsRef}>
+        <SubHeader>Most Viewed Author Indexes</SubHeader>
+        <SubDek>
+          This table shows your most frequently visited author index pages for
+          the given date range.
+        </SubDek>
+      </SubHeaderContainer>
+      <p tw="p-2">
+        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+        {props.endDate.format('dddd, MMMM Do YYYY')}
+      </p>
+
+      <table tw="w-full table-auto">
+        <thead>
+          <tr>
+            <th tw="px-4">Path</th>
+            <th tw="px-4">Views</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedAuthorPageViews.map((item, i) => (
             <tr key={`page-view-row-${i}`}>
               <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
                 {item[0]}

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -289,6 +289,84 @@ export async function hasuraGetNewsletterImpressions(params) {
   });
 }
 
+const HASURA_GET_CATEGORY_PAGE_VIEWS = `query FrontendGetCategoryPageViews($startDate: date!, $endDate: date!, $limit: Int) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {
+    _and: [
+      {date: {_gte: $startDate, _lte: $endDate}},
+      {path: {_ilike: "/categories%"}},
+    ]},
+    limit: $limit) {
+    count
+    date
+    path
+  }
+}`;
+
+export async function hasuraGetCategoryPageViews(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_CATEGORY_PAGE_VIEWS,
+    name: 'FrontendGetCategoryPageViews',
+    variables: {
+      startDate: params['startDate'],
+      endDate: params['endDate'],
+    },
+  });
+}
+
+const HASURA_GET_AUTHOR_PAGE_VIEWS = `query FrontendGetAuthorPageViews($startDate: date!, $endDate: date!, $limit: Int) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {
+    _and: [
+      {date: {_gte: $startDate, _lte: $endDate}},
+      {path: {_ilike: "/authors%"}},
+    ]},
+    limit: $limit) {
+    count
+    date
+    path
+  }
+}`;
+
+export async function hasuraGetAuthorPageViews(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_AUTHOR_PAGE_VIEWS,
+    name: 'FrontendGetAuthorPageViews',
+    variables: {
+      startDate: params['startDate'],
+      endDate: params['endDate'],
+    },
+  });
+}
+
+const HASURA_GET_ARTICLE_PAGE_VIEWS = `query FrontendGetArticlePageViews($startDate: date!, $endDate: date!, $limit: Int) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {
+    _and: [
+      {date: {_gte: $startDate, _lte: $endDate}},
+      {path: {_ilike: "/articles%"}},
+    ]},
+    limit: $limit) {
+    count
+    date
+    path
+  }
+}`;
+
+export async function hasuraGetArticlePageViews(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    orgSlug: params['orgSlug'],
+    query: HASURA_GET_ARTICLE_PAGE_VIEWS,
+    name: 'FrontendGetArticlePageViews',
+    variables: {
+      startDate: params['startDate'],
+      endDate: params['endDate'],
+    },
+  });
+}
+
 const HASURA_GET_PAGE_VIEWS = `query FrontendGetPageViews($startDate: date!, $endDate: date!, $limit: Int) {
   ga_page_views(order_by: {date: asc, count: desc}, where: {
     _and: [

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -156,7 +156,13 @@ export async function hasuraGetSessionDuration(params) {
 }
 
 const HASURA_GET_READING_DEPTH_PAGE_VIEWS = `query FrontendGetReadingDepthPageViews($date: date_comparison_exp) {
-  ga_reading_depth(where: {date: $date}) {
+  ga_reading_depth(where: {
+    _and: [
+      {date: $date},
+      { path: {_nilike: "/tinycms%"} },
+       { path: {_nilike: "/preview%"} },
+    ]
+  }) {
     date
     id
     organization_id
@@ -284,7 +290,13 @@ export async function hasuraGetNewsletterImpressions(params) {
 }
 
 const HASURA_GET_PAGE_VIEWS = `query FrontendGetPageViews($startDate: date!, $endDate: date!, $limit: Int) {
-  ga_page_views(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}, path: {_nilike: "/tinycms%"}}, limit: $limit) {
+  ga_page_views(order_by: {date: asc, count: desc}, where: {
+    _and: [
+      {date: {_gte: $startDate, _lte: $endDate}},
+      {path: {_nilike: "/tinycms%"}},
+      { path: {_nilike: "/preview%"} },
+    ]},
+    limit: $limit) {
     count
     date
     path


### PR DESCRIPTION
Closes #953

This PR breaks out the page views data into the following:

* top 10 overall
* most viewed sections
* most viewed author indexes
* most viewed articles

Do you think we should include anymore?

I was originally thinking of doing this in a single section with tabs to navigate, but then I realized I typically dislike it when sites hide data that way so I decided to keep it all on one page with scroll. I'm open to changing this, though, if you have opinions about it @TylerFisher.