### PR TITLE
bugfix: await image upload to s3

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -34,7 +34,7 @@ export async function processDocumentContents(
   // var listElementChildren = [];
   var elementCount = elements.length;
 
-  elements.forEach((element) => {
+  for (const element of elements) {
     // console.log('element: ' + JSON.stringify(element));
     if (element.paragraph && element.paragraph.elements) {
       // console.log("paragraph element: " + JSON.stringify(element))
@@ -183,7 +183,7 @@ export async function processDocumentContents(
         }
       }
 
-      element.paragraph.elements.forEach((subElement) => {
+      for (const subElement of element.paragraph.elements) {
         // console.log('subElement:', subElement);
 
         var newEleData;
@@ -350,26 +350,25 @@ export async function processDocumentContents(
                     .imageProperties.contentUri
                 );
 
-                uploadImageToS3(
+                const data = await uploadImageToS3(
                   oauthToken,
                   imageID,
                   fullImageData.inlineObjectProperties.embeddedObject
                     .imageProperties.contentUri,
                   slug
-                ).then((data) => {
-                  s3Url = data.s3Url;
+                );
+                s3Url = data.s3Url;
 
-                  imageList[imageID] = s3Url;
+                imageList[imageID] = s3Url;
 
-                  if (data && data.height) {
-                    imageHeight = data.height;
-                    // console.log('Image Height: ', imageHeight);
-                  }
-                  if (data && data.width) {
-                    imageWidth = data.width;
-                    // console.log('Image Width: ', imageWidth);
-                  }
-                });
+                if (data && data.height) {
+                  imageHeight = data.height;
+                  // console.log('Image Height: ', imageHeight);
+                }
+                if (data && data.width) {
+                  imageWidth = data.width;
+                  // console.log('Image Width: ', imageWidth);
+                }
               } else {
                 // console.log(slug + " " + imageID + " has already been uploaded: " + articleSlugMatches + " " + s3Url);
                 imageList[imageID] = s3Url;
@@ -431,7 +430,7 @@ export async function processDocumentContents(
             }
           }
         }
-      });
+      }
       // skip any blank elements, embeds and lists because they've already been handled above
       if (
         storeElement &&
@@ -449,7 +448,7 @@ export async function processDocumentContents(
       }
     }
     elementsProcessed++;
-  });
+  }
 
   let formattedElements = formatElements(orderedElements);
   let mainImage = getMainImage(formattedElements);


### PR DESCRIPTION
Closes #1050 

Fixes the issue where newly uploaded images were missing URLs. This was happening because the images were being uploaded but the code wasn't waiting for the upload function to return the S3 URL. Subsequent saves (preview or publish) would "fix" this because in those cases the image would have already been uploaded.

The code fix:

1. added `await` ahead of the async upload function call
2. switched the two `forEach` loops to `for` loops so we could use the reserved word `await`