### PR TITLE
Remove the article body from several queries

### DIFF
--- a/components/homepage/ArticleLink.js
+++ b/components/homepage/ArticleLink.js
@@ -90,13 +90,7 @@ export default function ArticleLink({
     try {
       mainImageNode = mainImageContent;
     } catch (e) {
-      console.error(
-        article.id,
-        headline,
-        'error finding main image:',
-        e,
-        articleContent
-      );
+      console.error(article.id, headline, 'error finding main image:', e);
     }
   }
 

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -640,7 +640,6 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($tag_slug: String!) {
     tag_articles(where: {article: {article_translations: {published: {_eq: true}}}}, order_by: {article: {article_translations_aggregate: {min: {first_published_at: desc}}}}) {
       article {
         article_translations(where: {}) {
-          content
           custom_byline
           facebook_description
           facebook_title

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -683,7 +683,6 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($tag_slug: String!) {
 const HASURA_CATEGORY_PAGE = `query FrontendCategoryPage($category_slug: String!) {
   articles(order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
     article_translations {
-      content
       custom_byline
       facebook_description
       facebook_title
@@ -1056,7 +1055,6 @@ const HASURA_GET_ARTICLE_BY_SLUG = `query FrontendGetArticleBySlug($slug: String
 const HASURA_AUTHOR_PAGE = `query FrontendAuthorPage($author_slug: String!) {
   articles(order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, author_articles: {author: {slug: {_eq: $author_slug}}}}) {
     article_translations {
-      content
       custom_byline
       facebook_description
       facebook_title


### PR DESCRIPTION
Closes #1061 

This affects 3 queries used on the category, tag and author index pages: I can confirm that none of these require the article content anymore.

I'm reviewing [the usage tab in the Hasura dashboard](https://cloud.hasura.io/project/1f4ba420-516e-4b05-8d0e-5b6bcab99c50/console/pro/usage?filters=%5B%7B%22type%22:%22time_range%22,%22value%22:%22Last%20hour%22%7D%5D&groupbys=%5B%22operation_name%22%5D) but figured this simple change to these three queries would cut down on data usage with relatively low risk.

Tested locally with `dev` and `build` and cypress full test suite passing.