### PR TITLE
Fixes urgent malformed list / blank list item bug

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -33,7 +33,6 @@ export async function processDocumentContents(
   var elementCount = elements.length;
 
   for (const element of elements) {
-    // console.log('element: ' + JSON.stringify(element));
     if (element.paragraph && element.paragraph.elements) {
       // console.log("paragraph element: " + JSON.stringify(element))
 
@@ -48,7 +47,7 @@ export async function processDocumentContents(
       if (element.paragraph.bullet) {
         storeElement = true;
 
-        // console.log('Processing list...');
+        // console.log('Processing List: ' + JSON.stringify(element));
         eleData.items = [];
         eleData.type = 'list';
         eleData.index = element.endIndex;
@@ -71,11 +70,19 @@ export async function processDocumentContents(
           // console.log(
           //   listID,
           //   '* found list element in orderedElements: ',
-          //   listElement
+          //   JSON.stringify(listElement)
           // );
 
           let listItemChild;
           element.paragraph.elements.forEach((subElement) => {
+            let subElementContent = cleanContent(subElement.textRun.content);
+            if (!subElementContent) {
+              console.log(
+                'error skipping blank list item',
+                JSON.stringify(subElement)
+              );
+              return;
+            }
             // append list items to the main list element's children
             listItemChild = {
               content: cleanContent(subElement.textRun.content),
@@ -88,10 +95,15 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log("liChild: " + JSON.stringify(listItemChild));
+            // console.log('liChild91: ' + JSON.stringify(listItemChild));
             // listElementChildren.push(listItemChild);
           });
-          if (listItemChild) {
+          if (listItemChild && listItemChild.content) {
+            // console.log(
+            //   'pushing listItemChild to ' +
+            //     listElement.items.length +
+            //     ' listElement items'
+            // );
             listElement.items.push({
               children: [listItemChild],
               index: eleData.index,
@@ -102,10 +114,14 @@ export async function processDocumentContents(
           // console.log(
           //   listID,
           //   'updated listElement:',
-          //   JSON.stringify(listElement)
+          //   listElement.items.length,
+          //   JSON.stringify(listElement.items)
           // );
         } else {
-          // console.log(listID, "* didn't find list element, making new item ");
+          // console.log(
+          //   listID,
+          //   "* didn't find list element, making new list element "
+          // );
           // make a new list element
           if (listInfo[listID]) {
             eleData.listType = listInfo[listID];
@@ -128,17 +144,18 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log("liChild: " + JSON.stringify(listItemChild));
+            // console.log('liChild135: ' + JSON.stringify(listItemChild));
             // listElementChildren.push(listItemChild);
           });
           if (listItemChild) {
+            // console.log('pushing listItemChild to eleData.items');
             eleData.items.push({
               nestingLevel: nestingLevel,
               children: [listItemChild],
               index: eleData.index,
             });
           }
-          // console.log('eleData:', eleData);
+          // console.log('eleData:', JSON.stringify(eleData));
           orderedElements.push(eleData);
         }
       }


### PR DESCRIPTION
Don't append a blank list item to the list - something strange is causing `\n` to come through as a second element for a few list items in the HWH example docs I saw, and that led to blank list items instead of items with actual text content. This PR fixes the issue by preventing blank list item children from being added to the list.

Closes #1076