### PR TITLE
Get our image data right for Facebook

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -33,6 +33,24 @@ export default function AboutPage({
     isAmp,
     siteMetadata
   );
+  let mainImageNode;
+  let mainImage = null;
+  if (page) {
+    try {
+      mainImageNode = localisedPage?.content.find(
+        (node) => node.type === 'mainImage'
+      );
+
+      if (mainImageNode) {
+        mainImage = mainImageNode.children[0];
+        siteMetadata['coverImage'] = mainImage.imageUrl;
+        siteMetadata['coverImageWidth'] = mainImage.width;
+        siteMetadata['coverImageHeight'] = mainImage.height;
+      }
+    } catch (err) {
+      console.error('error finding main image: ', err);
+    }
+  }
 
   return (
     <Layout locale={locale} meta={siteMetadata} page={page} sections={sections}>

--- a/components/Article.js
+++ b/components/Article.js
@@ -51,6 +51,8 @@ export default function Article({
         mainImage = mainImageNode.children[0];
         if (mainImage.imageUrl) {
           siteMetadata['coverImage'] = mainImage.imageUrl;
+          siteMetadata['coverImageWidth'] = mainImage.width;
+          siteMetadata['coverImageHeight'] = mainImage.height;
         }
       }
     } catch (err) {

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -31,6 +31,14 @@ export default function Layout({
     meta = {};
   }
 
+  // helper function to determine what to tell facebook width/height of image are
+  function coverImageDimensions(w, h) {
+    return {
+      width: w > 1201 ? w : 1201,
+      height: w > 1201 ? h : (h / w) * 1201,
+    };
+  }
+
   // console.log('Layout locale:', locale);
 
   const metaValues = {
@@ -55,6 +63,28 @@ export default function Layout({
     facebookAppId: meta['facebookAppId'],
     siteTwitter: meta['siteTwitter'],
   };
+
+  // figure out what dimensions to set for facebook cover image
+  let dimensions = null;
+  if (meta.coverImage && meta.coverImageWidth && meta.coverImageHeight) {
+    dimensions = coverImageDimensions(
+      meta.coverImageWidth,
+      meta.coverImageHeight
+    );
+  } else if (
+    meta.defaultSocialImage &&
+    meta.defaultSocialImageWidth &&
+    meta.defaultSocialImageHeight
+  ) {
+    dimensions = coverImageDimensions(
+      meta.defaultSocialImageWidth,
+      meta.defaultSocialImageHeight
+    );
+  }
+  metaValues.coverImageWidth = dimensions?.width;
+  metaValues.coverImageHeight = dimensions?.height;
+
+  console.log(meta);
 
   // override default canonical url if there's one specified on the article
   if (article && article.canonical_url) {
@@ -207,6 +237,11 @@ export default function Layout({
         <meta property="og:type" content={metaValues.documentType} />
         <meta property="og:url" content={metaValues.canonical} />
         <meta property="og:image" content={metaValues.coverImage} />
+        <meta property="og:image:width" content={metaValues.coverImageWidth} />
+        <meta
+          property="og:image:height"
+          content={metaValues.coverImageHeight}
+        />
         <meta
           property="og:description"
           content={metaValues.facebookDescription}

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -28,6 +28,8 @@ export default function StaticPage({
 
   let localisedPage;
   let body;
+  let mainImageNode;
+  let mainImage = null;
   if (page) {
     // there will only be one translation returned for a given page + locale
     localisedPage = page.page_translations[0];
@@ -38,6 +40,20 @@ export default function StaticPage({
       isAmp,
       siteMetadata
     );
+    try {
+      mainImageNode = localisedPage?.content.find(
+        (node) => node.type === 'mainImage'
+      );
+
+      if (mainImageNode) {
+        mainImage = mainImageNode.children[0];
+        siteMetadata['coverImage'] = mainImage.imageUrl;
+        siteMetadata['coverImageWidth'] = mainImage.width;
+        siteMetadata['coverImageHeight'] = mainImage.height;
+      }
+    } catch (err) {
+      console.error('error finding main image: ', err);
+    }
   }
 
   return (

--- a/components/articles/StaticMainImage.js
+++ b/components/articles/StaticMainImage.js
@@ -23,10 +23,8 @@ export default function StaticMainImage({ page, locale, isAmp, siteMetadata }) {
   ) {
     try {
       mainImageNode = pageContent.find((node) => node.type === 'mainImage');
-
       if (mainImageNode) {
         mainImage = mainImageNode.children[0];
-        siteMetadata['coverImage'] = mainImage.imageUrl;
       }
     } catch (err) {
       console.error('error finding main image: ', err);

--- a/components/tinycms/SiteInfoSettings.js
+++ b/components/tinycms/SiteInfoSettings.js
@@ -277,6 +277,12 @@ export default function SiteInfoSettings(props) {
   const [defaultSocialImage, setDefaultSocialImage] = useState(
     props.parsedData['defaultSocialImage']
   );
+  const [defaultSocialImageWidth, setDefaultSocialImageWidth] = useState(
+    props.parsedData['defaultSocialImageWidth']
+  );
+  const [defaultSocialImageHeight, setDefaultSocialImageHeight] = useState(
+    props.parsedData['defaultSocialImageHeight']
+  );
   let parsedDonationOptions;
   try {
     parsedDonationOptions = JSON.parse(props.parsedData['donationOptions']);
@@ -976,10 +982,14 @@ export default function SiteInfoSettings(props) {
               awsConfig={props.awsConfig}
               slug={shortName}
               imageKey="defaultSocialImage"
+              widthKey="defaultSocialImageWidth"
+              heightKey="defaultSocialImageHeight"
               image={defaultSocialImage}
               updateParsedData={props.updateParsedData}
               parsedData={props.parsedData}
               setter={setDefaultSocialImage}
+              widthSetter={setDefaultSocialImageWidth}
+              heightSetter={setDefaultSocialImageHeight}
               setNotificationMessage={props.setNotificationMessage}
               setNotificationType={props.setNotificationType}
               setShowNotification={props.setShowNotification}

--- a/components/tinycms/Upload.js
+++ b/components/tinycms/Upload.js
@@ -22,6 +22,13 @@ export default function Upload(props) {
       };
       img.src = props.image;
 
+      if (props.widthSetter) {
+        props.widthSetter(imageWidth);
+      }
+      if (props.heightSetter) {
+        props.heightSetter(imageHeight);
+      }
+
       setImageSrc(props.image);
     }
   }, [props.image]);
@@ -40,12 +47,6 @@ export default function Upload(props) {
           let assetUrl =
             'https://assets.tinynewsco.org' + uploadedS3Url.pathname;
           props.setter(assetUrl);
-          if (props.widthSetter) {
-            props.widthSetter(imageWidth);
-          }
-          if (props.heightSetter) {
-            props.heightSetter(imageHeight);
-          }
 
           if (props.parsedData) {
             let updatedParsedData = props.parsedData;

--- a/lib/document.js
+++ b/lib/document.js
@@ -361,7 +361,18 @@ export async function processDocumentContents(
             let fullImageData = inlineObjects[imageID];
             if (fullImageData) {
               // console.log("Found full image data: " + JSON.stringify(fullImageData))
-              let s3Url = imageList[imageID];
+              const storedImageData = imageList[imageID];
+              let s3Url = null;
+              let imageHeight = null;
+              let imageWidth = null;
+
+              console.log('storedImageData', storedImageData);
+              // check for the new format. if it's the old format, reupload to force getting new data
+              if (typeof storedImageData === 'object') {
+                s3Url = storedImageData.url;
+                imageHeight = storedImageData.height;
+                imageWidth = storedImageData.width;
+              }
               let articleSlugMatches = false;
               let assetDomainMatches = false;
 
@@ -378,13 +389,6 @@ export async function processDocumentContents(
                 articleSlugMatches = false;
                 assetDomainMatches = false;
               }
-
-              let imageHeight =
-                fullImageData.inlineObjectProperties.embeddedObject.size.height
-                  .magnitude;
-              let imageWidth =
-                fullImageData.inlineObjectProperties.embeddedObject.size.width
-                  .magnitude;
 
               if (
                 s3Url === null ||
@@ -408,7 +412,11 @@ export async function processDocumentContents(
                 );
                 s3Url = data.s3Url;
 
-                imageList[imageID] = s3Url;
+                imageList[imageID] = {
+                  url: s3Url,
+                  height: data?.height,
+                  width: data?.width,
+                };
 
                 if (data && data.height) {
                   imageHeight = data.height;
@@ -420,7 +428,7 @@ export async function processDocumentContents(
                 }
               } else {
                 // console.log(slug + " " + imageID + " has already been uploaded: " + articleSlugMatches + " " + s3Url);
-                imageList[imageID] = s3Url;
+                imageList[imageID] = storedImageData;
               }
 
               let childImage = {
@@ -433,6 +441,8 @@ export async function processDocumentContents(
                   fullImageData.inlineObjectProperties.embeddedObject.title
                 ),
               };
+
+              console.log('childImage:', childImage);
 
               if (eleData.type === 'mainImage') {
                 mainImageElement = {
@@ -506,6 +516,7 @@ export async function processDocumentContents(
   let formattedElements = formatElements(orderedElements);
   let mainImage = getMainImage(formattedElements);
 
+  console.log('imageList', imageList);
   return {
     formattedElements: formattedElements,
     mainImage: mainImage,

--- a/lib/tiny_s3.js
+++ b/lib/tiny_s3.js
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk';
 import imageSize from 'image-size';
+import imageType from 'image-type';
 
 export default {
   /*
@@ -18,11 +19,12 @@ export default {
 
     var orgNameSlug = process.env.ORG_SLUG;
 
-    var objectName = 'image' + imageID + '.png'; // TODO use real file ext
+    var objectName = 'image' + imageID;
 
     // get the image data from google first
     let imageData;
     let imageDimensions;
+    let imageExtension;
     let buffer;
     const response = await fetch(contentUri, {
       method: 'GET',
@@ -41,6 +43,7 @@ export default {
           buffer = Buffer.from(buffer);
           params.Body = buffer;
           imageDimensions = imageSize(buffer);
+          imageExtension = imageType(buffer);
           console.log('imageDims:', imageDimensions);
         } catch (e) {
           console.error(
@@ -55,9 +58,13 @@ export default {
       return null;
     }
 
-    let destinationPath = orgNameSlug + '/' + articleSlug + '/' + objectName;
+    let destinationPath = `${orgNameSlug}/${articleSlug}/${objectName}.${imageExtension.ext}`;
     // console.log('GOT IMAGE FROM GOOGLE! ', destinationPath);
     params.Key = destinationPath;
+    params.ContentType = imageExtension.mime;
+    params.ACL = 'public-read';
+
+    console.log('uploading image:', params, imageDimensions);
 
     try {
       // console.log('token:', oauthToken);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "graphql-request": "^2.0.0",
         "gray-matter": "^4.0.3",
         "image-size": "^1.0.1",
+        "image-type": "^4.1.0",
         "journalize": "^2.4.0",
         "js-yaml": "^4.1.0",
         "local-storage-fallback": "^4.1.1",
@@ -9677,6 +9678,14 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -11276,6 +11285,17 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "dependencies": {
+        "file-type": "^10.10.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/import-cwd": {
@@ -34711,6 +34731,11 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-type": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -35941,6 +35966,14 @@
       "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
       "requires": {
         "queue": "6.0.2"
+      }
+    },
+    "image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "requires": {
+        "file-type": "^10.10.0"
       }
     },
     "import-cwd": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "babelMacros": {
     "twin": {
-        "config": "./tailwind.config.js",
-        "preset": "styled-components"
+      "config": "./tailwind.config.js",
+      "preset": "styled-components"
     }
   },
   "lint-staged": {
@@ -84,6 +84,7 @@
     "graphql-request": "^2.0.0",
     "gray-matter": "^4.0.3",
     "image-size": "^1.0.1",
+    "image-type": "^4.1.0",
     "journalize": "^2.4.0",
     "js-yaml": "^4.1.0",
     "local-storage-fallback": "^4.1.1",

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -55,6 +55,25 @@ export default function Donate({
     siteMetadata
   );
 
+  let mainImageNode;
+  let mainImage = null;
+  if (page) {
+    try {
+      mainImageNode = localisedPage?.content.find(
+        (node) => node.type === 'mainImage'
+      );
+
+      if (mainImageNode) {
+        mainImage = mainImageNode.children[0];
+        siteMetadata['coverImage'] = mainImage.imageUrl;
+        siteMetadata['coverImageWidth'] = mainImage.width;
+        siteMetadata['coverImageHeight'] = mainImage.height;
+      }
+    } catch (err) {
+      console.error('error finding main image: ', err);
+    }
+  }
+
   return (
     <Layout locale={locale} meta={siteMetadata} page={page} sections={sections}>
       <SectionContainer>

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -63,6 +63,25 @@ export default function ThankYou({
     siteMetadata
   );
 
+  let mainImageNode;
+  let mainImage = null;
+  if (page) {
+    try {
+      mainImageNode = localisedPage?.content.find(
+        (node) => node.type === 'mainImage'
+      );
+
+      if (mainImageNode) {
+        mainImage = mainImageNode.children[0];
+        siteMetadata['coverImage'] = mainImage.imageUrl;
+        siteMetadata['coverImageWidth'] = mainImage.width;
+        siteMetadata['coverImageHeight'] = mainImage.height;
+      }
+    } catch (err) {
+      console.error('error finding main image: ', err);
+    }
+  }
+
   return (
     <Layout locale={locale} meta={siteMetadata} page={page} sections={sections}>
       <SectionContainer>


### PR DESCRIPTION
Hoo boy. This all started by trying to fix the image type of our uploaded images on S3. It evolved into changing just about everything about how we get images to open graph tags. Lots of changes in here.

1. Introduces `image-type` to determine the image type of an uploaded image. I went with this library instead of just using what's in `image-size` because it also returns the proper MIME type that S3 needs (e.g. `image/jpeg`).
2. Fixes a bug where subsequent publishes of already uploaded images would overwrite dimension data with the dimensions from the Google Doc. This necessitates a change to the `imageList` property on our document. We now store an object for every image with the url, the width and the height.
3. We now set two new Open Graph tags, per Facebook's specifications, `og:image:width` and `og:image:height`. This means Facebook no longer has to process images asynchronously, and there will be an image with the first post of an article to Facebook.
4. To do this predictably, we need to know the width and height of the default social image as well. This uses the same code as the logo dimension setting, but I discovered a bug there. We waited until the image was uploaded to s3 to send the data back to the `parsedData`. We should send this when we read the image in JS.
5. The way we were setting meta tags for static pages did not work for Facebook. We were setting them in `staticMainImage`, which means that we were updating the `meta` tag with the correct data on subsequent renders. Facebook was not grabbing that subsequent render. This PR moves all of the static main image parsing to a pre-rendering step, like we do for articles. Meant duplicating some code unfortunately, but I tested with Facebook's debugger and it all worked as expected.

Things I tested (via ngrok):
- Facebook cards on articles with main images
- Facebook cards on articles without main images (falls back to default social image)
- Facebook cards on static pages with main images
- Facebook cards on static pages without main images
- Facebook cards on about page
- Facebook cards on donate page

This is a boatload of stuff, but I think we're getting all the right data now.