### PR TITLE
preview routes for: donate, staff and thank you pages

### DIFF
--- a/pages/api/preview-static.js
+++ b/pages/api/preview-static.js
@@ -29,7 +29,7 @@ export default async function Handler(req, res) {
   if (localeCode) {
     nextPath = '/' + localeCode;
   }
-  if (req.query.slug === 'about') {
+  if (['about', 'staff', 'thank-you', 'donate'].includes(req.query.slug)) {
     nextPath += '/preview/' + req.query.slug;
   } else {
     nextPath += '/preview/static/' + req.query.slug;

--- a/pages/preview/donate.js
+++ b/pages/preview/donate.js
@@ -1,0 +1,172 @@
+import tw, { styled } from 'twin.macro';
+import { useRouter } from 'next/router';
+import { hasuraGetPage } from '../../lib/articles.js';
+import { hasuraLocalizeText, renderBody } from '../../lib/utils';
+import Layout from '../../components/Layout';
+import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
+import StaticMainImage from '../../components/articles/StaticMainImage';
+import DonationOptionsBlock from '../../components/plugins/DonationOptionsBlock.js';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+  SectionLayout,
+  Block,
+} from '../../components/common/CommonStyles.js';
+
+const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+const WideContainer = styled.div(() => ({
+  ...tw`px-5 md:px-12 mx-auto w-full`,
+  maxWidth: '1280px',
+}));
+
+export default function Donate({
+  page,
+  sections,
+  siteMetadata,
+  locales,
+  locale,
+}) {
+  const isAmp = false;
+  const router = useRouter();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
+  // there will only be one translation returned for a given page + locale
+  const headline = hasuraLocalizeText(
+    locale,
+    page.page_translations,
+    'headline'
+  );
+
+  const body = renderBody(
+    locale,
+    page.page_translations,
+    [],
+    isAmp,
+    siteMetadata
+  );
+
+  return (
+    <Layout locale={locale} meta={siteMetadata} page={page} sections={sections}>
+      <SectionContainer>
+        <article className="container">
+          <ArticleTitle meta={siteMetadata} tw="text-center">
+            {headline}
+          </ArticleTitle>
+          <StaticMainImage
+            isAmp={isAmp}
+            locale={locale}
+            page={page}
+            siteMetadata={siteMetadata}
+          />
+          <PostText>
+            <PostTextContainer>{body}</PostTextContainer>
+          </PostText>
+        </article>
+      </SectionContainer>
+      <WideContainer>
+        <DonationOptionsBlock metadata={siteMetadata} wrap={true} />
+      </WideContainer>
+      {locales.length > 1 && (
+        <SectionLayout>
+          <SectionContainer>
+            <Block>
+              <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+            </Block>
+          </SectionContainer>
+        </SectionLayout>
+      )}
+    </Layout>
+  );
+}
+
+export async function getStaticProps(context) {
+  let locale = context.locale;
+  let preview = context.preview;
+
+  if (!preview) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  let page = {};
+  let sections;
+  let siteMetadata = {};
+  let locales = [];
+
+  const { errors, data } = await hasuraGetPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: 'donate',
+  });
+  if (errors || !data) {
+    console.error('Returning a 404 - errors:', errors);
+
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      console.error('Returning a 404 - page slug version not found:', data);
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
+
+    var allPageLocales = page.page_translations;
+    var distinctLocaleCodes = [];
+    var distinctLocales = [];
+    for (var i = 0; i < allPageLocales.length; i++) {
+      let pageLocale = allPageLocales[i];
+
+      if (
+        pageLocale &&
+        pageLocale.locale &&
+        !distinctLocaleCodes.includes(pageLocale.locale.code)
+      ) {
+        distinctLocaleCodes.push(pageLocale.locale.code);
+        distinctLocales.push(pageLocale);
+      }
+    }
+    locales = distinctLocales;
+
+    sections = data.categories;
+
+    siteMetadata = hasuraLocalizeText(
+      locale,
+      data.site_metadatas[0].site_metadata_translations,
+      'data'
+    );
+
+    for (i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocalizeText(
+        locale,
+        sections[i].category_translations,
+        'title'
+      );
+    }
+  }
+
+  return {
+    props: {
+      page,
+      sections,
+      siteMetadata,
+      locales,
+      locale,
+    },
+    revalidate: 1,
+  };
+}

