### PR TITLE
conditionally build and deploy the site based on env, git branch and …

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+echo "VERCEL_ENV: $VERCEL_ENV"
+echo "ORG_SLUG: $ORG_SLUG"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "stable" && "$VERCEL_ENV" == "production" && "$ORG_SLUG" != "oaklyn"  ]] ; then
+  # Proceed with the build
+  echo "✅ - Not Oaklyn: build can proceed for stable branch in production env"
+  exit 1;
+
+elif [[ "$VERCEL_GIT_COMMIT_REF" == "main" && "$VERCEL_ENV" == "production" && "$ORG_SLUG" == "oaklyn"  ]] ; then
+# Proceed with the build
+  echo "✅ - Oaklyn: build can proceed for main branch in production env"
+  exit 1;
+
+elif [[ "$VERCEL_GIT_COMMIT_REF" == "main" && "$VERCEL_ENV" == "preview" && "$ORG_SLUG" != "oaklyn"  ]] ; then
+# Proceed with the build
+  echo "✅ - Not Oaklyn: build can proceed for main branch in preview env"
+  exit 1;
+
+elif [[ "$ORG_SLUG" == "oaklyn" ]] ; then
+  echo "✅ - Oaklyn: build can proceed for branch $VERCEL_GIT_COMMIT_REF in env $VERCEL_ENV"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled for org '$ORG_SLUG' in env '$VERCEL_ENV' on branch '$VERCEL_GIT_COMMIT_REF'"
+  exit 0;
+fi


### PR DESCRIPTION
Closes #1060

I followed [the Vercel instructions on adding a deploy script](https://vercel.com/support/articles/how-do-i-use-the-ignored-build-step-field-on-vercel) to the repo. I think I covered all of the cases you outlined, @TylerFisher, but give it a read over and let me know if it seems correct to you.

You can run different combinations locally like this:

```
export VERCEL_ENV=production
export ORG_SLUG=oaklyn
export VERCEL_GIT_COMMIT_REF=main

bash ./deploy.sh

VERCEL_GIT_COMMIT_REF: main
VERCEL_ENV: production
ORG_SLUG: oaklyn
✅ - Oaklyn: build can proceed for main branch in production env
```

The cases in the script currently are:

* if not oaklyn and (stable + production) or (main + preview): BUILD
* if oaklyn and (main + production): BUILD *
* if oaklyn otherwise: BUILD *
* otherwise: DO NOT BUILD

The two `*` cases can be folded together, depending on what we want: do we want to allow Oaklyn to build no matter what? Or, do we want Oaklyn to build only in the following cases:

* preview env + list of matching dev branches (feature, bugfix, hotfix, ...)? or preview env + any branch != 'stable'? 
* any env + list of matching dev branches (feature, bugfix, hotfix, ...)? or any env + any branch != 'stable'? 
* main branch + production env

If we're aiming to reduce the amount of data transferred with Hasura, we might want to limit Oaklyn by env + branch; otherwise it's not a big deal to build it more than required.