### PR TITLE
analytics: displaying different page views with tabs

### DIFF
--- a/components/tinycms/analytics/PageViews.js
+++ b/components/tinycms/analytics/PageViews.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 // import { parsePageViews } from '../../../lib/utils';
 import {
   hasuraGetPageViews,
@@ -12,11 +12,27 @@ const SubHeaderContainer = tw.div`pt-3 pb-5`;
 const SubHeader = tw.h1`inline-block text-xl font-extrabold text-gray-900 tracking-tight`;
 const SubDek = tw.p`max-w-3xl`;
 
+const tabStyles = {
+  open: tw`text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-white bg-gray-600`,
+  closed: tw`text-xs font-bold uppercase px-5 py-3 shadow-lg rounded block leading-normal text-gray-600 bg-white`,
+};
+
+const TabButton = styled.a(({ status }) => tabStyles[status]);
+
+const tabContentStyles = {
+  open: tw`block`,
+  closed: tw`hidden`,
+};
+
+const TabContent = styled.div(({ status }) => tabContentStyles[status]);
+
 const PageViews = (props) => {
   const pageviewsRef = useRef();
   const articleViewsRef = useRef();
   const sectionViewsRef = useRef();
   const authorViewsRef = useRef();
+
+  const [openTab, setOpenTab] = React.useState(1);
 
   const [sortedPageViews, setSortedPageViews] = useState([]);
   const [totalPageViews, setTotalPageViews] = useState({});
@@ -26,6 +42,8 @@ const PageViews = (props) => {
   const [categoryPageViews, setCategoryPageViews] = useState({});
   const [sortedAuthorPageViews, setSortedAuthorPageViews] = useState([]);
   const [authorPageViews, setAuthorPageViews] = useState({});
+
+  let color = 'blueGray';
 
   useEffect(() => {
     let pvParams = {
@@ -171,137 +189,223 @@ const PageViews = (props) => {
 
   return (
     <>
-      <SubHeaderContainer ref={pageviewsRef}>
-        <SubHeader>Top 10 Viewed Pages</SubHeader>
-        <SubDek>
-          This table shows your most frequently visited pages for your given
-          date range across the entire site.
-        </SubDek>
-      </SubHeaderContainer>
-      <p tw="p-2">
-        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
-        {props.endDate.format('dddd, MMMM Do YYYY')}
-      </p>
+      <div tw="flex flex-wrap">
+        <div tw="w-full">
+          <ul
+            tw="flex mb-0 list-none flex-wrap pt-3 pb-4 flex-row"
+            role="tablist"
+          >
+            <li tw="-mb-px mr-2 last:mr-0 flex-auto text-center">
+              <TabButton
+                status={openTab === 1 ? 'open' : 'closed'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenTab(1);
+                }}
+                data-toggle="tab"
+                href="#link1"
+                role="tablist"
+              >
+                Overall
+              </TabButton>
+            </li>
+            <li tw="-mb-px mr-2 last:mr-0 flex-auto text-center">
+              <TabButton
+                status={openTab === 2 ? 'open' : 'closed'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenTab(2);
+                }}
+                data-toggle="tab"
+                href="#link2"
+                role="tablist"
+              >
+                Articles
+              </TabButton>
+            </li>
+            <li tw="-mb-px mr-2 last:mr-0 flex-auto text-center">
+              <TabButton
+                status={openTab === 3 ? 'open' : 'closed'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenTab(3);
+                }}
+                data-toggle="tab"
+                href="#link3"
+                role="tablist"
+              >
+                Sections
+              </TabButton>
+            </li>
+            <li tw="-mb-px mr-2 last:mr-0 flex-auto text-center">
+              <TabButton
+                status={openTab === 4 ? 'open' : 'closed'}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenTab(4);
+                }}
+                data-toggle="tab"
+                href="#link4"
+                role="tablist"
+              >
+                Authors
+              </TabButton>
+            </li>
+          </ul>
+          <div tw="relative flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-lg rounded">
+            <div tw="px-4 py-5 flex-auto">
+              <div className="tab-content tab-space">
+                <TabContent
+                  status={openTab === 1 ? 'open' : 'closed'}
+                  id="link1"
+                >
+                  <SubHeaderContainer ref={pageviewsRef}>
+                    <SubHeader>Top 10 Viewed Overall</SubHeader>
+                    <SubDek>
+                      This table shows your most frequently visited pages for
+                      your given date range across the entire site.
+                    </SubDek>
+                  </SubHeaderContainer>
+                  <p tw="p-2">
+                    {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+                    {props.endDate.format('dddd, MMMM Do YYYY')}
+                  </p>
+                  <table tw="w-full table-auto">
+                    <thead>
+                      <tr>
+                        <th tw="px-4">Path</th>
+                        <th tw="px-4">Views</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedPageViews.map((item, i) => (
+                        <tr key={`page-view-row-${i}`}>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[0]}
+                          </td>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[1]}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>{' '}
+                  <br />
+                </TabContent>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Path</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedPageViews.map((item, i) => (
-            <tr key={`page-view-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                <TabContent
+                  status={openTab === 2 ? 'open' : 'closed'}
+                  id="link2"
+                >
+                  {' '}
+                  <SubHeaderContainer ref={articleViewsRef}>
+                    <SubHeader>Most Viewed Articles</SubHeader>
+                    <SubDek>
+                      This table shows your most frequently visited articles
+                      (only) for the given date range.
+                    </SubDek>
+                  </SubHeaderContainer>
+                  <p tw="p-2">
+                    {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+                    {props.endDate.format('dddd, MMMM Do YYYY')}
+                  </p>
+                  <table tw="w-full table-auto">
+                    <thead>
+                      <tr>
+                        <th tw="px-4">Path</th>
+                        <th tw="px-4">Views</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedArticlePageViews.map((item, i) => (
+                        <tr key={`page-view-row-${i}`}>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[0]}
+                          </td>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[1]}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </TabContent>
+                <TabContent
+                  status={openTab === 3 ? 'open' : 'closed'}
+                  id="link3"
+                >
+                  <SubHeaderContainer ref={sectionViewsRef}>
+                    <SubHeader>Most Viewed Section Pages</SubHeader>
+                    <SubDek>
+                      This table shows your most frequently visited section
+                      index pages for the given date range.
+                    </SubDek>
+                  </SubHeaderContainer>
+                  <p tw="p-2">
+                    {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+                    {props.endDate.format('dddd, MMMM Do YYYY')}
+                  </p>
 
-      <SubHeaderContainer ref={articleViewsRef}>
-        <SubHeader>Most Viewed Articles</SubHeader>
-        <SubDek>
-          This table shows your most frequently visited articles (only) for the
-          given date range.
-        </SubDek>
-      </SubHeaderContainer>
-      <p tw="p-2">
-        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
-        {props.endDate.format('dddd, MMMM Do YYYY')}
-      </p>
+                  <table tw="w-full table-auto">
+                    <thead>
+                      <tr>
+                        <th tw="px-4">Path</th>
+                        <th tw="px-4">Views</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedCategoryPageViews.map((item, i) => (
+                        <tr key={`page-view-row-${i}`}>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[0]}
+                          </td>
+                          <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                            {item[1]}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </TabContent>
+              </div>
+              <TabContent status={openTab === 4 ? 'open' : 'closed'} id="link4">
+                <SubHeaderContainer ref={authorViewsRef}>
+                  <SubHeader>Most Viewed Author Pages</SubHeader>
+                  <SubDek>
+                    This table shows your most frequently visited author index
+                    pages for the given date range.
+                  </SubDek>
+                </SubHeaderContainer>
+                <p tw="p-2">
+                  {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
+                  {props.endDate.format('dddd, MMMM Do YYYY')}
+                </p>
 
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Path</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedArticlePageViews.map((item, i) => (
-            <tr key={`page-view-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <SubHeaderContainer ref={sectionViewsRef}>
-        <SubHeader>Most Viewed Section Indexes</SubHeader>
-        <SubDek>
-          This table shows your most frequently visited section index pages for
-          the given date range.
-        </SubDek>
-      </SubHeaderContainer>
-      <p tw="p-2">
-        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
-        {props.endDate.format('dddd, MMMM Do YYYY')}
-      </p>
-
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Path</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedCategoryPageViews.map((item, i) => (
-            <tr key={`page-view-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <SubHeaderContainer ref={authorViewsRef}>
-        <SubHeader>Most Viewed Author Indexes</SubHeader>
-        <SubDek>
-          This table shows your most frequently visited author index pages for
-          the given date range.
-        </SubDek>
-      </SubHeaderContainer>
-      <p tw="p-2">
-        {props.startDate.format('dddd, MMMM Do YYYY')} -{' '}
-        {props.endDate.format('dddd, MMMM Do YYYY')}
-      </p>
-
-      <table tw="w-full table-auto">
-        <thead>
-          <tr>
-            <th tw="px-4">Path</th>
-            <th tw="px-4">Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedAuthorPageViews.map((item, i) => (
-            <tr key={`page-view-row-${i}`}>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[0]}
-              </td>
-              <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
-                {item[1]}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                <table tw="w-full table-auto">
+                  <thead>
+                    <tr>
+                      <th tw="px-4">Path</th>
+                      <th tw="px-4">Views</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedAuthorPageViews.map((item, i) => (
+                      <tr key={`page-view-row-${i}`}>
+                        <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                          {item[0]}
+                        </td>
+                        <td tw="border border-gray-500 px-4 py-2 text-gray-600 font-medium">
+                          {item[1]}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </TabContent>
+            </div>
+          </div>
+        </div>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
I've changed my mind on this - I think the tabs view looks better. What do you think @TylerFisher?

<img width="969" alt="Screen Shot 2021-11-11 at 10 25 50 am" src="https://user-images.githubusercontent.com/3397/141209813-b974c5b5-9df2-451d-b580-c5bcfc101cbb.png">

[http://localhost:3000/tinycms/analytics/pageviews](http://localhost:3000/tinycms/analytics/pageviews)

(Note: I've been using BBG settings to view this as there's more data available)