### PR TITLE
Fixes for (preview) article rendering issues

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -49,7 +49,9 @@ export default function Article({
 
       if (mainImageNode) {
         mainImage = mainImageNode.children[0];
-        siteMetadata['coverImage'] = mainImage.imageUrl;
+        if (mainImage.imageUrl) {
+          siteMetadata['coverImage'] = mainImage.imageUrl;
+        }
       }
     } catch (err) {
       console.error('error finding main image: ', err);

--- a/components/articles/MainImage.js
+++ b/components/articles/MainImage.js
@@ -10,6 +10,10 @@ export default function MainImage({ articleContent, isAmp }) {
     mainImage = mainImageNode.children[0];
   }
 
+  if (!mainImage || !mainImage.imageUrl) {
+    console.error('Missing image src:', mainImageNode);
+    return null;
+  }
   return (
     <>
       {mainImage && isAmp && (

--- a/components/nodes/EmbedNode.js
+++ b/components/nodes/EmbedNode.js
@@ -14,6 +14,10 @@ const EmbedWrapper = tw.div`mb-5 max-w-full w-full`;
 export default function EmbedNode({ node, amp }) {
   /* eslint-disable no-case-declarations */
   let el = null;
+  if (!node.link) {
+    console.error('Embed missing link:', node);
+    return null;
+  }
   const url = new URL(node.link);
   switch (url.hostname.replace('www.', '')) {
     case 'twitter.com':

--- a/components/nodes/EmbedNode.js
+++ b/components/nodes/EmbedNode.js
@@ -15,10 +15,22 @@ export default function EmbedNode({ node, amp }) {
   /* eslint-disable no-case-declarations */
   let el = null;
   if (!node.link) {
-    console.error('Embed missing link:', node);
+    console.error('Error rendering embed due to missing link:', node);
     return null;
   }
-  const url = new URL(node.link);
+
+  let url;
+  try {
+    url = new URL(node.link);
+  } catch (e) {
+    console.error(
+      `Error rendering embed due to invalid URL '${
+        node.link
+      }': ${JSON.stringify(e)}`
+    );
+    return null;
+  }
+
   switch (url.hostname.replace('www.', '')) {
     case 'twitter.com':
       el = <Twitter node={node} amp={amp} />;

--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -10,6 +10,10 @@ export default function ImageNode({ node, amp }) {
   if (!image) {
     return null;
   }
+  if (!image.imageUrl) {
+    console.error('IMAGE MISSING SRC:', node, image);
+    return null;
+  }
   const figure = amp ? (
     <amp-img
       width={710}

--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -11,7 +11,7 @@ export default function ImageNode({ node, amp }) {
     return null;
   }
   if (!image.imageUrl) {
-    console.error('IMAGE MISSING SRC:', node, image);
+    console.error('Error rendering image due to missing link:', node, image);
     return null;
   }
   const figure = amp ? (

--- a/lib/document.js
+++ b/lib/document.js
@@ -1323,7 +1323,7 @@ export async function uploadImageToS3(
   params.Key = destinationPath;
 
   try {
-    console.log('token:', oauthToken);
+    // console.log('token:', oauthToken);
     const data = await s3.upload(params).promise();
     console.log('uploadImage const data:', data);
     let imageData = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -286,7 +286,7 @@ export const renderBody = (
         }
         break;
       case 'image':
-        console.log('image node:', node);
+        // console.log('image node:', node);
         renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
         break;
       case 'embed':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -286,6 +286,7 @@ export const renderBody = (
         }
         break;
       case 'image':
+        console.log('image node:', node);
         renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
         break;
       case 'embed':


### PR DESCRIPTION
This PR adds some small validation / sanity checking / error reporting to article rendering, after we experienced some issues with the (likely) MS Word related formatting of [this specific document](https://docs.google.com/document/d/1kdjsbFb3k921WvmNdQzH57eOIWWnTgHZZlMzYBNg85g/edit?addon_dry_run=AAnXSK_Sy1pgmvoXr0yTAGF9KZVGI4ba0ZOUuuD4j_IrecuDQdabs-9PDaZRwaXoeGRPWPqmym1VMsMMtaTOdBH7oCqqplqoMBI6lIQulstz7zzpxohgJjMCQ8vCuK5SlsG-qhpViwcx):

* Image nodes: must have a valid `imageUrl` to be rendered
* Embed nodes: must have a valid embed url to be rendered
* Main image nodes: must have a valid `imageUrl` to be rendered _and_ to delegated as social media `coverImage` in meta tags

I am able to successfully preview the article produced by [this copy of the problematic document](https://docs.google.com/document/d/1kdjsbFb3k921WvmNdQzH57eOIWWnTgHZZlMzYBNg85g/edit?addon_dry_run=AAnXSK_Sy1pgmvoXr0yTAGF9KZVGI4ba0ZOUuuD4j_IrecuDQdabs-9PDaZRwaXoeGRPWPqmym1VMsMMtaTOdBH7oCqqplqoMBI6lIQulstz7zzpxohgJjMCQ8vCuK5SlsG-qhpViwcx) when using:

* Script editor latest code
* Sidebar Admin Tools pointing at my localhost API behind an ngrok-supplied URL
* Oaklyn environment config (didn't want to publish to BBG!)

I think these changes make sense to roll out in general - we can't render images or embeds without URLs and this should help us catch places where these links are either missing or badly formatted.