--- a/pages/preview/staff.js
+++ b/pages/preview/staff.js
@@ -1,12 +1,11 @@
 import { hasuraGetPage } from '../../lib/articles.js';
 import { hasuraLocalizeText } from '../../lib/utils';
-import AboutPage from '../../components/AboutPage';
+import StaffPage from '../../components/StaffPage';
 
-export default function About(props) {
-  // const isAmp = useAmp();
+export default function Staff(props) {
   const isAmp = false;
 
-  return <AboutPage {...props} isAmp={isAmp} />;
+  return <StaffPage {...props} isAmp={isAmp} />;
 }
 
 export async function getStaticProps(context) {
@@ -18,21 +17,22 @@ export async function getStaticProps(context) {
       notFound: true,
     };
   }
+
   const apiUrl = process.env.HASURA_API_URL;
   const apiToken = process.env.ORG_SLUG;
 
   let page = {};
   let sections;
   let siteMetadata = {};
-  let locales = [];
+  let authors = [];
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
     orgSlug: apiToken,
     slug: 'about',
-    localeCode: locale,
   });
   if (errors || !data) {
+    console.error(errors);
     return {
       notFound: true,
     };
@@ -44,21 +44,10 @@ export async function getStaticProps(context) {
       };
     }
     page = data.page_slug_versions[0].page;
-
-    var allPageLocales = data.pages[0].page_translations;
-    var distinctLocaleCodes = [];
-    var distinctLocales = [];
-    for (var i = 0; i < allPageLocales.length; i++) {
-      if (!distinctLocaleCodes.includes(allPageLocales[i].locale.code)) {
-        distinctLocaleCodes.push(allPageLocales[i].locale.code);
-        distinctLocales.push(allPageLocales[i]);
-      }
-    }
-    locales = distinctLocales;
-
     sections = data.categories;
+    authors = data.authors;
     siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
