### PR TITLE
Search title is no longer required, if blank set to headline

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -87,9 +87,11 @@ export default function Layout({
     metaValues['documentType'] = 'website';
   }
   if (translations && translations.length > 0) {
-    pageTitle = hasuraLocalizeText(locale, translations, 'search_title');
-    if (pageTitle === 'Untitled Document') {
-      let headline = hasuraLocalizeText(locale, translations, 'headline');
+    let headline = hasuraLocalizeText(locale, translations, 'headline');
+    let searchTitle = hasuraLocalizeText(locale, translations, 'search_title');
+    let pageTitle = searchTitle;
+
+    if (!pageTitle || pageTitle === 'Untitled Document') {
       if (headline !== 'Untitled Document') {
         pageTitle = headline + ' | ' + metaValues.siteName;
       } else {
@@ -106,11 +108,11 @@ export default function Layout({
         'title'
       );
     }
-    metaValues.searchTitle = hasuraLocalizeText(
-      locale,
-      translations,
-      'search_title'
-    );
+    metaValues.searchTitle = searchTitle;
+    // fallback to headline if no search title is given
+    if (!metaValues.searchTitle) {
+      metaValues.searchTitle = headline;
+    }
     metaValues.searchDescription = hasuraLocalizeText(
       locale,
       translations,


### PR DESCRIPTION
Related to https://github.com/news-catalyst/google-app-scripts/issues/396

[This Google Apps Script PR](https://github.com/news-catalyst/google-app-scripts/pull/404) makes the search title no longer a required field and falls back to the headline.

This front-end PR ensures that on the off chance the search title meta value is blank, it gets set to the headline. This fallback-to-headline is also used for the facebook and twitter title values.