### PR TITLE
Bugfix/list parsing

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -53,7 +53,7 @@ export async function processDocumentContents(
         }
         // Find existing element with the same list ID
         let listID = element.paragraph.bullet.listId;
-        console.log('listID:', listID);
+        console.log('listID:', listID, element.paragraph.elements.length);
 
         let findListElement = (element) =>
           element.type === 'list' && element.listId === listID;
@@ -65,6 +65,7 @@ export async function processDocumentContents(
           let listElement = orderedElements[listElementIndex];
 
           let listItemChild;
+          let listItemChildren = [];
           element.paragraph.elements.forEach((subElement) => {
             let subElementContent = cleanContent(subElement.textRun.content);
             if (!subElementContent) {
@@ -86,36 +87,46 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-
-            if (!listElement.items || !listElement.items[0]) {
-              listElement.items = [];
-              listElement.items.push({
-                nestingLevel: nestingLevel,
-                children: [listItemChild],
-                index: eleData.index,
-              });
-            } else if (
-              listElement.items &&
-              listElement.items[0] &&
-              listElement.items[0].children
-            ) {
-              // console.log(
-              //   'li109 listElement.items.length: ' + listElement.items.length
-              // );
-              // console.log(
-              //   'li112 listElement.items[0].children.length: ' +
-              //     listElement.items[0].children.length,
-              //   JSON.stringify(listElement)
-              // );
-              // listElement.items[0].children.push(listItemChild);
-            }
-            // listElement.items.push({
-            //   children: [listItemChild],
-            //   index: eleData.index,
-            //   nestingLevel: nestingLevel,
-            // });
+            listItemChildren.push(listItemChild);
           });
 
+          if (!listElement.items || !listElement.items[0]) {
+            let newListItem = {
+              nestingLevel: nestingLevel,
+              children: listItemChildren,
+              index: eleData.index,
+            };
+            console.log(
+              listID,
+              'li99 no items, adding first one to listElement:',
+              JSON.stringify(newListItem)
+            );
+            listElement.items = [];
+            listElement.items.push(newListItem);
+          } else if (
+            listElement.items &&
+            listElement.items[0] &&
+            listElement.items[0].children
+          ) {
+            console.log(
+              listID,
+              'li111 has items - what to do?: ' +
+                listElement.items.length +
+                ': '
+            );
+            console.log(
+              'listItemChildren:',
+              listItemChildren.length,
+              JSON.stringify(listItemChildren)
+            );
+            console.log('LIST ITEM CHILD:', JSON.stringify(listItemChild));
+            console.log('LIST ELEMENT:', JSON.stringify(listElement));
+            listElement.items.push({
+              children: listItemChildren,
+              index: eleData.index,
+              nestingLevel: nestingLevel,
+            });
+          }
           orderedElements[listElementIndex] = listElement;
         } else {
           // make a new list element

--- a/lib/document.js
+++ b/lib/document.js
@@ -53,7 +53,7 @@ export async function processDocumentContents(
         }
         // Find existing element with the same list ID
         let listID = element.paragraph.bullet.listId;
-        // console.log('listID:', listID);
+        console.log('listID:', listID);
 
         let findListElement = (element) =>
           element.type === 'list' && element.listId === listID;
@@ -63,11 +63,6 @@ export async function processDocumentContents(
         // just append this element's text to the exist list's items
         if (listElementIndex > 0) {
           let listElement = orderedElements[listElementIndex];
-          // console.log(
-          //   listID,
-          //   '* found list element in orderedElements: ',
-          //   JSON.stringify(listElement)
-          // );
 
           let listItemChild;
           element.paragraph.elements.forEach((subElement) => {
@@ -91,33 +86,38 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log('liChild91: ' + JSON.stringify(listItemChild));
-            // listElementChildren.push(listItemChild);
+
+            if (!listElement.items || !listElement.items[0]) {
+              listElement.items = [];
+              listElement.items.push({
+                nestingLevel: nestingLevel,
+                children: [listItemChild],
+                index: eleData.index,
+              });
+            } else if (
+              listElement.items &&
+              listElement.items[0] &&
+              listElement.items[0].children
+            ) {
+              // console.log(
+              //   'li109 listElement.items.length: ' + listElement.items.length
+              // );
+              // console.log(
+              //   'li112 listElement.items[0].children.length: ' +
+              //     listElement.items[0].children.length,
+              //   JSON.stringify(listElement)
+              // );
+              // listElement.items[0].children.push(listItemChild);
+            }
+            // listElement.items.push({
+            //   children: [listItemChild],
+            //   index: eleData.index,
+            //   nestingLevel: nestingLevel,
+            // });
           });
-          if (listItemChild && listItemChild.content) {
-            // console.log(
-            //   'pushing listItemChild to ' +
-            //     listElement.items.length +
-            //     ' listElement items'
-            // );
-            listElement.items.push({
-              children: [listItemChild],
-              index: eleData.index,
-              nestingLevel: nestingLevel,
-            });
-          }
+
           orderedElements[listElementIndex] = listElement;
-          // console.log(
-          //   listID,
-          //   'updated listElement:',
-          //   listElement.items.length,
-          //   JSON.stringify(listElement.items)
-          // );
         } else {
-          // console.log(
-          //   listID,
-          //   "* didn't find list element, making new list element "
-          // );
           // make a new list element
           if (listInfo[listID]) {
             eleData.listType = listInfo[listID];
@@ -127,7 +127,7 @@ export async function processDocumentContents(
           eleData.type = 'list';
           eleData.listId = listID;
 
-          let listItemChild;
+          let listItemChild = {};
           element.paragraph.elements.forEach((subElement) => {
             // append list items to the main list element's children
             listItemChild = {
@@ -140,18 +140,23 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log('liChild135: ' + JSON.stringify(listItemChild));
-            // listElementChildren.push(listItemChild);
+
+            if (!eleData.items || !eleData.items[0]) {
+              eleData.items = [];
+              eleData.items.push({
+                nestingLevel: nestingLevel,
+                children: [listItemChild],
+                index: eleData.index,
+              });
+            } else if (
+              eleData.items &&
+              eleData.items[0] &&
+              eleData.items[0].children
+            ) {
+              eleData.items[0].children.push(listItemChild);
+            }
           });
-          if (listItemChild) {
-            // console.log('pushing listItemChild to eleData.items');
-            eleData.items.push({
-              nestingLevel: nestingLevel,
-              children: [listItemChild],
-              index: eleData.index,
-            });
-          }
-          // console.log('eleData:', JSON.stringify(eleData));
+
           orderedElements.push(eleData);
         }
       }


### PR DESCRIPTION
The bug has to do with how Google treats lists: there are items, which refer to each bullet point, and there are children, which refer to each block of formatted text within an item. 

This should fix the issue by building an array of children for each list item; then checking if the current list has any items; composing the list item with the full set of children elements; appending the list item to the list.

Testing should happen against the preview URL, once it is deployed, using the sidebar with document api url pointed there.