### PR TITLE
Feature: facebook embeds

### DIFF
--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -32,15 +32,15 @@ export default function Facebook({ node }) {
   };
 
   useEffect(() => {
-    async function loadFB() {
-      if (!document.getElementById('load-facebook-sdk')) {
-        await injectScript();
-      }
+    // async function loadFB() {
+    //   if (!document.getElementById('load-facebook-sdk')) {
+    //     await injectScript();
+    //   }
 
-      await checkFacebookSdk();
-    }
+    //   await checkFacebookSdk();
+    // }
 
-    loadFB();
+    // loadFB();
 
     if (node.html) {
       setMarkup(node.html);

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import Script from 'next/script';
 
 const FB_SDK_URL = 'https://connect.facebook.net/en_US/sdk.js';
 
@@ -52,6 +53,10 @@ export default function Facebook({ node }) {
 
   return (
     <div>
+      <Script
+        src="https://connect.facebook.net/en_US/sdk.js"
+        strategy="beforeInteractive"
+      />
       <div dangerouslySetInnerHTML={{ __html: markup }} />
     </div>
   );

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -55,7 +55,7 @@ export default function Facebook({ node }) {
     <div>
       <Script
         src="https://connect.facebook.net/en_US/sdk.js"
-        strategy="beforeInteractive"
+        strategy="lazyOnload"
       />
       <div dangerouslySetInnerHTML={{ __html: markup }} />
     </div>

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -1,5 +1,35 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+
+const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
+const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 
 export default function Facebook({ node }) {
-  return <div />;
+  const [fbPost, setFbPost] = useState(null);
+
+  useEffect(() => {
+    const fbApiUrl =
+      'https://graph.facebook.com/v12.0/oembed_post?url=' + node.link;
+    const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
+    fetch(fbApiUrl, {
+      headers: {
+        Authorization: `Bearer ${fbAccessToken}`,
+        'Content-Type': 'application/json',
+      },
+      method: 'GET',
+    })
+      .then((res) => res.json())
+      .then((result) => {
+        // console.log('result:', result);
+        setFbPost(result.html);
+      });
+  }, [node.link]);
+  return (
+    <div>
+      <script
+        async=""
+        src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v12.0"
+      />
+      <div dangerouslySetInnerHTML={{ __html: fbPost }} />
+    </div>
+  );
 }

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -2,11 +2,25 @@ import { useEffect, useState } from 'react';
 
 const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
 const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
+const FB_SDK_URL = 'https://connect.facebook.net/en_US/sdk.js';
 
 export default function Facebook({ node }) {
   const [fbContent, setFbContent] = useState(null);
 
+  function injectScript() {
+    const script = document.createElement('script');
+    script.id = 'load-facebook-sdk';
+    script.src = FB_SDK_URL;
+    script.async = true;
+    console.log('appending', script, 'to the body of the page');
+    const body = document.body;
+    body.appendChild(script);
+  }
+
   useEffect(() => {
+    if (!document.getElementById('load-facebook-sdk')) {
+      injectScript();
+    }
     let fbApiUrl;
     if (/\/videos/.test(node.link)) {
       fbApiUrl =
@@ -20,6 +34,12 @@ export default function Facebook({ node }) {
     }
 
     const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
+    console.log(
+      'FB tokens (app, client, combo):',
+      FB_APP_ID,
+      FB_CLIENT_TOKEN,
+      fbAccessToken
+    );
     fetch(fbApiUrl, {
       headers: {
         Authorization: `Bearer ${fbAccessToken}`,
@@ -29,16 +49,12 @@ export default function Facebook({ node }) {
     })
       .then((res) => res.json())
       .then((result) => {
-        // console.log('result:', result);
+        console.log('result:', result);
         setFbContent(result.html);
       });
   }, [node.link]);
   return (
     <div>
-      <script
-        async=""
-        src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v12.0"
-      />
       <div dangerouslySetInnerHTML={{ __html: fbContent }} />
     </div>
   );

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -4,11 +4,21 @@ const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
 const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 
 export default function Facebook({ node }) {
-  const [fbPost, setFbPost] = useState(null);
+  const [fbContent, setFbContent] = useState(null);
 
   useEffect(() => {
-    const fbApiUrl =
-      'https://graph.facebook.com/v12.0/oembed_post?url=' + node.link;
+    let fbApiUrl;
+    if (/\/videos/.test(node.link)) {
+      fbApiUrl =
+        'https://graph.facebook.com/v12.0/oembed_video?url=' + node.link;
+    } else if (/\/posts/.test(node.link)) {
+      fbApiUrl =
+        'https://graph.facebook.com/v12.0/oembed_post?url=' + node.link;
+    } else {
+      fbApiUrl =
+        'https://graph.facebook.com/v12.0/oembed_page?url=' + node.link;
+    }
+
     const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
     fetch(fbApiUrl, {
       headers: {
@@ -20,7 +30,7 @@ export default function Facebook({ node }) {
       .then((res) => res.json())
       .then((result) => {
         // console.log('result:', result);
-        setFbPost(result.html);
+        setFbContent(result.html);
       });
   }, [node.link]);
   return (
@@ -29,7 +39,7 @@ export default function Facebook({ node }) {
         async=""
         src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v12.0"
       />
-      <div dangerouslySetInnerHTML={{ __html: fbPost }} />
+      <div dangerouslySetInnerHTML={{ __html: fbContent }} />
     </div>
   );
 }

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react';
 
-const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
-const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 const FB_SDK_URL = 'https://connect.facebook.net/en_US/sdk.js';
 
 export default function Facebook({ node }) {
-  const [fbReady, setFbReady] = useState(false);
-  const [fbContent, setFbContent] = useState(null);
-  const [someRando, setSomeRando] = useState(null);
+  const [markup, setMarkup] = useState(null);
+
   async function injectScript() {
     const script = document.createElement('script');
     script.id = 'load-facebook-sdk';
@@ -19,86 +16,43 @@ export default function Facebook({ node }) {
     body.appendChild(script);
   }
 
-  async function initFacebook() {
-    console.log('initializing facebook');
-    window.FB.init({
-      appId: FB_APP_ID,
-      status: true,
-      xfbml: true,
-      version: 'v12.0',
-    });
-  }
-
   const checkFacebookSdk = () => {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       self.timer = window.setTimeout(() => {
         if (window.FB) {
           clearTimeout(self.timer);
           console.log('* found window.FB, clearing timeout and resolving!');
-
-          setFbReady(true);
           resolve(1);
         } else {
           console.log(':( no window.FB, waiting 20ms then retrying', self);
-          setFbReady(false);
           checkFacebookSdk(self);
         }
       }, 20);
     });
   };
 
-  async function loadEmbed(link) {
-    console.log('loadEmbed:', link);
-    let fbApiUrl;
-    if (/\/videos/.test(link)) {
-      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_video?url=' + link;
-    } else if (/\/posts/.test(node.link)) {
-      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_post?url=' + link;
-    } else {
-      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_page?url=' + link;
-    }
-
-    const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
-
-    const res = await fetch(fbApiUrl, {
-      headers: {
-        Authorization: `Bearer ${fbAccessToken}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'GET',
-    });
-    console.log('result from fetch:', res);
-
-    const data = await res.json();
-    console.log('setting fbContent html:', data.html);
-    setFbContent(data.html);
-  }
-
   useEffect(() => {
-    if (window.FB && fbReady) {
-      async function loadAndParseEmbed() {
-        console.log(
-          'useEffect window.FB found, loading embed for',
-          node.link,
-          '...'
-        );
-        await initFacebook();
-        await loadEmbed(node.link);
-        window.FB.XFBML.parse();
-      }
-      loadAndParseEmbed();
-    } else {
+    async function loadFB() {
       if (!document.getElementById('load-facebook-sdk')) {
-        injectScript();
+        await injectScript();
       }
 
-      checkFacebookSdk();
+      await checkFacebookSdk();
     }
-  }, [node.link, fbReady]);
+
+    loadFB();
+
+    if (node.html) {
+      setMarkup(node.html);
+      console.log('Set markup to the node.html:', node.html);
+    } else {
+      console.error('No markup found for the facebook embed...', node);
+    }
+  }, [node.link]);
 
   return (
     <div>
-      <div dangerouslySetInnerHTML={{ __html: fbContent }} />
+      <div dangerouslySetInnerHTML={{ __html: markup }} />
     </div>
   );
 }

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -1,51 +1,13 @@
 import { useEffect, useState } from 'react';
 import Script from 'next/script';
 
-const FB_SDK_URL = 'https://connect.facebook.net/en_US/sdk.js';
-
 export default function Facebook({ node }) {
   const [markup, setMarkup] = useState(null);
 
-  async function injectScript() {
-    const script = document.createElement('script');
-    script.id = 'load-facebook-sdk';
-    script.src = FB_SDK_URL;
-    script.async = true;
-    script.defer = true;
-    console.log('appending', script, 'to the body of the page');
-    const body = document.body;
-    body.appendChild(script);
-  }
-
-  const checkFacebookSdk = () => {
-    return new Promise((resolve) => {
-      self.timer = window.setTimeout(() => {
-        if (window.FB) {
-          clearTimeout(self.timer);
-          console.log('* found window.FB, clearing timeout and resolving!');
-          resolve(1);
-        } else {
-          console.log(':( no window.FB, waiting 20ms then retrying', self);
-          checkFacebookSdk(self);
-        }
-      }, 20);
-    });
-  };
-
   useEffect(() => {
-    // async function loadFB() {
-    //   if (!document.getElementById('load-facebook-sdk')) {
-    //     await injectScript();
-    //   }
-
-    //   await checkFacebookSdk();
-    // }
-
-    // loadFB();
-
     if (node.html) {
       setMarkup(node.html);
-      console.log('Set markup to the node.html:', node.html);
+      // console.log('Set markup to the node.html:', node.html);
     } else {
       console.error('No markup found for the facebook embed...', node);
     }

--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -5,54 +5,97 @@ const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 const FB_SDK_URL = 'https://connect.facebook.net/en_US/sdk.js';
 
 export default function Facebook({ node }) {
+  const [fbReady, setFbReady] = useState(false);
   const [fbContent, setFbContent] = useState(null);
-
-  function injectScript() {
+  const [someRando, setSomeRando] = useState(null);
+  async function injectScript() {
     const script = document.createElement('script');
     script.id = 'load-facebook-sdk';
     script.src = FB_SDK_URL;
     script.async = true;
+    script.defer = true;
     console.log('appending', script, 'to the body of the page');
     const body = document.body;
     body.appendChild(script);
   }
 
-  useEffect(() => {
-    if (!document.getElementById('load-facebook-sdk')) {
-      injectScript();
-    }
+  async function initFacebook() {
+    console.log('initializing facebook');
+    window.FB.init({
+      appId: FB_APP_ID,
+      status: true,
+      xfbml: true,
+      version: 'v12.0',
+    });
+  }
+
+  const checkFacebookSdk = () => {
+    return new Promise((resolve, reject) => {
+      self.timer = window.setTimeout(() => {
+        if (window.FB) {
+          clearTimeout(self.timer);
+          console.log('* found window.FB, clearing timeout and resolving!');
+
+          setFbReady(true);
+          resolve(1);
+        } else {
+          console.log(':( no window.FB, waiting 20ms then retrying', self);
+          setFbReady(false);
+          checkFacebookSdk(self);
+        }
+      }, 20);
+    });
+  };
+
+  async function loadEmbed(link) {
+    console.log('loadEmbed:', link);
     let fbApiUrl;
-    if (/\/videos/.test(node.link)) {
-      fbApiUrl =
-        'https://graph.facebook.com/v12.0/oembed_video?url=' + node.link;
+    if (/\/videos/.test(link)) {
+      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_video?url=' + link;
     } else if (/\/posts/.test(node.link)) {
-      fbApiUrl =
-        'https://graph.facebook.com/v12.0/oembed_post?url=' + node.link;
+      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_post?url=' + link;
     } else {
-      fbApiUrl =
-        'https://graph.facebook.com/v12.0/oembed_page?url=' + node.link;
+      fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_page?url=' + link;
     }
 
     const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
-    console.log(
-      'FB tokens (app, client, combo):',
-      FB_APP_ID,
-      FB_CLIENT_TOKEN,
-      fbAccessToken
-    );
-    fetch(fbApiUrl, {
+
+    const res = await fetch(fbApiUrl, {
       headers: {
         Authorization: `Bearer ${fbAccessToken}`,
         'Content-Type': 'application/json',
       },
       method: 'GET',
-    })
-      .then((res) => res.json())
-      .then((result) => {
-        console.log('result:', result);
-        setFbContent(result.html);
-      });
-  }, [node.link]);
+    });
+    console.log('result from fetch:', res);
+
+    const data = await res.json();
+    console.log('setting fbContent html:', data.html);
+    setFbContent(data.html);
+  }
+
+  useEffect(() => {
+    if (window.FB && fbReady) {
+      async function loadAndParseEmbed() {
+        console.log(
+          'useEffect window.FB found, loading embed for',
+          node.link,
+          '...'
+        );
+        await initFacebook();
+        await loadEmbed(node.link);
+        window.FB.XFBML.parse();
+      }
+      loadAndParseEmbed();
+    } else {
+      if (!document.getElementById('load-facebook-sdk')) {
+        injectScript();
+      }
+
+      checkFacebookSdk();
+    }
+  }, [node.link, fbReady]);
+
   return (
     <div>
       <div dangerouslySetInnerHTML={{ __html: fbContent }} />

--- a/components/nodes/embeds/Instagram.js
+++ b/components/nodes/embeds/Instagram.js
@@ -1,6 +1,6 @@
 import InstagramEmbed from 'react-instagram-embed';
 
-const FB_APP_ID = '200171875317911';
+const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
 const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 
 export default function Instagram({ node }) {

--- a/components/nodes/embeds/TikTok.js
+++ b/components/nodes/embeds/TikTok.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import Script from 'next/script';
 
 export default function TikTokEmbed({ node, amp }) {
   const [video, setVideo] = useState(null);
@@ -20,7 +21,7 @@ export default function TikTokEmbed({ node, amp }) {
     <div />
   ) : (
     <div>
-      <script async="" src="https://www.tiktok.com/embed.js" />
+      <Script src="https://www.tiktok.com/embed.js" strategy="lazyOnload" />
       <div dangerouslySetInnerHTML={{ __html: video }} />
     </div>
   );

--- a/lib/document.js
+++ b/lib/document.js
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { fetchGraphQL, slugify } from './graphql';
+import { getFacebookMarkup } from './embeds';
 import TinyS3 from './tiny_s3';
 
 export async function processDocumentContents(
@@ -34,6 +35,7 @@ export async function processDocumentContents(
         children: [],
         link: null,
         type: null,
+        html: null,
         index: element.endIndex,
       };
 
@@ -191,6 +193,17 @@ export async function processDocumentContents(
             if (/forms\.gle/.test(linkUrl)) {
               let redirectURL = await getFullGoogleFormsUrl(linkUrl);
               eleData.link = redirectURL;
+              orderedElements.push(eleData);
+
+              // special case to grab the html from Facebook as doing this in the Embed node is ridiculous/doesn't work
+            } else if (/facebook\.com/.test(linkUrl)) {
+              let markup = await getFacebookMarkup(linkUrl);
+              eleData.link = linkUrl;
+              eleData.html = markup;
+              console.log(
+                'facebook eleData stored with html:',
+                JSON.stringify(eleData)
+              );
               orderedElements.push(eleData);
             } else {
               eleData.link = linkUrl;
@@ -1247,6 +1260,7 @@ function formatElements(elements) {
         type: element.type,
         style: element.style,
         link: element.link,
+        html: element.html,
         listType: element.listType,
       };
       if (formattedElement.type === 'list') {

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -6,11 +6,17 @@ const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
 export async function getFacebookMarkup(link) {
   let fbApiUrl;
   if (/\/videos/.test(link)) {
-    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_video?url=' + link;
+    fbApiUrl =
+      'https://graph.facebook.com/v12.0/oembed_video?omitscript=true&url=' +
+      link;
   } else if (/\/posts/.test(link)) {
-    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_post?url=' + link;
+    fbApiUrl =
+      'https://graph.facebook.com/v12.0/oembed_post?omitscript=true&url=' +
+      link;
   } else {
-    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_page?url=' + link;
+    fbApiUrl =
+      'https://graph.facebook.com/v12.0/oembed_page?omitscript=true&url=' +
+      link;
   }
 
   const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -1,0 +1,30 @@
+import fetch from 'node-fetch';
+
+const FB_APP_ID = process.env.NEXT_PUBLIC_FB_APP_ID;
+const FB_CLIENT_TOKEN = process.env.NEXT_PUBLIC_FB_CLIENT_TOKEN;
+
+export async function getFacebookMarkup(link) {
+  let fbApiUrl;
+  if (/\/videos/.test(link)) {
+    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_video?url=' + link;
+  } else if (/\/posts/.test(link)) {
+    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_post?url=' + link;
+  } else {
+    fbApiUrl = 'https://graph.facebook.com/v12.0/oembed_page?url=' + link;
+  }
+
+  const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
+
+  const res = await fetch(fbApiUrl, {
+    headers: {
+      Authorization: `Bearer ${fbAccessToken}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'GET',
+  });
+  // console.log('result from fetch:', res);
+
+  const data = await res.json();
+  // console.log('returning html:', data.html);
+  return data.html;
+}


### PR DESCRIPTION
Closes #1031 

**Note:** environment settings update required. See https://github.com/news-catalyst/tnc-org-envs/pull/4

**Update:** this PR has changed to request the markup for the embed from FB at document parsing time, then stores the html in hasura in the body. The component injects the javascript SDK from Facebook into the body of the page, and loads the html from the embed node.

This updates the Facebook embed node to support three kinds of embeddable FB content:

* posts (matches `/posts` in the content URL)
* videos (`/videos`)
* pages (any other FB url)
