### PR TITLE
bugfix: don't display format start/end markers when rendering content

### DIFF
--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -45,9 +45,11 @@ export default function TextNode({ node, metadata }) {
     return text;
   };
 
-  const children = node.children.map((child, i) =>
-    processChild(child, node.children[i + 1])
-  );
+  const children = node.children.map((child, i) => {
+    if (child.content !== 'FORMAT START' && child.content !== 'FORMAT END') {
+      return processChild(child, node.children[i + 1]);
+    }
+  });
   let wrapper = null;
 
   if (node.style == 'TITLE') {
@@ -63,6 +65,7 @@ export default function TextNode({ node, metadata }) {
   } else if (node.style == 'NORMAL_TEXT') {
     wrapper = <Paragraph>{children}</Paragraph>;
   } else if (node.style == 'FORMATTED_TEXT') {
+    console.log('FORMATTED_TEXT node:', node);
     wrapper = <pre>{children}</pre>;
   } else {
     wrapper = <>{children}</>;


### PR DESCRIPTION
Closes https://github.com/news-catalyst/google-app-scripts/issues/378

`FORMAT START` and `FORMAT END` markers should not display when rendering specially formatted text. Example article to check in this branch when running locally: http://localhost:3000/articles/community/poetry-in-the-rain