### PR TITLE
Don't render a blockquote the child content is all blank, fixes #1021

### DIFF
--- a/components/nodes/BlockquoteNode.js
+++ b/components/nodes/BlockquoteNode.js
@@ -3,6 +3,9 @@ import { Blockquote, Paragraph, Anchor } from '../common/CommonStyles';
 
 export default function BlockquoteNode({ node, metadata }) {
   const processChild = function (child, nextChild) {
+    if (!child.content) {
+      return null;
+    }
     let supportedPunctuation = [',', '.', '?', '!', ';', ':', '"', '“', '”'];
     // omit the comma here, we want to add a space after a trailing comma
     let supportedTrailingPunctuation = ['.', '?', '!', ';', ':', '"', '“', '”'];
@@ -43,10 +46,20 @@ export default function BlockquoteNode({ node, metadata }) {
     return text;
   };
 
-  const children = node.children.map((child, i) =>
-    processChild(child, node.children[i + 1])
-  );
+  const children = node.children
+    .filter(function (child) {
+      if (!child.content) {
+        return false; // skip
+      }
+      return true;
+    })
+    .map((child, i) => {
+      return processChild(child, node.children[i + 1]);
+    });
 
+  if (!children || children.length <= 0) {
+    return null;
+  }
   let quotedContent = (
     <Blockquote meta={metadata}>
       <p tw="text-lg leading-relaxed">{children}</p>


### PR DESCRIPTION
<img width="739" alt="Screen Shot 2022-01-13 at 9 54 57 am" src="https://user-images.githubusercontent.com/3397/149354281-76bd3432-e014-4fd8-9e98-dd1c28c038ad.png">

This change allows blockquotes to appear if there is any actual content, otherwise prevents blank blockquotes from being rendered as was happening in the screenshot above, from Austin Vida ([link](http://localhost:3000/articles/community/sisepuede))