### PR TITLE
Bugfix: leading and trailing spaces should not be underlined

### DIFF
--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -18,20 +18,42 @@ export default function TextNode({ node, metadata }) {
     let text = (
       <span key={child.index ? child.index : child.content}>
         {child.content}
-        {delimiterSpaceChar}
       </span>
     );
 
     if (child.style) {
       if (child.style.underline && !child.link) {
-        text = <u key={`${child.index}-u-${text}`}>{text}</u>;
+        text = (
+          <>
+            {delimiterSpaceChar}
+            <u key={`${child.index}-u-${text}`}>{text}</u>
+            {delimiterSpaceChar}
+          </>
+        );
       }
       if (child.style.italic) {
-        text = <em key={`${child.index}-em-${text}`}>{text}</em>;
+        text = (
+          <>
+            <em key={`${child.index}-em-${text}`}>{text}</em>
+            {delimiterSpaceChar}
+          </>
+        );
       }
       if (child.style.bold) {
-        text = <strong key={`${child.index}-strong-${text}`}>{text}</strong>;
+        text = (
+          <>
+            <strong key={`${child.index}-strong-${text}`}>{text}</strong>
+            {delimiterSpaceChar}
+          </>
+        );
       }
+    } else {
+      text = (
+        <>
+          {text}
+          {delimiterSpaceChar}
+        </>
+      );
     }
 
     if (child.link) {
@@ -65,7 +87,7 @@ export default function TextNode({ node, metadata }) {
   } else if (node.style == 'NORMAL_TEXT') {
     wrapper = <Paragraph>{children}</Paragraph>;
   } else if (node.style == 'FORMATTED_TEXT') {
-    console.log('FORMATTED_TEXT node:', node);
+    // console.log('FORMATTED_TEXT node:', node);
     wrapper = <pre>{children}</pre>;
   } else {
     wrapper = <>{children}</>;

--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -45,9 +45,11 @@ export default function TextNode({ node, metadata }) {
     return text;
   };
 
-  const children = node.children.map((child, i) =>
-    processChild(child, node.children[i + 1])
-  );
+  const children = node.children.map((child, i) => {
+    if (child.content !== 'FORMAT START' && child.content !== 'FORMAT END') {
+      return processChild(child, node.children[i + 1]);
+    }
+  });
   let wrapper = null;
 
   if (node.style == 'TITLE') {
@@ -63,6 +65,7 @@ export default function TextNode({ node, metadata }) {
   } else if (node.style == 'NORMAL_TEXT') {
     wrapper = <Paragraph>{children}</Paragraph>;
   } else if (node.style == 'FORMATTED_TEXT') {
+    console.log('FORMATTED_TEXT node:', node);
     wrapper = <pre>{children}</pre>;
   } else {
     wrapper = <>{children}</>;


### PR DESCRIPTION
I noticed this issue while fixing the various Word doc-related formatting problems in https://github.com/news-catalyst/google-app-scripts/issues/379: the spacing around underlined text should not be underlined, it looks badly formatted. 

Before:

<img width="680" alt="Screen Shot 2021-11-29 at 10 31 32 am" src="https://user-images.githubusercontent.com/3397/143896517-54a3d087-f729-4fe4-9065-36e086ae749d.png">

After (with this PR):

<img width="714" alt="Screen Shot 2021-11-29 at 10 31 38 am" src="https://user-images.githubusercontent.com/3397/143896688-e5cac2fd-148e-4f9b-a531-3acdb451a553.png">

Example article link: http://localhost:3000/articles/community/top-5-influential-hip-hop