### PR TITLE
Avoid using 'Untitled Document' as page title

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -82,7 +82,16 @@ export default function Layout({
   }
   if (translations && translations.length > 0) {
     pageTitle = hasuraLocalizeText(locale, translations, 'search_title');
-    pageTitle += ' | ' + metaValues.siteName;
+    if (pageTitle === 'Untitled Document') {
+      let headline = hasuraLocalizeText(locale, translations, 'headline');
+      if (headline !== 'Untitled Document') {
+        pageTitle = headline + ' | ' + metaValues.siteName;
+      } else {
+        pageTitle = metaValues.siteName;
+      }
+    } else {
+      pageTitle += ' | ' + metaValues.siteName;
+    }
 
     if (article && article.category) {
       metaValues.section = hasuraLocalizeText(


### PR DESCRIPTION
Fallback to headline and at worst just the site name instead of using 'Untitled Document' for page title:

* if search title not 'untitled document', use it (translated) and append the site name
* otherwise, if headline not 'untitled document', use it (translated) and append the site name
* finally, if neither one of those works, just use the site name (no pipe char)