### PR TITLE
Data importers should be run as scheduled jobs only

### DIFF
--- a/.github/workflows/import-data-from-ga-ang-diaryo.yml
+++ b/.github/workflows/import-data-from-ga-ang-diaryo.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Ang Diaryo
 'on':
   schedule:
     - cron: 5 9 * * *
-  push:
-    branches:
-      - main
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-austin-vida.yml
+++ b/.github/workflows/import-data-from-ga-austin-vida.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Austin Vida
 'on':
   schedule:
     - cron: 5 9 * * *
-  push:
-    branches:
-      - main
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-black-by-god.yml
+++ b/.github/workflows/import-data-from-ga-black-by-god.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Black By God
 'on':
   schedule:
     - cron: 5 9 * * *
-  push:
-    branches:
-      - bugfix/ga-data-import-failing-jobs
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-five-wards-media.yml
+++ b/.github/workflows/import-data-from-ga-five-wards-media.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Five Wards Media
 'on':
   schedule:
     - cron: 5 9 * * *
-  push:
-    branches:
-      - main
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-spotlight-schools.yml
+++ b/.github/workflows/import-data-from-ga-spotlight-schools.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Spotlight Schools
 'on':
   schedule:
     - cron: 5 9 * * *
-  push:
-    branches:
-      - main
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -2,9 +2,6 @@ name: GA Data Importer Oaklyn
 on:
   schedule:
     - cron: '5 9 * * *'
-  push:
-    branches:
-      - main
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/script/remove.js
+++ b/script/remove.js
@@ -1,13 +1,14 @@
-
 const { program } = require('commander');
 program.version('0.0.1');
 
-const vercel = require("./vercel");
-const shared = require("./shared");
+const fs = require('fs');
 
-const { Octokit } = require("@octokit/rest"); 
+const vercel = require('./vercel');
+const shared = require('./shared');
 
-require('dotenv').config({ path: '.env.local' })
+const { Octokit } = require('@octokit/rest');
+
+require('dotenv').config({ path: '.env.local' });
 
 const apiUrl = process.env.HASURA_API_URL;
 const adminSecret = process.env.HASURA_ADMIN_SECRET;
@@ -15,12 +16,20 @@ const adminSecret = process.env.HASURA_ADMIN_SECRET;
 const githubRepo = process.env.GIT_REPO;
 const githubToken = process.env.GITHUB_TOKEN;
 
