### PR TITLE
New feature: Google Forms embed support

### DIFF
--- a/components/nodes/EmbedNode.js
+++ b/components/nodes/EmbedNode.js
@@ -8,6 +8,7 @@ import Spotify from './embeds/Spotify';
 import ApplePodcasts from './embeds/ApplePodcasts';
 import Vimeo from './embeds/Vimeo';
 import Twitch from './embeds/Twitch';
+import GoogleForm from './embeds/GoogleForm';
 
 const EmbedWrapper = tw.div`mb-5 max-w-full w-full`;
 
@@ -58,6 +59,14 @@ export default function EmbedNode({ node, amp }) {
       break;
     case 'twitch.tv':
       el = <Twitch node={node} amp={amp} url={url} />;
+      break;
+    case 'forms.gle':
+      el = <GoogleForm node={node} amp={amp} />;
+      break;
+    case 'docs.google.com':
+      if (url.pathname.match(/^\/forms/)) {
+        el = <GoogleForm node={node} amp={amp} />;
+      }
       break;
     default:
       el = (

--- a/components/nodes/embeds/GoogleForm.js
+++ b/components/nodes/embeds/GoogleForm.js
@@ -1,0 +1,15 @@
+export default function GoogleForm({ node, amp }) {
+  const el = amp ? (
+    <div />
+  ) : (
+    <iframe
+      src={node.link}
+      width="640"
+      height="640"
+      frameBorder="0"
+      marginheight="0"
+      marginwidth="0"
+    />
+  );
+  return el;
+}

--- a/components/nodes/embeds/GoogleForm.js
+++ b/components/nodes/embeds/GoogleForm.js
@@ -4,8 +4,8 @@ export default function GoogleForm({ node, amp }) {
   ) : (
     <iframe
       src={node.link}
-      width="640"
-      height="640"
+      width="100%"
+      height="640px"
       frameBorder="0"
       marginHeight="0"
       marginWidth="0"

--- a/components/nodes/embeds/GoogleForm.js
+++ b/components/nodes/embeds/GoogleForm.js
@@ -7,8 +7,8 @@ export default function GoogleForm({ node, amp }) {
       width="640"
       height="640"
       frameBorder="0"
-      marginheight="0"
-      marginwidth="0"
+      marginHeight="0"
+      marginWidth="0"
     />
   );
   return el;

--- a/cypress/integration/document_parser_spec.js
+++ b/cypress/integration/document_parser_spec.js
@@ -11,192 +11,180 @@ describe('document API', () => {
     {
       sectionBreak: {
         sectionStyle: {
+          sectionType: 'CONTINUOUS',
           contentDirection: 'LEFT_TO_RIGHT',
           columnSeparatorStyle: 'NONE',
-          sectionType: 'CONTINUOUS',
         },
       },
       endIndex: 1,
     },
     {
+      startIndex: 1,
       paragraph: {
+        paragraphStyle: {
+          namedStyleType: 'NORMAL_TEXT',
+          direction: 'LEFT_TO_RIGHT',
+        },
         elements: [
           {
             endIndex: 29,
-            textRun: {
-              content: 'This sentence has a word in ',
-              textStyle: {},
-            },
             startIndex: 1,
+            textRun: {
+              textStyle: {},
+              content: 'This sentence has a word in ',
+            },
           },
           {
-            endIndex: 33,
             textRun: {
               content: 'bold',
               textStyle: {
                 bold: true,
               },
             },
+            endIndex: 33,
             startIndex: 29,
           },
           {
+            endIndex: 35,
             startIndex: 33,
             textRun: {
-              textStyle: {},
               content: ', ',
+              textStyle: {},
             },
-            endIndex: 35,
           },
           {
+            endIndex: 41,
+            startIndex: 35,
             textRun: {
               textStyle: {
                 italic: true,
               },
               content: 'italic',
             },
-            startIndex: 35,
-            endIndex: 41,
           },
           {
-            startIndex: 41,
             textRun: {
-              content: ', and ',
               textStyle: {},
+              content: ', and ',
             },
+            startIndex: 41,
             endIndex: 47,
           },
           {
-            startIndex: 47,
-            endIndex: 57,
             textRun: {
               content: 'underlined',
               textStyle: {
                 underline: true,
               },
             },
+            startIndex: 47,
+            endIndex: 57,
           },
           {
-            textRun: {
-              content: '. \n',
-              textStyle: {},
-            },
-            startIndex: 57,
             endIndex: 60,
+            startIndex: 57,
+            textRun: {
+              textStyle: {},
+              content: '. \n',
+            },
           },
         ],
-        paragraphStyle: {
-          direction: 'LEFT_TO_RIGHT',
-          namedStyleType: 'NORMAL_TEXT',
-        },
       },
       endIndex: 60,
-      startIndex: 1,
     },
     {
+      startIndex: 60,
+      endIndex: 61,
       paragraph: {
         paragraphStyle: {
-          namedStyleType: 'NORMAL_TEXT',
           direction: 'LEFT_TO_RIGHT',
+          namedStyleType: 'NORMAL_TEXT',
         },
         elements: [
           {
             startIndex: 60,
-            endIndex: 61,
             textRun: {
               textStyle: {},
               content: '\n',
             },
+            endIndex: 61,
           },
         ],
       },
-      endIndex: 61,
-      startIndex: 60,
     },
     {
-      startIndex: 61,
       paragraph: {
-        paragraphStyle: {
-          direction: 'LEFT_TO_RIGHT',
-          namedStyleType: 'NORMAL_TEXT',
-        },
         elements: [
           {
+            endIndex: 88,
             startIndex: 61,
             textRun: {
-              textStyle: {},
               content: 'This sentence has a single ',
+              textStyle: {},
             },
-            endIndex: 88,
           },
           {
-            startIndex: 88,
             textRun: {
               content: 'word',
               textStyle: {
+                underline: true,
                 foregroundColor: {
                   color: {
                     rgbColor: {
                       green: 0.33333334,
-                      blue: 0.8,
                       red: 0.06666667,
+                      blue: 0.8,
                     },
                   },
                 },
                 link: {
                   url: 'https://tinynewsco.org',
                 },
-                underline: true,
               },
             },
             endIndex: 92,
+            startIndex: 88,
           },
           {
-            endIndex: 137,
             startIndex: 92,
+            endIndex: 137,
             textRun: {
               content: ' linked to the tinynewsco website homepage. \n',
               textStyle: {},
             },
           },
         ],
-      },
-      endIndex: 137,
-    },
-    {
-      startIndex: 137,
-      endIndex: 138,
-      paragraph: {
         paragraphStyle: {
           namedStyleType: 'NORMAL_TEXT',
           direction: 'LEFT_TO_RIGHT',
         },
+      },
+      endIndex: 137,
+      startIndex: 61,
+    },
+    {
+      paragraph: {
+        paragraphStyle: {
+          direction: 'LEFT_TO_RIGHT',
+          namedStyleType: 'NORMAL_TEXT',
+        },
         elements: [
           {
             textRun: {
-              content: '\n',
               textStyle: {},
+              content: '\n',
             },
             endIndex: 138,
             startIndex: 137,
           },
         ],
       },
+      endIndex: 138,
+      startIndex: 137,
     },
     {
-      endIndex: 150,
+      startIndex: 138,
       paragraph: {
-        paragraphStyle: {
-          namedStyleType: 'NORMAL_TEXT',
-          indentFirstLine: {
-            unit: 'PT',
-            magnitude: 18,
-          },
-          indentStart: {
-            magnitude: 36,
-            unit: 'PT',
-          },
-          direction: 'LEFT_TO_RIGHT',
-        },
         bullet: {
           listId: 'kix.qqyukljg8mnr',
           textStyle: {
@@ -205,41 +193,20 @@ describe('document API', () => {
         },
         elements: [
           {
+            startIndex: 138,
             endIndex: 150,
             textRun: {
               textStyle: {},
               content: 'list item 1\n',
             },
-            startIndex: 138,
           },
         ],
-      },
-      startIndex: 138,
-    },
-    {
-      paragraph: {
-        elements: [
-          {
-            endIndex: 162,
-            startIndex: 150,
-            textRun: {
-              textStyle: {},
-              content: 'list item 2\n',
-            },
-          },
-        ],
-        bullet: {
-          textStyle: {
-            underline: false,
-          },
-          listId: 'kix.qqyukljg8mnr',
-        },
         paragraphStyle: {
-          namedStyleType: 'NORMAL_TEXT',
           indentFirstLine: {
             magnitude: 18,
             unit: 'PT',
           },
+          namedStyleType: 'NORMAL_TEXT',
           indentStart: {
             magnitude: 36,
             unit: 'PT',
@@ -247,21 +214,52 @@ describe('document API', () => {
           direction: 'LEFT_TO_RIGHT',
         },
       },
+      endIndex: 150,
+    },
+    {
+      paragraph: {
+        bullet: {
+          textStyle: {
+            underline: false,
+          },
+          listId: 'kix.qqyukljg8mnr',
+        },
+        paragraphStyle: {
+          indentStart: {
+            magnitude: 36,
+            unit: 'PT',
+          },
+          direction: 'LEFT_TO_RIGHT',
+          namedStyleType: 'NORMAL_TEXT',
+          indentFirstLine: {
+            magnitude: 18,
+            unit: 'PT',
+          },
+        },
+        elements: [
+          {
+            textRun: {
+              textStyle: {},
+              content: 'list item 2\n',
+            },
+            endIndex: 162,
+            startIndex: 150,
+          },
+        ],
+      },
       startIndex: 150,
       endIndex: 162,
     },
     {
-      startIndex: 162,
-      endIndex: 177,
       paragraph: {
         elements: [
           {
             endIndex: 177,
-            startIndex: 162,
             textRun: {
-              content: 'Heading Size 1\n',
               textStyle: {},
+              content: 'Heading Size 1\n',
             },
+            startIndex: 162,
           },
         ],
         paragraphStyle: {
@@ -270,60 +268,60 @@ describe('document API', () => {
           direction: 'LEFT_TO_RIGHT',
         },
       },
+      startIndex: 162,
+      endIndex: 177,
     },
     {
       startIndex: 177,
       paragraph: {
         elements: [
           {
-            startIndex: 177,
             textRun: {
-              textStyle: {},
               content: 'paragraph\n',
+              textStyle: {},
             },
+            startIndex: 177,
             endIndex: 187,
           },
         ],
         paragraphStyle: {
-          namedStyleType: 'NORMAL_TEXT',
           direction: 'LEFT_TO_RIGHT',
+          namedStyleType: 'NORMAL_TEXT',
         },
       },
       endIndex: 187,
     },
     {
       startIndex: 187,
-      endIndex: 202,
       paragraph: {
+        paragraphStyle: {
+          direction: 'LEFT_TO_RIGHT',
+          namedStyleType: 'HEADING_2',
+          headingId: 'h.zdu1t9xjbq6s',
+        },
         elements: [
           {
             endIndex: 202,
-            startIndex: 187,
             textRun: {
               content: 'Heading Size 2\n',
               textStyle: {},
             },
+            startIndex: 187,
           },
         ],
-        paragraphStyle: {
-          namedStyleType: 'HEADING_2',
-          direction: 'LEFT_TO_RIGHT',
-          headingId: 'h.zdu1t9xjbq6s',
-        },
       },
+      endIndex: 202,
     },
     {
-      endIndex: 212,
-      startIndex: 202,
       paragraph: {
         elements: [
           {
-            textRun: {
-              textStyle: {},
-              content: 'paragraph\n',
-            },
             startIndex: 202,
             endIndex: 212,
+            textRun: {
+              content: 'paragraph\n',
+              textStyle: {},
+            },
           },
         ],
         paragraphStyle: {
@@ -331,38 +329,151 @@ describe('document API', () => {
           direction: 'LEFT_TO_RIGHT',
         },
       },
+      startIndex: 202,
+      endIndex: 212,
     },
     {
-      endIndex: 214,
+      endIndex: 213,
       paragraph: {
+        paragraphStyle: {
+          namedStyleType: 'NORMAL_TEXT',
+          direction: 'LEFT_TO_RIGHT',
+        },
         elements: [
           {
-            startIndex: 212,
-            endIndex: 213,
-            inlineObjectElement: {
+            textRun: {
+              content: '\n',
               textStyle: {},
-              inlineObjectId: 'kix.wr6s7brrno1m',
+            },
+            endIndex: 213,
+            startIndex: 212,
+          },
+        ],
+      },
+      startIndex: 212,
+    },
+    {
+      startIndex: 213,
+      endIndex: 249,
+      paragraph: {
+        paragraphStyle: {
+          namedStyleType: 'NORMAL_TEXT',
+          direction: 'LEFT_TO_RIGHT',
+        },
+        elements: [
+          {
+            endIndex: 248,
+            startIndex: 213,
+            textRun: {
+              textStyle: {
+                underline: true,
+                link: {
+                  url: 'https://forms.gle/413sboQBCkw4p1PW6',
+                },
+                foregroundColor: {
+                  color: {
+                    rgbColor: {
+                      blue: 0.8,
+                      green: 0.33333334,
+                      red: 0.06666667,
+                    },
+                  },
+                },
+              },
+              content: 'https://forms.gle/413sboQBCkw4p1PW6',
             },
           },
           {
-            startIndex: 213,
+            endIndex: 249,
+            textRun: {
+              content: '\n',
+              textStyle: {},
+            },
+            startIndex: 248,
+          },
+        ],
+      },
+    },
+    {
+      paragraph: {
+        paragraphStyle: {
+          namedStyleType: 'NORMAL_TEXT',
+          direction: 'LEFT_TO_RIGHT',
+        },
+        elements: [
+          {
+            startIndex: 249,
             textRun: {
               textStyle: {},
               content: '\n',
             },
-            endIndex: 214,
+            endIndex: 250,
           },
         ],
+      },
+      endIndex: 250,
+      startIndex: 249,
+    },
+    {
+      endIndex: 252,
+      paragraph: {
         paragraphStyle: {
           namedStyleType: 'NORMAL_TEXT',
           direction: 'LEFT_TO_RIGHT',
         },
+        elements: [
+          {
+            endIndex: 251,
+            startIndex: 250,
+            inlineObjectElement: {
+              inlineObjectId: 'kix.wr6s7brrno1m',
+              textStyle: {},
+            },
+          },
+          {
+            textRun: {
+              content: '\n',
+              textStyle: {},
+            },
+            startIndex: 251,
+            endIndex: 252,
+          },
+        ],
       },
-      startIndex: 212,
+      startIndex: 250,
     },
   ];
 
   context('processDocumentContents', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'https://accounts.google.com/ServiceLogin?service=wise&passive=1209600&continue=https://docs.google.com/forms/d/e/1FAIpQLSfVOl8qdT54E2r_T367YsRlka57bUY_fnjedMLezp1Tll9OQw/viewform?usp%3Dsend_form&followup=https://docs.google.com/forms/d/e/1FAIpQLSfVOl8qdT54E2r_T367YsRlka57bUY_fnjedMLezp1Tll9OQw/viewform?usp%3Dsend_form&ltmpl=forms',
+        {
+          statusCode: 200,
+        }
+      );
+      cy.intercept(
+        {
+          https: true,
+          method: 'GET',
+          hostname: 'forms.gle',
+          url: '/*',
+        },
+        (req) => {
+          req.reply({
+            headers: {
+              Location:
+                'https://accounts.google.com/ServiceLogin?service=wise&passive=1209600&continue=https://docs.google.com/forms/d/e/1FAIpQLSfVOl8qdT54E2r_T367YsRlka57bUY_fnjedMLezp1Tll9OQw/viewform?usp%3Dsend_form&followup=https://docs.google.com/forms/d/e/1FAIpQLSfVOl8qdT54E2r_T367YsRlka57bUY_fnjedMLezp1Tll9OQw/viewform?usp%3Dsend_form&ltmpl=forms',
+            },
+            statusCode: 301,
+            body: {
+              name: 'Peter Pan',
+            },
+          });
+        }
+      ).as('googleForms');
+    });
+
     it('returns an object with main image, an updated list of images, and formatted elements', () => {
       cy.wrap(
         processDocumentContents(
@@ -474,6 +585,26 @@ describe('document API', () => {
         expect(paragraph2.type).to.eq('text');
         expect(paragraph2.style).to.eq('HEADING_2');
         expect(paragraph2.children[0].content).to.eq('Heading Size 2');
+      });
+    });
+
+    it('formats google forms embed short links', () => {
+      cy.wrap(
+        processDocumentContents(
+          elements,
+          listInfo,
+          inlineObjects,
+          imageList,
+          slug,
+          oauthToken
+        )
+      ).then((result) => {
+        let el = result.formattedElements[10];
+
+        expect(el.type).to.eq('embed');
+        expect(el.link).to.eq(
+          'https://docs.google.com/forms/d/e/1FAIpQLSfVOl8qdT54E2r_T367YsRlka57bUY_fnjedMLezp1Tll9OQw/viewform?usp=send_form'
+        );
       });
     });
   });

--- a/lib/document.js
+++ b/lib/document.js
@@ -160,10 +160,10 @@ export async function processDocumentContents(
         );
         var linkUrl = null;
         // var embeddableUrlRegex = /twitter\.com|youtube\.com|youtu\.be|google\.com|imgur.com|twitch\.tv|vimeo\.com|mixcloud\.com|instagram\.com|facebook\.com|dailymotion\.com|spotify.com|apple.com/i;
-        var embeddableUrlRegex = /twitter\.com|youtube\.com|youtu\.be|instagram\.com|facebook\.com|spotify\.com|vimeo\.com|apple\.com|tiktok\.com/i;
+        var embeddableUrlRegex = /twitter\.com|youtube\.com|youtu\.be|instagram\.com|facebook\.com|spotify\.com|vimeo\.com|apple\.com|tiktok\.com|forms\.gle|docs\.google\.com\/forms/i;
         if (foundLink) {
           linkUrl = foundLink.textRun.textStyle.link.url;
-          // console.log("found link: " + linkUrl + " type: " + eleData.type);
+          // console.log('found embed: ' + linkUrl + ' type: ' + eleData.type);
 
           // try to find a URL by itself that google hasn't auto-linked
         } else if (
@@ -175,6 +175,10 @@ export async function processDocumentContents(
         if (linkUrl !== null && eleData.type !== 'list') {
           var embeddableUrl = embeddableUrlRegex.test(linkUrl);
           if (embeddableUrl) {
+            // special case to get the full URL for Google Forms - the short form URL doesn't embed correctly
+            if (/forms\.gle/.test(linkUrl)) {
+              linkUrl = await getFullGoogleFormsUrl(linkUrl);
+            }
             eleData.type = 'embed';
             eleData.link = linkUrl;
             orderedElements.push(eleData);
@@ -1458,4 +1462,22 @@ export async function hasuraInsertPageGoogleDoc(params) {
       url: params['document_url'],
     },
   });
+}
+
+async function getFullGoogleFormsUrl(shortUrl) {
+  try {
+    const response = await fetch(shortUrl, {
+      redirect: 'manual',
+    });
+    if (response.status === 301 || response.status === 302) {
+      const locationURL = new URL(
+        response.headers.get('location'),
+        response.url
+      );
+      return locationURL.toString();
+    }
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
 }

--- a/lib/document.js
+++ b/lib/document.js
@@ -175,13 +175,17 @@ export async function processDocumentContents(
         if (linkUrl !== null && eleData.type !== 'list') {
           var embeddableUrl = embeddableUrlRegex.test(linkUrl);
           if (embeddableUrl) {
+            eleData.type = 'embed';
+
             // special case to get the full URL for Google Forms - the short form URL doesn't embed correctly
             if (/forms\.gle/.test(linkUrl)) {
-              linkUrl = await getFullGoogleFormsUrl(linkUrl);
+              let redirectURL = await getFullGoogleFormsUrl(linkUrl);
+              eleData.link = redirectURL;
+              orderedElements.push(eleData);
+            } else {
+              eleData.link = linkUrl;
+              orderedElements.push(eleData);
             }
-            eleData.type = 'embed';
-            eleData.link = linkUrl;
-            orderedElements.push(eleData);
           }
         }
       }
@@ -1467,14 +1471,16 @@ export async function hasuraInsertPageGoogleDoc(params) {
 async function getFullGoogleFormsUrl(shortUrl) {
   try {
     const response = await fetch(shortUrl, {
-      redirect: 'manual',
+      redirect: 'follow',
     });
-    if (response.status === 301 || response.status === 302) {
-      const locationURL = new URL(
-        response.headers.get('location'),
-        response.url
-      );
-      return locationURL.toString();
+    if (response.redirected && response.url) {
+      const followedParams = new URL(response.url).searchParams;
+      let longUrl = followedParams.get('continue');
+      if (longUrl) {
+        return longUrl;
+      } else {
+        return response.url;
+      }
     }
   } catch (err) {
     console.error(err);

--- a/script/shared.js
+++ b/script/shared.js
@@ -204,7 +204,9 @@ const HASURA_REMOVE_ORGANIZATION = `mutation FrontendRemoveOrganization($slug: S
   delete_category_translations(where: {category: {organization: {slug: {_eq: $slug}}}}) {
     affected_rows
   }
-  
+  delete_author_articles(where: {author: {organization: {slug: {_eq: $slug}}}}) {
+    affected_rows
+  }
   delete_page_google_documents(where: {page: {organization: {slug: {_eq: $slug}}}}) {
     affected_rows
   }
@@ -227,9 +229,6 @@ const HASURA_REMOVE_ORGANIZATION = `mutation FrontendRemoveOrganization($slug: S
     affected_rows
   }
   delete_homepage_layout_schemas(where: {organization: {slug: {_eq: $slug}}}) {
-    affected_rows
-  }
-  delete_author_articles(where: {author: {organization: {slug: {_eq: $slug}}}}) {
     affected_rows
   }
   delete_tag_translations(where: {tag: {organization: {slug: {_eq: $slug}}}}) {


### PR DESCRIPTION
Closes #1055 

We have a new embed for Google Forms that supports using either the default long form URL or shortened embed URL for the form. To support the shortened URL, the code follows the redirect returned by Google and parses the resulting location for the `continue` query string parameter used by Google Forms for the actual embed link.

I tested this using ngrok + nextjs localhost and pointing the oaklyn sidebar at my localhost url.

This new feature also has cypress test coverage, the first embed document parsing test I've written! It helped me catch a few issues, which are, briefly - if you're interested:

1. while `redirect: 'manual'` works great in production for `node-fetch` to handle the Google Forms, it does NOT work in Cypress - the response is an opaqueredirect with a `0` statusCode, and it totally blows up the specs
2. `redirect: 'follow'` is the default behaviour of node-fetch and allows intercepting the request in cypress
3. ... but this results in a different style Google Forms redirect URL that then has to be parsed for its query string params
4. and generally, I had to play around a lot with the many options cypress gives you for stubbing network requests to figure out the right way to accomplish a fake redirect here

Both the Test Doc we've been using and the Cypress Test Doc have been updated to include google forms. This feature did not require any changes in the sidebar code \o/