### PR TITLE
Remove en-US from sitemap URLs. #997

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -17,6 +17,10 @@ module.exports = {
       priority = 0.7;
     }
 
+    if (path.includes('/en-US/')) {
+      path = path.replace('/en-US', '');
+    }
+
     return {
       loc: path,
       changefreq: changefreq,


### PR DESCRIPTION
Thought about the sitemap/canonical issue and I think this is the right move for a couple reasons:

1. Our "default locale" in all cases is `en-US`. That is hardcoded in `next-config.js`.
2. This means that translated pages would get their own listing in the sitemap, but the default, unqualified URL will always go to the English version, and that should be the canonical URL.