### PR TITLE
Allow manual runs of data importer jobs

### DIFF
--- a/.github/workflows/import-data-from-ga-ang-diaryo.yml
+++ b/.github/workflows/import-data-from-ga-ang-diaryo.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Ang Diaryo
 'on':
   schedule:
     - cron: 5 9 * * *
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-austin-vida.yml
+++ b/.github/workflows/import-data-from-ga-austin-vida.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Austin Vida
 'on':
   schedule:
     - cron: 5 9 * * *
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-five-wards-media.yml
+++ b/.github/workflows/import-data-from-ga-five-wards-media.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Five Wards Media
 'on':
   schedule:
     - cron: 5 9 * * *
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-harvey-world-herald.yml
+++ b/.github/workflows/import-data-from-ga-harvey-world-herald.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Harvey World Herald
 'on':
   schedule:
     - cron: 5 9 * * *
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga-spotlight-schools.yml
+++ b/.github/workflows/import-data-from-ga-spotlight-schools.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Spotlight Schools
 'on':
   schedule:
     - cron: 5 9 * * *
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest

--- a/.github/workflows/import-data-from-ga.yml
+++ b/.github/workflows/import-data-from-ga.yml
@@ -2,6 +2,7 @@ name: GA Data Importer Oaklyn
 on:
   schedule:
     - cron: '5 9 * * *'
+  workflow_dispatch:
 jobs:
   GA-Data-Importer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In order to run any of the data importer jobs on demand (in addition to the currently configured cron schedule), the GH action workflow files need a [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) event configured. I just tested this on the BBG workflow and it works great. Adding this option to the configuration yaml files results in a new button showing up on the GH Action pages, offering a way to manually run the workflow on demand:

<img width="955" alt="Screen Shot 2022-01-24 at 10 48 37 am" src="https://user-images.githubusercontent.com/3397/150817309-90c4a084-1666-436c-8e94-91fcd0c326d2.png">

I added this to the template file used when we bootstrap new TNC orgs so this feature should be included going forward.