### PR TITLE
bugfix for spacing around punctuation and links

### DIFF
--- a/components/nodes/TextNode.js
+++ b/components/nodes/TextNode.js
@@ -3,9 +3,21 @@ import { Paragraph, H1, H2, H3, Anchor } from '../common/CommonStyles';
 
 export default function TextNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
-    let supportedPunctuation = [',', '.', '?', '!', ';', ':', '"', '“', '”'];
-    // omit the comma here, we want to add a space after a trailing comma
-    let supportedTrailingPunctuation = ['.', '?', '!', ';', ':', '"', '“', '”'];
+    let supportedPunctuation = [
+      ',',
+      '.',
+      '?',
+      '!',
+      ';',
+      ':',
+      '"',
+      '“',
+      '”',
+
+      ')',
+    ];
+    // add a space after this list of punctuation: colon, comma, period
+    let supportedTrailingPunctuation = ['?', '!', ';', '"', '“', '”', '('];
     let delimiterSpaceChar = ' ';
     // if the next node/child starts with one of the punctuation marks above, don't add a space
     if (


### PR DESCRIPTION
Closes #1000

**_(Issue one thousand!)_**

TextNode formatting fix for some issues around spacing before and after punctuation with hyperlinks.

Note: this is an issue with links in particular because of how Google Docs treats them, as elements in the document separate from the surrounding text.

Using the new [Test Doc](https://docs.google.com/document/d/1LSyMzR1KxyKoml6q56DYQaxEV8Qm4EZo2y_xEFIkvGw/edit?addon_dry_run=AAnXSK9EA7M389bPWmMGwMDRpRdURqjSZkyegOHRl2lO2j0iMuM6SvnwjS0MrBnZzsX6UCG4KoR6LrN-bEOy00fIgI_zGFVis5xroiNXfzjfyQJ3RzkbuE5p6I_oE0UdRvBgQbH4EN5i#heading=h.mbmfrnnxfyot) I found problems with how spacing is rendered before/after colon, period and parentheses. See the linked issue for screenshot of how this looked before. Here is what you should see with these changes:

<img width="697" alt="Screen Shot 2021-12-09 at 11 25 11 am" src="https://user-images.githubusercontent.com/3397/145436369-17edbfef-e6bf-41ab-9055-19bf9b384bc4.png">

<img width="648" alt="Screen Shot 2021-12-09 at 11 25 20 am" src="https://user-images.githubusercontent.com/3397/145436395-2215485c-a209-428e-8de9-5cf5c1d59021.png">

[local linked article](http://localhost:3000/articles/community/test-doc-for-article-features)