### PR TITLE
Tiny MCE for the payment options description 

### DIFF
--- a/components/plugins/DonationCard.js
+++ b/components/plugins/DonationCard.js
@@ -89,9 +89,11 @@ export default function DonationCard({ option, metadata, tinycms }) {
               </label>
             </>
           )}
-          <CardDonationDescription meta={metadata}>
-            {option.description}
-          </CardDonationDescription>
+
+          <CardDonationDescription
+            meta={metadata}
+            dangerouslySetInnerHTML={{ __html: option.description }}
+          ></CardDonationDescription>
         </div>
       </CardContent>
       <CardFooter

--- a/components/tinycms/DonationOption.js
+++ b/components/tinycms/DonationOption.js
@@ -56,18 +56,6 @@ export default function DonationOption(props) {
     }));
   };
 
-  const updateDesc = (index, value) => {
-    setDesc(value);
-
-    let donationOptions = JSON.parse(props.parsedData.donationOptions);
-    donationOptions[index].description = value;
-
-    props.updateParsedData((prevState) => ({
-      ...prevState,
-      ['donationOptions']: JSON.stringify(donationOptions),
-    }));
-  };
-
   const updatePaymentType = (index, value) => {
     setPaymentType(value);
 

--- a/components/tinycms/DonationOption.js
+++ b/components/tinycms/DonationOption.js
@@ -3,6 +3,7 @@ import tw, { css, styled } from 'twin.macro';
 
 import ControlledInput from './ControlledInput';
 import { TinyInputField } from './TinyFormElements';
+import TinyEditor from './TinyEditor';
 
 const Input = styled.input`
   ${tw`px-3 py-3 mb-4 placeholder-gray-300 text-gray-600 relative bg-white bg-white rounded text-sm border-0 shadow outline-none focus:outline-none focus:ring w-full`}
@@ -14,9 +15,22 @@ export default function DonationOption(props) {
   const [name, setName] = useState(props.name);
   const [cta, setCTA] = useState(props.cta);
   const [desc, setDesc] = useState(props.desc);
+  const [staticDesc, setStaticDesc] = useState(props.desc);
   const [paymentType, setPaymentType] = useState(props.paymentType);
   const [monkeypodId, setMonkeypodId] = useState(props.monkeypodId);
   const [amount, setAmount] = useState(props.amount);
+
+  const updateDesc = (value, editor) => {
+    setDesc(value);
+    let index = editor.getParam('index');
+    let donationOptions = JSON.parse(props.parsedData.donationOptions);
+    donationOptions[index].description = value;
+
+    props.updateParsedData((prevState) => ({
+      ...prevState,
+      ['donationOptions']: JSON.stringify(donationOptions),
+    }));
+  };
 
   const updateName = (index, value) => {
     setName(value);
@@ -97,13 +111,19 @@ export default function DonationOption(props) {
         </label>
       </div>
       <div tw="mt-2">
-        <TinyInputField
+        <TinyEditor
+          tinyApiKey={props.tinyApiKey}
+          setValue={updateDesc}
+          index={index}
+          value={staticDesc}
+        />
+        {/* <TinyInputField
           tw="w-full rounded-md border-solid border-gray-300"
           name={`donationOptions-${index}-description`}
           value={desc}
           onChange={(ev) => setDesc(ev.target.value)}
           label="Option description"
-        />
+        /> */}
       </div>
       <div tw="mt-2">
         <TinyInputField

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -939,6 +939,7 @@ export default function SiteInfoSettings(props) {
               monkeypodId={option.monkeypodId}
               parsedData={props.parsedData}
               updateParsedData={props.updateParsedData}
+              tinyApiKey={props.tinyApiKey}
             />
           ))}
       </DonationOptionsEditor>

--- a/components/tinycms/TinyEditor.js
+++ b/components/tinycms/TinyEditor.js
@@ -1,6 +1,6 @@
 import { Editor } from '@tinymce/tinymce-react';
 
-const TinyEditor = ({ tinyApiKey, value, setValue }) => {
+const TinyEditor = ({ tinyApiKey, value, setValue, ...props }) => {
   return (
     <Editor
       apiKey={tinyApiKey}
@@ -18,8 +18,10 @@ const TinyEditor = ({ tinyApiKey, value, setValue }) => {
           'undo redo | formatselect | bold italic link | \
             alignleft aligncenter alignright | \
             bullist numlist outdent indent | help',
+        index: props.index,
       }}
       onEditorChange={setValue}
+      {...props}
     />
   );
 };

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -192,6 +192,7 @@ export default function Settings({
     let parsed = parsedData;
 
     if (jsonData && (Object.keys(parsedData).length === 0 || editData)) {
+      console.log('setting parsed data to jsondata');
       parsed = JSON.parse(jsonData);
       setParsedData(parsed);
     }
@@ -251,6 +252,7 @@ export default function Settings({
       }
     }
 
+    console.log('parsed:', parsed);
     const { errors, data } = await hasuraUpsertMetadata({
       url: apiUrl,
       orgSlug: apiToken,

--- a/pages/tinycms/settings/index.js
+++ b/pages/tinycms/settings/index.js
@@ -89,9 +89,7 @@ export default function Settings({
   };
 
   const handleKeyDown = (e) => {
-    console.log('keyCode:', e.keyCode);
     if (e.keyCode === 18) {
-      console.log('preventing default');
       e.preventDefault();
     }
   };
@@ -192,7 +190,6 @@ export default function Settings({
     let parsed = parsedData;
 
     if (jsonData && (Object.keys(parsedData).length === 0 || editData)) {
-      console.log('setting parsed data to jsondata');
       parsed = JSON.parse(jsonData);
       setParsedData(parsed);
     }
@@ -252,7 +249,6 @@ export default function Settings({
       }
     }
 
-    console.log('parsed:', parsed);
     const { errors, data } = await hasuraUpsertMetadata({
       url: apiUrl,
       orgSlug: apiToken,
@@ -436,7 +432,6 @@ export async function getServerSideProps(context) {
   } else {
     locales = data.organization_locales;
     siteMetadata = data.site_metadatas[0];
-    console.log('siteMetadata:', JSON.stringify(siteMetadata));
   }
   if (siteMetadata === undefined) {
     siteMetadata = null;


### PR DESCRIPTION
Closes #1043

This PR includes the recent bugfix work that was merged into main this morning. Tested locally (Oaklyn), the donation options in the tinycms settings:

* allows html in description field using tinymce
* description changes reflected in preview (localhost:3000/tinycms/settings)
* also continues to update the preview for name, amount, payment type, cta, monkeypod id changes
* donation card component renders html for the description on preview and donate page (localhost:3000/donate)