### PR TITLE
fixes spacing issues around links and special punctuation

### DIFF
--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -3,17 +3,40 @@ import { Blockquote, Paragraph, Anchor } from '../common/CommonStyles';
 
 export default function BlockquoteNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
+    let supportedPunctuation = [',', '.', '?', '!', ';', ':', '"', '“', '”'];
+    // omit the comma here, we want to add a space after a trailing comma
+    let supportedTrailingPunctuation = ['.', '?', '!', ';', ':', '"', '“', '”'];
+    let delimiterSpaceChar = ' ';
+    // if the next node/child starts with one of the punctuation marks above, don't add a space
+    if (
+      (nextChild &&
+        nextChild.content &&
+        nextChild.content[0] &&
+        supportedPunctuation.includes(nextChild.content[0])) ||
+      (child &&
+        child.content &&
+        child.content.slice(-1) &&
+        supportedTrailingPunctuation.includes(child.content.slice(-1)))
+    ) {
+      delimiterSpaceChar = '';
+    }
+
     let text = (
       <span key={child.index ? child.index : child.content}>
         {child.content}
+        {delimiterSpaceChar}
       </span>
     );
 
     if (child.link) {
       text = (
-        <Anchor meta={metadata} key={child.link} href={child.link}>
-          {text}
-        </Anchor>
+        <>
+          {delimiterSpaceChar}
+          <Anchor meta={metadata} key={child.link} href={child.link}>
+            {text}
+          </Anchor>
+          {delimiterSpaceChar}
+        </>
       );
     }
 

--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -3,14 +3,20 @@ import { Paragraph, H1, H2, H3, Anchor } from '../common/CommonStyles';
 
 export default function TextNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
-    let supportedPunctuation = [',', '.', '?', '!', ';', ':'];
+    let supportedPunctuation = [',', '.', '?', '!', ';', ':', '"', '“', '”'];
+    // omit the comma here, we want to add a space after a trailing comma
+    let supportedTrailingPunctuation = ['.', '?', '!', ';', ':', '"', '“', '”'];
     let delimiterSpaceChar = ' ';
     // if the next node/child starts with one of the punctuation marks above, don't add a space
     if (
-      nextChild &&
-      nextChild.content &&
-      nextChild.content[0] &&
-      supportedPunctuation.includes(nextChild.content[0])
+      (nextChild &&
+        nextChild.content &&
+        nextChild.content[0] &&
+        supportedPunctuation.includes(nextChild.content[0])) ||
+      (child &&
+        child.content &&
+        child.content.slice(-1) &&
+        supportedTrailingPunctuation.includes(child.content.slice(-1)))
     ) {
       delimiterSpaceChar = '';
     }
@@ -18,6 +24,7 @@ export default function TextNode({ node, metadata }) {
     let text = (
       <span key={child.index ? child.index : child.content}>
         {child.content}
+        {child.link ? '' : delimiterSpaceChar}
       </span>
     );
 
@@ -62,16 +69,20 @@ export default function TextNode({ node, metadata }) {
       text = (
         <>
           {text}
-          {delimiterSpaceChar}
+          {child.link ? '' : delimiterSpaceChar}
         </>
       );
     }
 
     if (child.link) {
       text = (
-        <Anchor key={child.link} href={child.link} meta={metadata}>
-          {text}
-        </Anchor>
+        <>
+          {delimiterSpaceChar}
+          <Anchor key={child.link} href={child.link} meta={metadata}>
+            {text}
+          </Anchor>
+          {delimiterSpaceChar}
+        </>
       );
     }
 


### PR DESCRIPTION
There were some issues with spacing around links, italics, within blockquotes, and around some kinds of punctuation. Using [the Franny Lou article](http://localhost:3000/articles/community/franny-lous-porch) as an example of content with a lot of different text formats, this PR adjusts how and when the text & blockquote nodes add whitespace as a delimiter:

* opening & closing fancy quotes are added to the list of punctuation that shouldn't get extra spacing (see `warm space` in the article for an example of this)
* supported trailing punctuation case added to allow for adding space delimiters _after_ a comma (see the list of links `Philly Farmacy, Bunny Hop, and local mural artist Joshua Grace`)
* spacing added properly around bold/italic/underlined text
* spacing added properly around links, but not _within_ links (no leading/trailing underscored/linked space characters)

You can easily compare this PR locally against [the deployed, unfixed version](https://next-tinynewsdemo.vercel.app/articles/community/franny-lous-porch) to quickly review.