-    for (i = 0; i < sections.length; i++) {
+    for (var i = 0; i < sections.length; i++) {
       sections[i].title = hasuraLocalizeText(
         locale,
         sections[i].category_translations,
@@ -69,11 +58,11 @@ export async function getStaticProps(context) {
 
   return {
     props: {
-      page,
+      authors,
+      locale,
       sections,
       siteMetadata,
-      locales,
-      locale,
     },
+    revalidate: 1,
   };
 }

--- a/pages/preview/thank-you.js
+++ b/pages/preview/thank-you.js
@@ -1,0 +1,162 @@
+import tw from 'twin.macro';
+import { useRouter } from 'next/router';
+import { hasuraGetPage } from '../../lib/articles.js';
+import { useAnalytics } from '../../lib/hooks/useAnalytics.js';
+import { hasuraLocalizeText, renderBody } from '../../lib/utils';
+import ReadInOtherLanguage from '../../components/articles/ReadInOtherLanguage';
+import Layout from '../../components/Layout';
+import NewsletterBlock from '../../components/plugins/NewsletterBlock';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+  SectionLayout,
+  Block,
+} from '../../components/common/CommonStyles.js';
+
+const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+
+export default function ThankYou({
+  referrer,
+  page,
+  sections,
+  siteMetadata,
+  locales,
+  locale,
+}) {
+  const isAmp = false;
+  const router = useRouter();
+  // sets a cookie if request comes from monkeypod.io marking this browser as a donor
+  const { checkReferrer, trackEvent } = useAnalytics();
+
+  // If the page is not yet generated, this will be displayed
+  // initially until getStaticProps() finishes running
+  // See: https://nextjs.org/docs/basic-features/data-fetching#the-fallback-key-required
+  if (router.isFallback) {
+    // console.log('router.isFallback on thank you page');
+    return <div>Loading...</div>;
+  }
+
+  // this will return true if the request came from monkeypod, false otherwise
+  let isDonor = checkReferrer(referrer);
+  if (isDonor) {
+    setTimeout(() => {
+      trackEvent({
+        action: 'submit',
+        category: 'NTG membership',
+        label: 'success',
+        non_interaction: false,
+      });
+    }, 100);
+  }
+
+  // there will only be one translation returned for a given page + locale
+  const localisedPage = page.page_translations[0];
+  const body = renderBody(
+    locale,
+    page.page_translations,
+    [],
+    isAmp,
+    siteMetadata
+  );
+
+  return (
+    <Layout locale={locale} meta={siteMetadata} page={page} sections={sections}>
+      <SectionContainer>
+        <ArticleTitle meta={siteMetadata} tw="text-center">
+          {localisedPage.headline}
+        </ArticleTitle>
+        <PostText>
+          <PostTextContainer>{body}</PostTextContainer>
+        </PostText>
+        <NewsletterBlock
+          metadata={siteMetadata}
+          headline={localisedPage.headline}
+          wrap={false}
+        />
+      </SectionContainer>
+      {locales.length > 1 && (
+        <SectionLayout>
+          <SectionContainer>
+            <Block>
+              <ReadInOtherLanguage locales={locales} currentLocale={locale} />
+            </Block>
+          </SectionContainer>
+        </SectionLayout>
+      )}
+    </Layout>
+  );
+}
+
+export async function getServerSideProps(context) {
+  let locale = context.locale;
+  let preview = context.preview;
+
+  if (!preview) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const apiUrl = process.env.HASURA_API_URL;
+  const apiToken = process.env.ORG_SLUG;
+
+  const referrer = context.req.headers['referer'];
+
+  let page = {};
+  let sections;
+  let siteMetadata = {};
+  let locales = [];
+
+  const { errors, data } = await hasuraGetPage({
+    url: apiUrl,
+    orgSlug: apiToken,
+    slug: 'thank-you',
+    localeCode: locale,
+  });
+  if (errors || !data) {
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    if (!data.page_slug_versions || !data.page_slug_versions[0]) {
+      return {
+        notFound: true,
+      };
+    }
+    page = data.page_slug_versions[0].page;
+
+    var allPageLocales = data.pages[0].page_translations;
+    var distinctLocaleCodes = [];
+    var distinctLocales = [];
+    for (var i = 0; i < allPageLocales.length; i++) {
+      if (!distinctLocaleCodes.includes(allPageLocales[i].locale.code)) {
+        distinctLocaleCodes.push(allPageLocales[i].locale.code);
+        distinctLocales.push(allPageLocales[i]);
+      }
+    }
+    locales = distinctLocales;
+
+    sections = data.categories;
+    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+    for (i = 0; i < sections.length; i++) {
+      sections[i].title = hasuraLocalizeText(
+        locale,
+        sections[i].category_translations,
+        'title'
+      );
+    }
+  }
+
+  return {
+    props: {
+      referrer: referrer || '',
+      page,
+      sections,
+      siteMetadata,
+      locales,
+      locale,
+    },
+  };
+}


### PR DESCRIPTION
Closes #1056 

This adds the missing preview routes for the three special static pages (besides `about`) that have dedicated templates:

* donate: http://localhost:3000/api/preview-static?secret=DUNGEONSDRAGONS&slug=donate&locale=en-US
* staff: http://localhost:3000/api/preview-static?secret=DUNGEONSDRAGONS&slug=staff&locale=en-US
* thank you: http://localhost:3000/api/preview-static?secret=DUNGEONSDRAGONS&slug=thank-you&locale=en-US

the links above should resolve to the correct preview version of each page - these were 404'ing in preview with the nextjs api version of document processing.