### PR TITLE
ImageNode should find the node child with an actual image

### DIFF
--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -5,8 +5,11 @@ const Figure = tw.figure`my-4`;
 const Figcaption = tw.figcaption`text-gray-500 text-sm pt-1`;
 
 export default function ImageNode({ node, amp }) {
-  const image = node.children[0];
+  const image = node.children.find((child) => child.imageUrl);
 
+  if (!image) {
+    return null;
+  }
   const figure = amp ? (
     <amp-img
       width={710}


### PR DESCRIPTION
Closes #987 

The build for BBG was failing due to a problem with how the `ImageNode` detects an image element in the given node's list of children. I think this has become a bug due to the work I did recently around how the Google Docs add-on processes images in content originating in MS Word - in other words, the nodes now might contain images along with text, whereas before these images were being skipped.

Anyway, the `ImageNode` was relying on the `node.children[0]` to contain the image, but that's silly. Instead, this PR makes the `ImageNode` look for the child containing an image, and if none are found (unlikely, but just in case, for a node with a type indicating an image), don't try to render the image element for this node.