### PR TITLE
Ensure we're getting the latest article translation on category, tag, author pages

### DIFF
--- a/lib/articles.js
+++ b/lib/articles.js
@@ -706,7 +706,7 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($tag_slug: String!) {
 }`;
 
 const HASURA_CATEGORY_PAGE = `query FrontendCategoryPage($category_slug: String!) {
-  articles(order_by: {article_translations_aggregate: {min: {last_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
+  articles(order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
     article_translations(where: {published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
       custom_byline
       facebook_description

--- a/lib/articles.js
+++ b/lib/articles.js
@@ -665,7 +665,7 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($tag_slug: String!) {
     }
     tag_articles(where: {article: {article_translations: {published: {_eq: true}}}}, order_by: {article: {article_translations_aggregate: {min: {first_published_at: desc}}}}) {
       article {
-        article_translations(where: {}) {
+        article_translations(where: {published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
           custom_byline
           facebook_description
           facebook_title
@@ -706,8 +706,8 @@ const HASURA_TAG_PAGE = `query FrontendTagPage($tag_slug: String!) {
 }`;
 
 const HASURA_CATEGORY_PAGE = `query FrontendCategoryPage($category_slug: String!) {
-  articles(order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
-    article_translations {
+  articles(order_by: {article_translations_aggregate: {min: {last_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, category: {slug: {_eq: $category_slug}}}) {
+    article_translations(where: {published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
       custom_byline
       facebook_description
       facebook_title
@@ -1079,7 +1079,7 @@ const HASURA_GET_ARTICLE_BY_SLUG = `query FrontendGetArticleBySlug($slug: String
 
 const HASURA_AUTHOR_PAGE = `query FrontendAuthorPage($author_slug: String!) {
   articles(order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}, where: {article_translations: {published: {_eq: true}}, author_articles: {author: {slug: {_eq: $author_slug}}}}) {
-    article_translations {
+    article_translations(where: {published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
       custom_byline
       facebook_description
       facebook_title


### PR DESCRIPTION
Closes #1113. We weren't getting the latest article translation properly on category, tag, and author pages in the GraphQL query. I matched the article translations query to match what we do on the homepage.