### PR TITLE
Bugfix: support accented characters in tinycms settings text input fields

### DIFF
--- a/components/tinycms/ControlledInput.js
+++ b/components/tinycms/ControlledInput.js
@@ -11,6 +11,7 @@ const ControlledInput = (props) => {
 
   useEffect(() => {
     const input = ref.current;
+
     if (input) input.setSelectionRange(cursor, cursor);
   }, [ref, cursor, value]);
 

--- a/components/tinycms/DonationOption.js
+++ b/components/tinycms/DonationOption.js
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import tw, { css, styled } from 'twin.macro';
+
+import ControlledInput from './ControlledInput';
+import { TinyInputField } from './TinyFormElements';
+
+const Input = styled.input`
+  ${tw`px-3 py-3 mb-4 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
+`;
+
+export default function DonationOption(props) {
+  const [index, setIndex] = useState(props.index);
+
+  const [name, setName] = useState(props.name);
+  const [cta, setCTA] = useState(props.cta);
+  const [desc, setDesc] = useState(props.desc);
+  const [paymentType, setPaymentType] = useState(props.paymentType);
+  const [monkeypodId, setMonkeypodId] = useState(props.monkeypodId);
+  const [amount, setAmount] = useState(props.amount);
+
+  const updateName = (index, value) => {
+    setName(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].name = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+
+  const updateCTA = (index, value) => {
+    setCTA(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].cta = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+  return (
+    <div key={`option-${index}`}>
+      <div tw="mt-2">
+        <TinyInputField
+          tw="w-full rounded-md border-solid border-gray-300"
+          name={`donationOptions-${index}-name`}
+          value={name}
+          onChange={(ev) => updateName(index, ev.target.value)}
+          label="Option name"
+        />
+      </div>
+      <div tw="mt-2">
+        <label htmlFor={`donationOptions-${index}-amount`}>
+          <span tw="mt-1 font-bold">Option amount</span>
+          <Input
+            tw="w-full rounded-md border-solid border-gray-300"
+            type="number"
+            name={`donationOptions-${index}-amount`}
+            value={amount}
+            onChange={(ev) => setAmount(ev.target.value)}
+          />
+        </label>
+      </div>
+      <div tw="mt-2 mb-8">
+        <label tw="block">
+          <input
+            type="radio"
+            name={`donationOptions-${index}-paymentType`}
+            value="monthly"
+            checked={paymentType === 'monthly'}
+            onChange={(ev) => setPaymentType(ev.target)}
+          />
+          <span tw="p-2 mt-1 font-bold">Monthly</span>
+        </label>
+        <label tw="block">
+          <input
+            type="radio"
+            name={`donationOptions-${index}-paymentType`}
+            value="one-time"
+            checked={paymentType === 'one-time'}
+            onChange={(ev) => setPaymentType(ev.target)}
+          />
+          <span tw="p-2 mt-1 font-bold">One-time payment</span>
+        </label>
+        <label tw="block">
+          <input
+            type="radio"
+            name={`donationOptions-${index}-paymentType`}
+            value="pay-what-you-want"
+            checked={paymentType === 'pay-what-you-want'}
+            onChange={(ev) => setPaymentType(ev.target)}
+          />
+          <span tw="p-2 mt-1 font-bold">Pay what you want</span>
+        </label>
+      </div>
+      <div tw="mt-2">
+        <TinyInputField
+          tw="w-full rounded-md border-solid border-gray-300"
+          name={`donationOptions-${index}-description`}
+          value={desc}
+          onChange={(ev) => setDesc(ev.target.value)}
+          label="Option description"
+        />
+      </div>
+      <div tw="mt-2">
+        <TinyInputField
+          tw="w-full rounded-md border-solid border-gray-300"
+          name={`donationOptions-${index}-cta`}
+          value={cta}
+          onChange={(ev) => updateCTA(index, ev.target.value)}
+          label="Option CTA"
+        />
+      </div>
+      <div tw="mt-2">
+        <label htmlFor={`donationOptions-${index}-monkeypodId`}>
+          <span tw="mt-1 font-bold">Option MonkeyPod ID</span>
+          <ControlledInput
+            tw="w-full rounded-md border-solid border-gray-300"
+            type="text"
+            name={`donationOptions-${index}-monkeypodId`}
+            value={monkeypodId}
+            onChange={(ev) => setMonkeypodId(ev.target.value)}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -930,6 +930,7 @@ export default function SiteInfoSettings(props) {
           donationOptions.map((option, i) => (
             <DonationOption
               index={i}
+              key={`option-${i}`}
               name={option.name}
               cta={option.cta}
               desc={option.description}

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -8,6 +8,7 @@ import DonationOptionsBlock from '../plugins/DonationOptionsBlock';
 import ControlledInput from './ControlledInput';
 import Upload from './Upload';
 import TinyEditor from './TinyEditor';
+import { TinyInputField } from './TinyFormElements';
 
 const SettingsHeader = tw.h1`text-4xl font-bold leading-normal mt-0 mb-2 text-black`;
 const SiteInfoFieldsContainer = tw.div`grid grid-cols-3 gap-4`;
@@ -411,24 +412,18 @@ export default function SiteInfoSettings(props) {
       </SettingsHeader>
 
       <SiteInfoFieldsContainer>
-        <label htmlFor="shortName">
-          <span tw="mt-1 font-bold">Site name</span>
-          <ControlledInput
-            type="text"
-            name="shortName"
-            value={shortName}
-            onChange={props.handleChange}
-          />
-        </label>
-        <label htmlFor="siteUrl">
-          <span tw="mt-1 font-bold">Site URL</span>
-          <ControlledInput
-            type="text"
-            name="siteUrl"
-            value={siteUrl}
-            onChange={props.handleChange}
-          />
-        </label>
+        <TinyInputField
+          name="shortName"
+          value={shortName}
+          onChange={(ev) => setShortName(ev.target.value)}
+          label="Site name"
+        />
+        <TinyInputField
+          name="siteUrl"
+          value={siteUrl}
+          onChange={(ev) => setSiteUrl(ev.target.value)}
+          label="Site URL"
+        />
         <label htmlFor="timeZone">
           <span tw="mt-1 font-bold">Time Zone</span>
           <Select
@@ -718,15 +713,12 @@ export default function SiteInfoSettings(props) {
       <HomepagePromoContainer ref={props.homepagePromoRef} id="homepage-promo">
         <SettingsHeader tw="col-span-3 mt-5">Homepage promo bar</SettingsHeader>
         <div>
-          <label htmlFor="heading">
-            <span tw="w-full mt-1 font-bold">About promo heading</span>
-            <ControlledInput
-              type="text"
-              name="aboutHed"
-              value={aboutHed}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="aboutHed"
+            value={aboutHed}
+            onChange={(ev) => setAboutHed(ev.target.value)}
+            label="About promo heading"
+          />
           <label htmlFor="description">
             <span tw="mt-1 font-bold">About promo description</span>
             <TinyEditor
@@ -735,26 +727,21 @@ export default function SiteInfoSettings(props) {
               value={staticAboutDek}
             />
           </label>
-          <label htmlFor="cta">
-            <span tw="mt-1 font-bold">About call to action</span>
-            <ControlledInput
-              type="text"
-              name="aboutCTA"
-              value={aboutCTA}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="aboutCTA"
+            value={aboutCTA}
+            onChange={(ev) => setAboutCTA(ev.target.value)}
+            label="About call to action"
+          />
         </div>
         <div>
-          <label htmlFor="heading">
-            <span tw="w-full mt-1 font-bold">Support promo heading</span>
-            <ControlledInput
-              type="text"
-              name="supportHed"
-              value={supportHed}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="supportHed"
+            value={supportHed}
+            onChange={(ev) => setSupportHed(ev.target.value)}
+            label="Support promo heading"
+          />
+
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Support promo description</span>
             <TinyEditor
@@ -763,15 +750,12 @@ export default function SiteInfoSettings(props) {
               value={staticSupportDek}
             />
           </label>
-          <label htmlFor="description">
-            <span tw="mt-1 font-bold">Support call to action</span>
-            <ControlledInput
-              type="text"
-              name="supportCTA"
-              value={supportCTA}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="supportCTA"
+            value={supportCTA}
+            onChange={(ev) => setSupportCTA(ev.target.value)}
+            label="Support call to action"
+          />
         </div>
       </HomepagePromoContainer>
       <div>
@@ -784,15 +768,13 @@ export default function SiteInfoSettings(props) {
         </SettingsHeader>
 
         <div tw="col-span-1">
-          <label htmlFor="heading">
-            <span tw="w-full mt-1 font-bold">Heading</span>
-            <ControlledInput
-              type="text"
-              name="newsletterHed"
-              value={newsletterHed}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="newsletterHed"
+            value={newsletterHed}
+            onChange={(ev) => setNewsletterHed(ev.target.value)}
+            label="Heading"
+          />
+
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
             <TinyEditor
@@ -824,15 +806,12 @@ export default function SiteInfoSettings(props) {
         </SettingsHeader>
 
         <div tw="col-span-1">
-          <label htmlFor="heading">
-            <span tw="w-full mt-1 font-bold">Heading</span>
-            <ControlledInput
-              type="text"
-              name="membershipHed"
-              value={membershipHed}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="membershipHed"
+            value={membershipHed}
+            onChange={(ev) => setMembershipHed(ev.target.value)}
+            label="Heading"
+          />
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
             <TinyEditor
@@ -841,15 +820,12 @@ export default function SiteInfoSettings(props) {
               value={staticMembershipDek}
             />
           </label>
-          <label htmlFor="CTA">
-            <span tw="mt-1 font-bold">CTA</span>
-            <ControlledInput
-              type="text"
-              name="membershipCTA"
-              value={membershipCTA}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="membershipCTA"
+            value={membershipCTA}
+            onChange={(ev) => setMembershipCTA(ev.target.value)}
+            label="CTA"
+          />
         </div>
         <div tw="col-span-1">
           <span tw="mt-1 font-bold">Preview</span>

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -5,6 +5,7 @@ import NewsletterBlock from '../plugins/NewsletterBlock';
 import HomepagePromoBar from '../homepage/HomepagePromoBar';
 import AdPromotion from '../ads/AdPromotion';
 import DonationOptionsBlock from '../plugins/DonationOptionsBlock';
+import DonationOption from './DonationOption';
 import ControlledInput from './ControlledInput';
 import Upload from './Upload';
 import TinyEditor from './TinyEditor';
@@ -284,6 +285,50 @@ export default function SiteInfoSettings(props) {
     props.parsedData['donationOptions'] ? parsedDonationOptions : null
   );
 
+  const updateKeyValue = (key, value) => {
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      [key]: value,
+    }));
+  };
+
+  const updateAboutCTA = (value) => {
+    setAboutCTA(value);
+    updateKeyValue('aboutCTA', value);
+  };
+  const updateAboutHed = (value) => {
+    setAboutHed(value);
+    updateKeyValue('aboutHed', value);
+  };
+  const updateSupportCTA = (value) => {
+    setSupportCTA(value);
+    updateKeyValue('supportCTA', value);
+  };
+  const updateSupportHed = (value) => {
+    setSupportHed(value);
+    updateKeyValue('supportHed', value);
+  };
+  const updateNewsletterHed = (value) => {
+    setNewsletterHed(value);
+    updateKeyValue('newsletterHed', value);
+  };
+  const updateMembershipHed = (value) => {
+    setMembershipHed(value);
+
+    updateKeyValue('membershipHed', value);
+  };
+  const updateMembershipCTA = (value) => {
+    setMembershipCTA(value);
+    updateKeyValue('membershipCTA', value);
+  };
+  const updateAdvertisingCTA = (value) => {
+    setAdvertisingCTA(value);
+    updateKeyValue('advertisingCTA', value);
+  };
+  const updateAdvertisingHed = (value) => {
+    setAdvertisingHed(value);
+    updateKeyValue('advertisingHed', value);
+  };
   const handleAboutDekEditorChange = (value) => {
     let content = value;
     setAboutDek(content);
@@ -415,7 +460,10 @@ export default function SiteInfoSettings(props) {
         <TinyInputField
           name="shortName"
           value={shortName}
-          onChange={(ev) => setShortName(ev.target.value)}
+          onChange={(ev) => {
+            setShortName(ev.target.value);
+            updateKeyValue('shortName', ev.target.value);
+          }}
           label="Site name"
         />
         <TinyInputField
@@ -716,7 +764,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="aboutHed"
             value={aboutHed}
-            onChange={(ev) => setAboutHed(ev.target.value)}
+            onChange={(ev) => updateAboutHed(ev.target.value)}
             label="About promo heading"
           />
           <label htmlFor="description">
@@ -730,7 +778,9 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="aboutCTA"
             value={aboutCTA}
-            onChange={(ev) => setAboutCTA(ev.target.value)}
+            onChange={(ev) => {
+              updateAboutCTA(ev.target.value);
+            }}
             label="About call to action"
           />
         </div>
@@ -738,7 +788,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="supportHed"
             value={supportHed}
-            onChange={(ev) => setSupportHed(ev.target.value)}
+            onChange={(ev) => updateSupportHed(ev.target.value)}
             label="Support promo heading"
           />
 
@@ -753,7 +803,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="supportCTA"
             value={supportCTA}
-            onChange={(ev) => setSupportCTA(ev.target.value)}
+            onChange={(ev) => updateSupportCTA(ev.target.value)}
             label="Support call to action"
           />
         </div>
@@ -771,7 +821,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="newsletterHed"
             value={newsletterHed}
-            onChange={(ev) => setNewsletterHed(ev.target.value)}
+            onChange={(ev) => updateNewsletterHed(ev.target.value)}
             label="Heading"
           />
 
@@ -809,7 +859,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="membershipHed"
             value={membershipHed}
-            onChange={(ev) => setMembershipHed(ev.target.value)}
+            onChange={(ev) => updateMembershipHed(ev.target.value)}
             label="Heading"
           />
           <label htmlFor="description">
@@ -823,7 +873,7 @@ export default function SiteInfoSettings(props) {
           <TinyInputField
             name="membershipCTA"
             value={membershipCTA}
-            onChange={(ev) => setMembershipCTA(ev.target.value)}
+            onChange={(ev) => updateMembershipCTA(ev.target.value)}
             label="CTA"
           />
         </div>
@@ -846,15 +896,12 @@ export default function SiteInfoSettings(props) {
         </p>
 
         <div tw="col-span-1">
-          <label htmlFor="heading">
-            <span tw="w-full mt-1 font-bold">Heading</span>
-            <ControlledInput
-              type="text"
-              name="advertisingHed"
-              value={advertisingHed}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="advertisingHed"
+            value={advertisingHed}
+            onChange={(ev) => updateAdvertisingHed(ev.target.value)}
+            label="Heading"
+          />
           <label htmlFor="description">
             <span tw="mt-1 font-bold">Description</span>
             <TinyEditor
@@ -863,15 +910,12 @@ export default function SiteInfoSettings(props) {
               value={staticAdvertisingDek}
             />
           </label>
-          <label htmlFor="CTA">
-            <span tw="mt-1 font-bold">CTA</span>
-            <ControlledInput
-              type="text"
-              name="advertisingCTA"
-              value={advertisingCTA}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="advertisingCTA"
+            value={advertisingCTA}
+            onChange={(ev) => updateAdvertisingCTA(ev.target.value)}
+            label="CTA"
+          />
         </div>
         <div tw="col-span-1">
           <span tw="mt-1 font-bold">Preview</span>
@@ -884,100 +928,17 @@ export default function SiteInfoSettings(props) {
         <SettingsHeader tw="col-span-3 mt-5">Payment options</SettingsHeader>
         {Array.isArray(donationOptions) &&
           donationOptions.map((option, i) => (
-            <div key={`option-${i}`}>
-              <div tw="mt-2">
-                <label htmlFor={`donationOptions-${i}-name`}>
-                  <span tw="mt-1 font-bold">Option name</span>
-                  <ControlledInput
-                    tw="w-full rounded-md border-solid border-gray-300"
-                    type="text"
-                    name={`donationOptions-${i}-name`}
-                    value={option.name}
-                    onChange={props.handleChange}
-                  />
-                </label>
-              </div>
-              <div tw="mt-2">
-                <label htmlFor={`donationOptions-${i}-amount`}>
-                  <span tw="mt-1 font-bold">Option amount</span>
-                  <Input
-                    tw="w-full rounded-md border-solid border-gray-300"
-                    type="number"
-                    name={`donationOptions-${i}-amount`}
-                    value={option.amount}
-                    onChange={props.handleChange}
-                  />
-                </label>
-              </div>
-              <div tw="mt-2 mb-8">
-                <label tw="block">
-                  <input
-                    type="radio"
-                    name={`donationOptions-${i}-paymentType`}
-                    value="monthly"
-                    checked={option.paymentType === 'monthly'}
-                    onChange={props.handleChange}
-                  />
-                  <span tw="p-2 mt-1 font-bold">Monthly</span>
-                </label>
-                <label tw="block">
-                  <input
-                    type="radio"
-                    name={`donationOptions-${i}-paymentType`}
-                    value="one-time"
-                    checked={option.paymentType === 'one-time'}
-                    onChange={props.handleChange}
-                  />
-                  <span tw="p-2 mt-1 font-bold">One-time payment</span>
-                </label>
-                <label tw="block">
-                  <input
-                    type="radio"
-                    name={`donationOptions-${i}-paymentType`}
-                    value="pay-what-you-want"
-                    checked={option.paymentType === 'pay-what-you-want'}
-                    onChange={props.handleChange}
-                  />
-                  <span tw="p-2 mt-1 font-bold">Pay what you want</span>
-                </label>
-              </div>
-              <div tw="mt-2">
-                <label htmlFor={`donationOptions-${i}-description`}>
-                  <span tw="mt-1 font-bold">Option Description</span>
-                  <ControlledInput
-                    tw="w-full rounded-md border-solid border-gray-300"
-                    type="text"
-                    name={`donationOptions-${i}-description`}
-                    value={option.description}
-                    onChange={props.handleChange}
-                  />
-                </label>
-              </div>
-              <div tw="mt-2">
-                <label htmlFor={`donationOptions-${i}-cta`}>
-                  <span tw="mt-1 font-bold">Option CTA</span>
-                  <ControlledInput
-                    tw="w-full rounded-md border-solid border-gray-300"
-                    type="text"
-                    name={`donationOptions-${i}-cta`}
-                    value={option.cta}
-                    onChange={props.handleChange}
-                  />
-                </label>
-              </div>
-              <div tw="mt-2">
-                <label htmlFor={`donationOptions-${i}-monkeypodId`}>
-                  <span tw="mt-1 font-bold">Option MonkeyPod ID</span>
-                  <ControlledInput
-                    tw="w-full rounded-md border-solid border-gray-300"
-                    type="text"
-                    name={`donationOptions-${i}-monkeypodId`}
-                    value={option.monkeypodId}
-                    onChange={props.handleChange}
-                  />
-                </label>
-              </div>
-            </div>
+            <DonationOption
+              index={i}
+              name={option.name}
+              cta={option.cta}
+              desc={option.description}
+              amount={option.amount}
+              paymentType={option.paymentType}
+              monkeypodId={option.monkeypodId}
+              parsedData={props.parsedData}
+              updateParsedData={props.updateParsedData}
+            />
           ))}
       </DonationOptionsEditor>
 
@@ -1018,28 +979,26 @@ export default function SiteInfoSettings(props) {
         </div>
 
         <div tw="mt-2">
-          <label htmlFor="searchTitle">
-            <span tw="mt-1 font-bold">Search title</span>
-            <ControlledInput
-              tw="w-full rounded-md border-solid border-gray-300"
-              type="text"
-              name="searchTitle"
-              value={searchTitle}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="searchTitle"
+            value={searchTitle}
+            onChange={(ev) => {
+              setSearchTitle(ev.target.value);
+              updateKeyValue('searchTitle', ev.target.value);
+            }}
+            label="Search title"
+          />
         </div>
         <div tw="mt-2">
-          <label htmlFor="searchDescription">
-            <span tw="mt-1 font-bold">Search description</span>
-            <ControlledInput
-              tw="w-full"
-              type="text"
-              name="searchDescription"
-              value={searchDescription}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="searchDescription"
+            value={searchDescription}
+            onChange={(ev) => {
+              setSearchDescription(ev.target.value);
+              updateKeyValue('searchDescription', ev.target.value);
+            }}
+            label="Search description"
+          />
         </div>
         <div tw="mt-2">
           <label htmlFor="facebookAdmins">
@@ -1070,28 +1029,26 @@ export default function SiteInfoSettings(props) {
           </label>
         </div>
         <div tw="mt-2">
-          <label htmlFor="facebookTitle">
-            <span tw="mt-1 font-bold">Facebook title</span>
-            <ControlledInput
-              tw="w-full"
-              type="text"
-              name="facebookTitle"
-              value={facebookTitle}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="facebookTitle"
+            value={facebookTitle}
+            onChange={(ev) => {
+              setFacebookTitle(ev.target.value);
+              updateKeyValue('facebookTitle', ev.target.value);
+            }}
+            label="Facebook title"
+          />
         </div>
         <div tw="mt-2">
-          <label htmlFor="facebookDescription">
-            <span tw="mt-1 font-bold">Facebook description</span>
-            <ControlledInput
-              tw="w-full"
-              type="text"
-              name="facebookDescription"
-              value={facebookDescription}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="facebookDescription"
+            value={facebookDescription}
+            onChange={(ev) => {
+              setFacebookDescription(ev.target.value);
+              updateKeyValue('facebookDescription', ev.target.value);
+            }}
+            label="Facebook description"
+          />
         </div>
         <div tw="mt-2">
           <label htmlFor="siteTwitter">
@@ -1106,28 +1063,26 @@ export default function SiteInfoSettings(props) {
           </label>
         </div>
         <div tw="mt-2">
-          <label htmlFor="twitterTitle">
-            <span tw="mt-1 font-bold">Twitter title</span>
-            <ControlledInput
-              tw="w-full"
-              type="text"
-              name="twitterTitle"
-              value={twitterTitle}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="twitterTitle"
+            value={twitterTitle}
+            onChange={(ev) => {
+              setTwitterTitle(ev.target.value);
+              updateKeyValue('twitterTitle', ev.target.value);
+            }}
+            label="Twitter title"
+          />
         </div>
         <div tw="mt-2">
-          <label htmlFor="twitterDescription">
-            <span tw="mt-1 font-bold">Twitter description</span>
-            <ControlledInput
-              tw="w-full"
-              type="text"
-              name="twitterDescription"
-              value={twitterDescription}
-              onChange={props.handleChange}
-            />
-          </label>
+          <TinyInputField
+            name="twitterDescription"
+            value={twitterDescription}
+            onChange={(ev) => {
+              setTwitterDescription(ev.target.value);
+              updateKeyValue('twitterDescription', ev.target.value);
+            }}
+            label="Twitter description"
+          />
         </div>
         <div tw="mt-2">
           <label htmlFor="founderTwitter">

--- a/components/tinycms/TinyFormElements.js
+++ b/components/tinycms/TinyFormElements.js
@@ -48,8 +48,14 @@ TinySubmitCancelButtons.displayName = 'TinySubmitCancelButtons';
 export const TinyInputField = ({ name, onChange, value, label, ...props }) => {
   return (
     <label htmlFor={name}>
-      <span tw="block font-medium text-gray-700">{label}</span>
-      <Input type="text" value={value} name={name} onChange={onChange} />
+      <span tw="block font-bold">{label}</span>
+      <Input
+        type="text"
+        value={value}
+        name={name}
+        onChange={onChange}
+        {...props}
+      />
     </label>
   );
 };

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -87,37 +87,34 @@ export default function Settings({
       return false;
     }
   };
+
+  const handleKeyDown = (e) => {
+    console.log('keyCode:', e.keyCode);
+    if (e.keyCode === 18) {
+      console.log('preventing default');
+      e.preventDefault();
+    }
+  };
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
 
-    if (name.startsWith('donationOptions')) {
-      const i = name.split('-')[1];
-      const property = name.split('-')[2];
-      setParsedData((prevState) => {
-        const newState = Object.assign({ ...prevState });
-        const newStateDonationOptions = JSON.parse(newState.donationOptions);
-        newStateDonationOptions[parseInt(i)][property] = value;
-        newState.donationOptions = JSON.stringify(newStateDonationOptions);
-        return newState;
-      });
+    if (type === 'checkbox') {
+      setParsedData((prevState) => ({
+        ...prevState,
+        [name]: checked,
+      }));
+    } else if (type === 'radio') {
+      setParsedData((prevState) => ({
+        ...prevState,
+        [name]: value,
+      }));
     } else {
-      if (type === 'checkbox') {
-        setParsedData((prevState) => ({
-          ...prevState,
-          [name]: checked,
-        }));
-      } else if (type === 'radio') {
-        setParsedData((prevState) => ({
-          ...prevState,
-          [name]: value,
-        }));
-      } else {
-        setParsedData((prevState) => ({
-          ...prevState,
-          [name]: value,
-        }));
-      }
+      setParsedData((prevState) => ({
+        ...prevState,
+        [name]: value,
+      }));
     }
+
     // select typography
     if (name === 'theme') {
       setParsedData((prevState) => ({
@@ -401,6 +398,7 @@ export default function Settings({
                 homepagePromoRef={homepagePromoRef}
                 paymentRef={paymentRef}
                 handleChange={handleChange}
+                handleKeyDown={handleKeyDown}
                 parsedData={parsedData}
                 updateParsedData={setParsedData}
                 awsConfig={awsConfig}
@@ -436,7 +434,7 @@ export async function getServerSideProps(context) {
   } else {
     locales = data.organization_locales;
     siteMetadata = data.site_metadatas[0];
-    console.log('siteMetadata:', siteMetadata);
+    console.log('siteMetadata:', JSON.stringify(siteMetadata));
   }
   if (siteMetadata === undefined) {
     siteMetadata = null;


### PR DESCRIPTION
Closes #1044 

This turned out to be more complex than anticipated, but the tinycms settings fields should all support combination character entry, like for accented léttèrs, at least on a Mac. _(I don't have access to Windows while I'm traveling - it's not on the macbook I have with me. I could try setting it up but it's a lengthy process IIRC)_

To test, open http://localhost:3000/tinycms/settings and try entering accented text in the following fields:

* site name
* homepage promo about & support headings & CTA
* newsletter block heading
* membership block heading & CTA
* advertising block heading & CTA
* payment options name, description, CTA * 3 (for each option)
* search title & description
* twitter title & description
* facebook title & description

The field values should update as one would expect. Where there's a preview panel, it should also update with the new value. Saving the form should also store all the new fields, with or without accents.

One last note: I didn't change fields that store URLs or dollar amounts to support accented letters. I didn't think they had to or should support more than basic latin characters, and I was trying to change the least amount of things. 

Let me know if I've missed one that should süppørt these special chars - I'll fix it up. Hopefully I covered what we needed, though.