-
-const { google } = require("googleapis");
-const credentials = require("./credentials.json");
-const scopes = ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/analytics", "https://www.googleapis.com/auth/analytics.edit"];
-const auth = new google.auth.JWT(credentials.client_email, null, credentials.private_key, scopes);
-const analytics = google.analytics({version: "v3", auth})
+const { google } = require('googleapis');
+const credentials = require('./credentials.json');
+const scopes = [
+  'https://www.googleapis.com/auth/drive',
+  'https://www.googleapis.com/auth/analytics',
+  'https://www.googleapis.com/auth/analytics.edit',
+];
+const auth = new google.auth.JWT(
+  credentials.client_email,
+  null,
+  credentials.private_key,
+  scopes
+);
+const analytics = google.analytics({ version: 'v3', auth });
 const googleAnalyticsAccountID = process.env.GA_ACCOUNT_ID;
 
 async function removeOrganization(slug, name) {
@@ -32,51 +41,79 @@ async function removeOrganization(slug, name) {
   const removeResult = await vercel.deleteProject(slug);
   console.log(removeResult);
 
-  let githubEnvironment = `data_import_${slug}`
+  let githubEnvironment = `data_import_${slug}`;
   try {
     const githubResponse = await octokit.rest.repos.deleteAnEnvironment({
-      "owner": owner,
-      "repo": repo,
-      "environment_name": githubEnvironment,
+      owner: owner,
+      repo: repo,
+      environment_name: githubEnvironment,
     });
-    if (githubResponse && githubResponse["status"] === 204) {
+    if (githubResponse && githubResponse['status'] === 204) {
       console.log(`Deleted ${githubEnvironment} environment from GitHub.`);
     }
-  } catch(e) {
+  } catch (e) {
     console.error(e);
   }
 
-  let statusResponse = await analytics.management.webproperties.list({'accountId': googleAnalyticsAccountID});
+  try {
+    let githubActionFile = `.github/workflows/import-data-from-ga-${slug}.yml`;
+    if (fs.existsSync(githubActionFile)) {
+      fs.unlink(githubActionFile, (err) => {
+        if (err) throw err;
+        console.log(`Deleted GitHub Action file: ${githubActionFile}`);
+      });
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  let statusResponse = await analytics.management.webproperties.list({
+    accountId: googleAnalyticsAccountID,
+  });
   if (statusResponse.data.items && statusResponse.data.items.length) {
     let items = statusResponse.data.items;
     for await (let item of items) {
       // console.log(`[GA] * ${item.id}: ${item.name} (${item.profileCount} profiles)` )
-      
+
       if (name === item.name) {
-        console.log( "[GA] *** Listing profile IDs in property " + item.id + " ***")
+        console.log(
+          '[GA] *** Listing profile IDs in property ' + item.id + ' ***'
+        );
         let response = await analytics.management.profiles.list({
-            accountId: googleAnalyticsAccountID,
-            webPropertyId: item.id
-        })
-        if (response && response.data && response.data.items && response.data.items[0]) {
+          accountId: googleAnalyticsAccountID,
+          webPropertyId: item.id,
+        });
+        if (
+          response &&
+          response.data &&
+          response.data.items &&
+          response.data.items[0]
+        ) {
           let profileId = response.data.items[0].id;
 
-          let deleteGA = await analytics.management.profiles.delete(
-            {
-              accountId: googleAnalyticsAccountID,
-              webPropertyId: item.id,
-              profileId: profileId
+          let deleteGA = await analytics.management.profiles.delete({
+            accountId: googleAnalyticsAccountID,
+            webPropertyId: item.id,
+            profileId: profileId,
           });
-        
-          if (deleteGA && deleteGA.statusText === "OK") {
-            console.log("*** [GA] Deleted profile from Google Analytics:", item.id, profileId);
+
+          if (deleteGA && deleteGA.statusText === 'OK') {
+            console.log(
+              '*** [GA] Deleted profile from Google Analytics:',
+              item.id,
+              profileId
+            );
           } else {
-            console.error(`!!! [GA] Error deleting profile from Google Analytics using webPropertyId:${item.id} and profileId:${profileId}:`, deleteGA);
+            console.error(
+              `!!! [GA] Error deleting profile from Google Analytics using webPropertyId:${item.id} and profileId:${profileId}:`,
+              deleteGA
+            );
           }
         } else {
-          console.log("*** [GA] skipping - no profiles found for property: " + item.id)
+          console.log(
+            '*** [GA] skipping - no profiles found for property: ' + item.id
+          );
         }
-
       }
     }
   }
@@ -85,21 +122,26 @@ async function removeOrganization(slug, name) {
     url: apiUrl,
     adminSecret: adminSecret,
     slug: slug,
-  })
+  });
 
   if (errors) {
-    console.error("Error deleting organization data: ", errors);
-
+    console.error('Error deleting organization data: ', errors);
   } else {
     console.log(`Deleted organization data for ${slug}`, data);
   }
 }
 
 program
-  .requiredOption('-s, --slug <slug>', 'unique slug identifier of the organization')
-  .requiredOption('-n, --name <name>', 'name of the organization as found in Google Analytics')
-  .description("removes all data for the specified org")
-  .action( (opts) => {
+  .requiredOption(
+    '-s, --slug <slug>',
+    'unique slug identifier of the organization'
+  )
+  .requiredOption(
+    '-n, --name <name>',
+    'name of the organization as found in Google Analytics'
+  )
+  .description('removes all data for the specified org')
+  .action((opts) => {
     removeOrganization(opts.slug, opts.name);
   });
 


### PR DESCRIPTION
I just noticed that most of the data importer actions were being run both on a cron schedule _and_ on every push to the main branch. These should only be run as scheduled jobs. This PR removes the `on: push` condition from the config scripts for all.