### PR TITLE
Bugfix for line breaks around "headers"

### DIFF
--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -7,6 +7,9 @@ const Figcaption = tw.figcaption`text-gray-500 text-sm pt-1`;
 export default function ImageNode({ node, amp }) {
   const image = node.children[0];
 
+  if (!image) {
+    return null;
+  }
   const figure = amp ? (
     <amp-img
       width={710}

--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -22,6 +22,9 @@ export default function TextNode({ node, metadata }) {
     );
 
     if (child.style) {
+      if (child.style.underline && child.style.bold && !child.link) {
+        delimiterSpaceChar = <br />;
+      }
       if (child.style.underline && !child.link) {
         text = (
           <>


### PR DESCRIPTION
Related to https://github.com/news-catalyst/google-app-scripts/issues/379, this PR adds line breaks around text that is bold & underlined, or in other words, appears like a header but is actually formatted (technically, at least, in the google docs data) as normal text.

Before:

<img width="692" alt="Screen Shot 2021-11-29 at 1 11 03 pm" src="https://user-images.githubusercontent.com/3397/143920695-33ba46fd-f549-4882-8e96-3b1537ef7415.png">


After:

<img width="810" alt="Screen Shot 2021-11-29 at 1 10 41 pm" src="https://user-images.githubusercontent.com/3397/143920738-ed1a6067-8ea4-47c0-9845-ca6b26c1d5c7.png">

