### PR TITLE
Properly set image dimensions on the frontend

### DIFF
--- a/components/articles/ArticleHeader.js
+++ b/components/articles/ArticleHeader.js
@@ -53,6 +53,7 @@ export default function ArticleHeader({
   let postUrl;
   let searchDescription;
   let articleContent;
+  let updatedAt;
 
   if (article && article.category) {
     categoryTitle = hasuraLocalizeText(
@@ -80,6 +81,12 @@ export default function ArticleHeader({
       locale,
       article.article_translations,
       'content'
+    );
+
+    updatedAt = hasuraLocalizeText(
+      locale,
+      article.article_translations,
+      'last_published_at'
     );
   }
 
@@ -129,7 +136,11 @@ export default function ArticleHeader({
           <FeaturedMediaFigure>
             <FeaturedMediaWrapper>
               {mainImage && (
-                <MainImage articleContent={articleContent} isAmp={isAmp} />
+                <MainImage
+                  articleContent={articleContent}
+                  isAmp={isAmp}
+                  updatedAt={updatedAt}
+                />
               )}
             </FeaturedMediaWrapper>
             <FeaturedMediaCaption>

--- a/components/articles/MainImage.js
+++ b/components/articles/MainImage.js
@@ -1,6 +1,7 @@
 import Image from 'next/image';
+import { IMAGE_DIMENSIONS_DATE } from '../../lib/utils';
 
-export default function MainImage({ articleContent, isAmp }) {
+export default function MainImage({ articleContent, isAmp, updatedAt }) {
   const mainImageNode = articleContent.find(
     (node) => node.type === 'mainImage'
   );
@@ -14,12 +15,21 @@ export default function MainImage({ articleContent, isAmp }) {
     console.error('Missing image src:', mainImageNode);
     return null;
   }
+
+  let constrainedImageWidth = 1080;
+
+  console.log(updatedAt);
+  // if we can trust that the image width is correct, then handle smaller images
+  if (Date.parse(updatedAt) > IMAGE_DIMENSIONS_DATE && mainImage.width < 1080) {
+    constrainedImageWidth = mainImage.width;
+  }
+
   return (
     <>
       {mainImage && isAmp && (
         <amp-img
-          width={1080}
-          height={(mainImage.height / mainImage.width) * 1080}
+          width={constrainedImageWidth}
+          height={(mainImage.height / mainImage.width) * constrainedImageWidth}
           src={mainImage.imageUrl}
           alt={mainImage.imageAlt}
           layout="responsive"
@@ -29,8 +39,8 @@ export default function MainImage({ articleContent, isAmp }) {
       {mainImage && !isAmp && (
         <Image
           src={mainImage.imageUrl}
-          width={1080}
-          height={(mainImage.height / mainImage.width) * 1080}
+          width={constrainedImageWidth}
+          height={(mainImage.height / mainImage.width) * constrainedImageWidth}
           alt={mainImage.imageAlt}
           className="image"
           priority={true}

--- a/components/homepage/FeaturedArticleThumbnail.js
+++ b/components/homepage/FeaturedArticleThumbnail.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import tw from 'twin.macro';
+import { IMAGE_DIMENSIONS_DATE } from '../../lib/utils';
 
 const AssetThumbnail = tw.div`overflow-hidden relative w-full mb-4 md:mb-0 md:ml-5 order-2 w-full cursor-pointer`;
 const Figure = tw.figure``;
@@ -24,14 +25,23 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
   if (!mainImage.imageUrl) {
     return <div />;
   }
+  let constrainedImageWidth = 1080;
+  const updatedAt = translation['last_published_at'];
+
+  // if we can trust that the image width is correct, then handle smaller images
+  if (Date.parse(updatedAt) > IMAGE_DIMENSIONS_DATE && mainImage.width < 1080) {
+    constrainedImageWidth = mainImage.width;
+  }
 
   return (
     <Link href={`/articles/${article.category.slug}/${article.slug}`} passHref>
       <AssetThumbnail>
         {isAmp ? (
           <amp-img
-            width={1080}
-            height={(mainImage.height / mainImage.width) * 1080}
+            width={constrainedImageWidth}
+            height={
+              (mainImage.height / mainImage.width) * constrainedImageWidth
+            }
             src={mainImage.imageUrl}
             alt={mainImage.imageAlt}
             layout="responsive"
@@ -40,8 +50,10 @@ export default function FeaturedArticleThumbnail({ article, isAmp }) {
           <Figure key={mainImage.imageUrl}>
             <Image
               src={mainImage.imageUrl}
-              width={1080}
-              height={(mainImage.height / mainImage.width) * 1080}
+              width={constrainedImageWidth}
+              height={
+                (mainImage.height / mainImage.width) * constrainedImageWidth
+              }
               alt={mainImage.imageAlt}
               className="image"
               priority={true}

--- a/components/nodes/ImageNode.js
+++ b/components/nodes/ImageNode.js
@@ -1,10 +1,11 @@
 import Image from 'next/image';
 import tw from 'twin.macro';
+import { IMAGE_DIMENSIONS_DATE } from '../../lib/utils';
 
 const Figure = tw.figure`my-4`;
 const Figcaption = tw.figcaption`text-gray-500 text-sm pt-1`;
 
-export default function ImageNode({ node, amp }) {
+export default function ImageNode({ node, amp, updatedAt }) {
   const image = node.children.find((child) => child.imageUrl);
 
   if (!image) {
@@ -14,10 +15,17 @@ export default function ImageNode({ node, amp }) {
     console.error('Error rendering image due to missing link:', node, image);
     return null;
   }
+  let constrainedImageWidth = 710;
+
+  // if we can trust that the image width is correct, then handle smaller images
+  if (Date.parse(updatedAt) > IMAGE_DIMENSIONS_DATE && image.width < 710) {
+    constrainedImageWidth = image.width;
+  }
+
   const figure = amp ? (
     <amp-img
-      width={710}
-      height={(image.height / image.width) * 710}
+      width={constrainedImageWidth}
+      height={(image.height / image.width) * constrainedImageWidth}
       src={image.imageUrl}
       alt={image.imageAlt}
       layout="responsive"
@@ -27,8 +35,8 @@ export default function ImageNode({ node, amp }) {
       <Image
         src={image.imageUrl}
         alt={image.imageAlt}
-        width={710}
-        height={(image.height / image.width) * 710}
+        width={constrainedImageWidth}
+        height={(image.height / image.width) * constrainedImageWidth}
       />
       <Figcaption>{image.imageAlt}</Figcaption>
     </Figure>

--- a/components/nodes/ImageNodeWordPress.js
+++ b/components/nodes/ImageNodeWordPress.js
@@ -23,6 +23,8 @@ export default function ImageNodeWordPress({ node, translations, locale }) {
   let month = ('0' + (publishedDate.getMonth() + 1)).slice(-2);
   let wordpressImagePath = `/wp-content/uploads/${year}/${month}/${filename}`;
 
+  const constrainedImageWidth = image.width > 710 ? 710 : image.width;
+
   // console.log(image.imageUrl, '->', wordpressImagePath);
 
   const figure = (
@@ -30,8 +32,8 @@ export default function ImageNodeWordPress({ node, translations, locale }) {
       <img
         src={wordpressImagePath}
         alt={image.imageAlt}
-        width={710}
-        height={(image.height / image.width) * 710}
+        width={constrainedImageWidth}
+        height={(image.height / image.width) * constrainedImageWidth}
       />
       <figcaption>{image.imageAlt}</figcaption>
     </figure>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,8 @@ import HorizontalRuleNode from '../components/nodes/HorizontalRuleNode.js';
 const ArticleAuthorLink = tw.a`font-bold cursor-pointer hover:underline`;
 const ArticleAuthorSpan = tw.span`font-bold`;
 
+export const IMAGE_DIMENSIONS_DATE = new Date('02/11/2022 12:00:00 AM');
+
 export function generateArticleUrl(baseUrl, article) {
   let currentUrl = new URL(baseUrl);
   let relativeArticleUrl =
@@ -222,7 +224,7 @@ export const renderBody = (
     );
   };
 
-  const serialize = (node, i) => {
+  const serialize = (node, i, updatedAt) => {
     // console.log(i, renderMainImage, 'node:', node);
     let renderedNode = null;
     switch (node.type) {
@@ -246,13 +248,17 @@ export const renderBody = (
       case 'mainImage':
         if (renderMainImage && !renderedMainImage) {
           // console.log('rendering main image: ', node);
-          renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
+          renderedNode = (
+            <ImageNode node={node} amp={isAmp} key={i} updatedAt={updatedAt} />
+          );
           renderedMainImage = true;
         }
         break;
       case 'image':
         // console.log('image node:', node);
-        renderedNode = <ImageNode node={node} amp={isAmp} key={i} />;
+        renderedNode = (
+          <ImageNode node={node} amp={isAmp} key={i} updatedAt={updatedAt} />
+        );
         break;
       case 'embed':
         renderedNode = <EmbedNode node={node} amp={isAmp} key={i} />;
@@ -309,13 +315,20 @@ export const renderBody = (
   };
 
   let articleContent = hasuraLocalizeText(locale, translations, 'content');
+  const articleUpdatedTime = hasuraLocalizeText(
+    locale,
+    translations,
+    'last_published_at'
+  );
 
   if (
     articleContent &&
     articleContent !== null &&
     typeof articleContent !== 'string'
   ) {
-    return articleContent.map((node, i) => serialize(node, i));
+    return articleContent.map((node, i) =>
+      serialize(node, i, articleUpdatedTime)
+    );
   } else {
     return [];
   }


### PR DESCRIPTION
Now that we're reliably getting the correct image dimensions of uploaded images, we can properly set their dimensions across the application. An easy place to see this is in this [Austin Vida](https://austinvida.tinynewsco.org/articles/cultura/welcomepage) article. She has her logo in the post, which get stretched out and pixelated to fit the width of the article column. With this PR, that is fixed.

However, because old articles don't have the proper dimensions, I had to build a workaround for that stuff. Thus, all our image nodes now also take `updatedAt`, which is the last updated time of the article. I check that against a hardcoded February 11th, which is the date the PR for image dimensions was merged. If the article hasn't been updated since then, we just hardcode things to the width of their container, because otherwise we'd be shrinking everything to unreasonably small sizes based on the bad image dimensions we were getting from Google.

If someone needs to update the images in an old article so they don't stretch, they just have to republish the article and we'll get the proper dimensions and size accordingly.