### PR TITLE
bugfix: update preview of donation options on all fields 

### DIFF
--- a/components/tinycms/DonationOption.js
+++ b/components/tinycms/DonationOption.js
@@ -66,6 +66,30 @@ export default function DonationOption(props) {
     }));
   };
 
+  const updateAmount = (index, value) => {
+    setAmount(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].amount = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+
+  const updateMonkeypodId = (index, value) => {
+    setMonkeypodId(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].monkeypodId = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+
   return (
     <div key={`option-${index}`}>
       <div tw="mt-2">
@@ -85,7 +109,7 @@ export default function DonationOption(props) {
             type="number"
             name={`donationOptions-${index}-amount`}
             value={amount}
-            onChange={(ev) => setAmount(ev.target.value)}
+            onChange={(ev) => updateAmount(index, ev.target.value)}
           />
         </label>
       </div>
@@ -147,7 +171,7 @@ export default function DonationOption(props) {
             type="text"
             name={`donationOptions-${index}-monkeypodId`}
             value={monkeypodId}
-            onChange={(ev) => setMonkeypodId(ev.target.value)}
+            onChange={(ev) => updateMonkeypodId(index, ev.target.value)}
           />
         </label>
       </div>

--- a/components/tinycms/DonationOption.js
+++ b/components/tinycms/DonationOption.js
@@ -41,6 +41,31 @@ export default function DonationOption(props) {
       ['donationOptions']: JSON.stringify(donationOptions),
     }));
   };
+
+  const updateDesc = (index, value) => {
+    setDesc(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].description = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+
+  const updatePaymentType = (index, value) => {
+    setPaymentType(value);
+
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].paymentType = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
+
   return (
     <div key={`option-${index}`}>
       <div tw="mt-2">
@@ -71,7 +96,7 @@ export default function DonationOption(props) {
             name={`donationOptions-${index}-paymentType`}
             value="monthly"
             checked={paymentType === 'monthly'}
-            onChange={(ev) => setPaymentType(ev.target)}
+            onChange={(ev) => updatePaymentType(index, ev.target.value)}
           />
           <span tw="p-2 mt-1 font-bold">Monthly</span>
         </label>
@@ -81,7 +106,7 @@ export default function DonationOption(props) {
             name={`donationOptions-${index}-paymentType`}
             value="one-time"
             checked={paymentType === 'one-time'}
-            onChange={(ev) => setPaymentType(ev.target)}
+            onChange={(ev) => updatePaymentType(index, ev.target.value)}
           />
           <span tw="p-2 mt-1 font-bold">One-time payment</span>
         </label>
@@ -91,7 +116,7 @@ export default function DonationOption(props) {
             name={`donationOptions-${index}-paymentType`}
             value="pay-what-you-want"
             checked={paymentType === 'pay-what-you-want'}
-            onChange={(ev) => setPaymentType(ev.target)}
+            onChange={(ev) => updatePaymentType(index, ev.target.value)}
           />
           <span tw="p-2 mt-1 font-bold">Pay what you want</span>
         </label>
@@ -101,7 +126,7 @@ export default function DonationOption(props) {
           tw="w-full rounded-md border-solid border-gray-300"
           name={`donationOptions-${index}-description`}
           value={desc}
-          onChange={(ev) => setDesc(ev.target.value)}
+          onChange={(ev) => updateDesc(index, ev.target.value)}
           label="Option description"
         />
       </div>


### PR DESCRIPTION
Closes #1064 

Changes to the donation options were not being reflected in the preview in the tinycms settings. Tested locally with Oaklyn; preview looked good, and donate page reflected the saved (changed) options.

Fields tested:

* name
* amount
* payment type
* description
* cta
* monkeypod ID