### PR TITLE
Log stats from each GitHub Action data import job run

### DIFF
--- a/script/ga.js
+++ b/script/ga.js
@@ -611,8 +611,35 @@ async function importDataFromGA(params) {
 
   try {
     storeData(params, rows);
+    shared
+      .hasuraInsertDataImport({
+        orgSlug: apiToken,
+        url: apiUrl,
+        end_date: endDate,
+        start_date: startDate,
+        table_name: params['data'],
+        success: true,
+        row_count: rows.length,
+      })
+      .then((result) => {
+        console.log('stored data import status:', result);
+      });
   } catch (e) {
     console.error('error importing data into hasura:', e);
+    shared
+      .hasuraInsertDataImport({
+        url: params['url'],
+        orgSlug: params['orgSlug'],
+        end_date: endDate,
+        start_date: startDate,
+        table_name: params['data'],
+        success: false,
+        row_count: 0,
+        notes: JSON.stringify(e),
+      })
+      .then((result) => {
+        console.log('stored data import status:', result);
+      });
     throw e;
   }
 }

--- a/script/shared.js
+++ b/script/shared.js
@@ -73,6 +73,8 @@ function hasuraInsertDataImport(params) {
       end_date: params['end_date'],
       start_date: params['start_date'],
       table_name: params['table_name'],
+      success: params['success'],
+      row_count: params['row_count'],
     },
   });
 }


### PR DESCRIPTION
I set up this `ga_data_imports` table awhile ago to log the stats of each GH action data importer run. This PR adds the logging, either 

* successful runs log how many rows of data added for each metric
* failing runs log the error and general job details

This will let me make a simple status page in the future that I can glance at to ensure all systems are running as expected.