### PR TITLE
push revalidation timeout to one minute

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -79,6 +79,6 @@ export async function getStaticProps({ locale }) {
       locales,
       locale,
     },
-    revalidate: 1,
+    revalidate: 60,
   };
 }

--- a/pages/articles/[category]/[slug].js
+++ b/pages/articles/[category]/[slug].js
@@ -139,8 +139,8 @@ export async function getStaticProps({ locale, params }) {
       publishedLocales,
       locale,
     },
-    // Re-generate the post at most once per second
+    // Re-generate the post at most once every 30 seconds
     // if a request comes in
-    revalidate: 1,
+    revalidate: 60,
   };
 }

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -161,6 +161,6 @@ export async function getStaticProps({ locale }) {
       locales,
       locale,
     },
-    revalidate: 1,
+    revalidate: 60,
   };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -134,6 +134,6 @@ export async function getStaticProps({ locale }) {
       siteMetadata,
       expandedAds,
     },
-    revalidate: 1,
+    revalidate: 60,
   };
 }

--- a/pages/staff.js
+++ b/pages/staff.js
@@ -56,6 +56,6 @@ export async function getStaticProps({ locale }) {
       sections,
       siteMetadata,
     },
-    revalidate: 1,
+    revalidate: 60,
   };
 }


### PR DESCRIPTION
Currently, most of our requests to our sites are uncached, which seems bad. I want to experiment with a longer timeout on the cache before the site revalidates and see if that helps. First, I'm going to try a preview deployment API and see if it's super frustrating to make edits to articles/the homepage with things working this way.