### PR TITLE
Documentation: how to launch a new Hasura instance

### DIFF
--- a/docs/howto_launch_hasura_production_copy.md
+++ b/docs/howto_launch_hasura_production_copy.md
@@ -28,7 +28,7 @@ I followed along with the official Hasura documentation [Local Dev to Staging to
 
 8. This process (Hasura -> launch db -> Heroku) should fill in the necessary env vars for the instance db connectivity, specifically the `HASURA_GRAPHQL_DATABASE_URL` var.
 
-9. Copy the webhook related vars from production Hasura and recreate in the new instance (`HASURA_GRAPHQL_AUTH_HOOK` => `https://huf7758ged.execute-api.us-east-1.amazonaws.com/prod/webhook`)
+9. You'll also need a new instance of the authorization webhook, which authenticates requests based on TBD and directs them to the right Hasura instance. If the existing webhook implementation is fine and you just need a webhook to point at the right Hasura instance, you can probably copy the `js` directory and update a couple of values (howto doc would be good to have, will add to the list) then deploy using `sls`. Once you have a deployed webhook, specify it in the settings for the new Hasura instance (`HASURA_GRAPHQL_AUTH_HOOK` => `https://${PREFIX}.execute-api.us-east-1.amazonaws.com/prod/webhook`).
 
 10. Also be sure to grab the GraphQL endpoint URL for the new Hasura instance
 

--- a/docs/howto_launch_hasura_production_copy.md
+++ b/docs/howto_launch_hasura_production_copy.md
@@ -1,0 +1,48 @@
+# How to launch a copy of production Hasura
+
+This document describes how to replicate the existing production Hasura instance - which includes the postgres database and graphql API - in another Hasura instance.
+
+I followed along with the official Hasura documentation [Local Dev to Staging to getting Production-Ready with Hasura! 🚀](https://hasura.io/blog/moving-from-local-development-staging-production-with-hasura/).
+
+## Steps
+
+1. Change into the [hasura](https://github.com/news-catalyst/hasura/) repo locally and ensure you have the [hasura CLI](https://hasura.io/docs/latest/graphql/core/hasura-cli/install-hasura-cli.html#install-hasura-cli) installed and working.
+
+2. Run this command to setup the initial migration script using pg_dump as an "up" migration:
+
+`hasura migrate create init-schema --from-server --endpoint <hasura-project-url> --admin-secret <admin-secret>`
+
+3. Find the migration timestamp by finding the file named something similar to `1627564572630_init-schema` in the directory `migrations/default` and copying the numeric prefix.
+
+4. Mark the new init migration as executed (without actually executing it!) in the production database to avoid it being run in the future:
+
+`hasura migrate apply --endpoint <hasura-project-url> --admin-secret <admin-secret> --version 1627564572630 --skip-execution`
+
+5. Run this command to make sure the latest production metadata is also exported to the filesystem:
+
+`hasura metadata reload --endpoint <hasura-project-url> --admin-secret <admin-secret> && hasura metadata export --endpoint <hasura-project-url> --admin-secret <admin-secret>`
+
+6. Launch a new Hasura project [on the Hasura projects list page](https://cloud.hasura.io/projects)
+
+7. Navigate to the Data tab in Hasura and Create Heroku Database. (NOTE: as an alternative, you can launch a postgres database in AWS under RDS.)
+
+8. This process (Hasura -> launch db -> Heroku) should fill in the necessary env vars for the instance db connectivity, specifically the `HASURA_GRAPHQL_DATABASE_URL` var.
+
+9. Copy the webhook related vars from production Hasura and recreate in the new instance (`HASURA_GRAPHQL_AUTH_HOOK` => `https://huf7758ged.execute-api.us-east-1.amazonaws.com/prod/webhook`)
+
+10. Also be sure to grab the GraphQL endpoint URL for the new Hasura instance
+
+11. Run these commands to apply the migration and metadata to the new Hasura instance:
+
+```
+hasura migrate apply --version <init-version-number-from-step-3> --endpoint <new-hasura-project-url> --database-name default --admin-secret <new-admin-secret>
+hasura metadata apply --endpoint <new-hasura-project-url> --admin-secret <new-admin-secret>
+```
+
+12. Check the output of the last command for any inconsistent metadata and fix any problems.
+
+13. Use the TNC admin hasura collection in Postman to request a data-only dump from the production instance. Save the output to a file (`pg_dump_production_{todays_date}.sql`)
+
+14. Copy the postgres connection URI and run this command from terminal:
+
+`psql <connection-uri-string> < pg_dump_production_{todays_date}.sql`

--- a/lib/document.js
+++ b/lib/document.js
@@ -53,7 +53,7 @@ export async function processDocumentContents(
         }
         // Find existing element with the same list ID
         let listID = element.paragraph.bullet.listId;
-        // console.log('listID:', listID);
+        console.log('listID:', listID);
 
         let findListElement = (element) =>
           element.type === 'list' && element.listId === listID;
@@ -63,11 +63,6 @@ export async function processDocumentContents(
         // just append this element's text to the exist list's items
         if (listElementIndex > 0) {
           let listElement = orderedElements[listElementIndex];
-          // console.log(
-          //   listID,
-          //   '* found list element in orderedElements: ',
-          //   JSON.stringify(listElement)
-          // );
 
           let listItemChild;
           element.paragraph.elements.forEach((subElement) => {
@@ -91,33 +86,38 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log('liChild91: ' + JSON.stringify(listItemChild));
-            // listElementChildren.push(listItemChild);
+
+            if (!listElement.items || !listElement.items[0]) {
+              listElement.items = [];
+              listElement.items.push({
+                nestingLevel: nestingLevel,
+                children: [listItemChild],
+                index: eleData.index,
+              });
+            } else if (
+              listElement.items &&
+              listElement.items[0] &&
+              listElement.items[0].children
+            ) {
+              // console.log(
+              //   'li109 listElement.items.length: ' + listElement.items.length
+              // );
+              // console.log(
+              //   'li112 listElement.items[0].children.length: ' +
+              //     listElement.items[0].children.length,
+              //   JSON.stringify(listElement)
+              // );
+              // listElement.items[0].children.push(listItemChild);
+            }
+            // listElement.items.push({
+            //   children: [listItemChild],
+            //   index: eleData.index,
+            //   nestingLevel: nestingLevel,
+            // });
           });
-          if (listItemChild && listItemChild.content) {
-            // console.log(
-            //   'pushing listItemChild to ' +
-            //     listElement.items.length +
-            //     ' listElement items'
-            // );
-            listElement.items.push({
-              children: [listItemChild],
-              index: eleData.index,
-              nestingLevel: nestingLevel,
-            });
-          }
+
           orderedElements[listElementIndex] = listElement;
-          // console.log(
-          //   listID,
-          //   'updated listElement:',
-          //   listElement.items.length,
-          //   JSON.stringify(listElement.items)
-          // );
         } else {
-          // console.log(
-          //   listID,
-          //   "* didn't find list element, making new list element "
-          // );
           // make a new list element
           if (listInfo[listID]) {
             eleData.listType = listInfo[listID];
@@ -127,7 +127,7 @@ export async function processDocumentContents(
           eleData.type = 'list';
           eleData.listId = listID;
 
-          let listItemChild;
+          let listItemChild = {};
           element.paragraph.elements.forEach((subElement) => {
             // append list items to the main list element's children
             listItemChild = {
@@ -140,18 +140,23 @@ export async function processDocumentContents(
             ) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-            // console.log('liChild135: ' + JSON.stringify(listItemChild));
-            // listElementChildren.push(listItemChild);
+
+            if (!eleData.items || !eleData.items[0]) {
+              eleData.items = [];
+              eleData.items.push({
+                nestingLevel: nestingLevel,
+                children: [listItemChild],
+                index: eleData.index,
+              });
+            } else if (
+              eleData.items &&
+              eleData.items[0] &&
+              eleData.items[0].children
+            ) {
+              eleData.items[0].children.push(listItemChild);
+            }
           });
-          if (listItemChild) {
-            // console.log('pushing listItemChild to eleData.items');
-            eleData.items.push({
-              nestingLevel: nestingLevel,
-              children: [listItemChild],
-              index: eleData.index,
-            });
-          }
-          // console.log('eleData:', JSON.stringify(eleData));
+
           orderedElements.push(eleData);
         }
       }


### PR DESCRIPTION
Part of #1085 

Note: this is a markdown document only PR and relates directly to https://github.com/news-catalyst/hasura/pull/103.

The values for Oaklyn's environment have been updated in this PR https://github.com/news-catalyst/tnc-org-envs/pull/7

As I had to setup another Hasura instance, based off our production instance, and found this process difficult the last time I tried it (for our testing instance), I thought I'd document how to accomplish creating a copy of the running production Hasura db and api step-by-step.

FYI: I'm also putting together a couple collections of Postman API requests. So far there's an admin collection that includes how to request the latest full data dump (no schema) from Hasura and an Oaklyn collection for the document API. I've also created several environments in Postman for our different envs (hasura endpoint, base URL for our API, etc). I'll post and share access when it seems full enough to be useful.