### PR TITLE
Fix Twitter meta image tag

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -200,7 +200,7 @@ export default function Layout({
         {metaValues.authorTwitter && (
           <meta name="twitter:creator" content={metaValues.authorTwitter} />
         )}
-        <meta name="twitter:image:src" content={metaValues.coverImage} />
+        <meta name="twitter:image" content={metaValues.coverImage} />
 
         {/* Facebook data */}
         <meta property="og:title" content={metaValues.facebookTitle} />


### PR DESCRIPTION
Basic one-line change, based on [these docs](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image). Closes #1053 