### PR TITLE
Maintenance mode

### DIFF
--- a/content/maintenance.md
+++ b/content/maintenance.md
@@ -1,0 +1,5 @@
+---
+title: Maintenance Underway
+---
+
+We're down right now for a scheduled maintenance window in order to roll out some improvements to the site. We will be back soon!

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,6 @@
 
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 echo "VERCEL_ENV: $VERCEL_ENV"
-echo "ORG_SLUG: $ORG_SLUG"
 
 # To-do before Vercel Platforms launch: remove this condition
 if [[ "$VERCEL_GIT_COMMIT_REF" == "feature/vercel-platforms" ]] ; then
@@ -23,10 +22,6 @@ elif [[ "$VERCEL_GIT_COMMIT_REF" == "main" && "$VERCEL_ENV" == "preview" ]] ; th
 # Proceed with the build
   echo "✅ - main/preview: build can proceed"
   exit 1;
-
-# elif [[ "$VERCEL_GIT_COMMIT_REF" == "feature/vercel-platforms" ]] ; then
-#   echo "✅ - feature/vercel-platforms: build can proceed in env $VERCEL_ENV"
-#   exit 1;
 
 else
   # Don't build

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,17 @@ require('dotenv').config({ path: '.env.local' });
 
 // to-do: replace d32qj1gowzeibr.cloudfront.net with assets.tinynewsco.dev
 module.exports = {
+  redirects() {
+    return [
+      process.env.MAINTENANCE === '1'
+        ? {
+            source: '/((?!maintenance).*)',
+            destination: '/maintenance',
+            permanent: false,
+          }
+        : null,
+    ].filter(Boolean);
+  },
   images: {
     domains: [
       'tnc-test-upload-bucket.s3.amazonaws.com',

--- a/pages/_sites/[site]/maintenance.js
+++ b/pages/_sites/[site]/maintenance.js
@@ -1,0 +1,107 @@
+import tw from 'twin.macro';
+import { generateAllDomainPaths } from '../../../lib/settings.js';
+import { hasuraGetSiteMetadata } from '../../../lib/site_metadata';
+import Layout from '../../../components/Layout';
+import { getPostBySlug, markdownToHtml } from '../../../lib/markdown';
+import {
+  ArticleTitle,
+  PostTextContainer,
+  PostText,
+} from '../../../components/common/CommonStyles.js';
+
+const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
+
+export default function Maintenance({ siteMetadata, post, content }) {
+  if (!post) {
+    return null;
+  }
+  return (
+    <Layout meta={siteMetadata} sections={{}}>
+      <SectionContainer>
+        <div key="title" className="section post__header">
+          <ArticleTitle meta={siteMetadata}>{post.title}</ArticleTitle>
+        </div>
+        <div className="section post__body rich-text" key="body">
+          <PostText>
+            <PostTextContainer>
+              <div dangerouslySetInnerHTML={{ __html: content }} />
+            </PostTextContainer>
+          </PostText>
+        </div>
+      </SectionContainer>
+      <style jsx global>
+        {`
+          .rich-text p {
+            margin-bottom: 1.25rem;
+            font-size: 1.25rem;
+            line-height: 1.625;
+          }
+          .rich-text a {
+            color: black;
+            cursor: pointer;
+            border-bottom: 1px solid rgb(59, 130, 246);
+          }
+          .rich-text h2 {
+            font-size: 1.875rem;
+            font-weight: bold;
+          }
+        `}
+      </style>
+    </Layout>
+  );
+}
+
+export async function getStaticPaths() {
+  const apiUrl = process.env.HASURA_API_URL;
+  const adminSecret = process.env.HASURA_ADMIN_SECRET;
+
+  const mappedPaths = await generateAllDomainPaths({
+    url: apiUrl,
+    adminSecret: adminSecret,
+    urlParams: { slug: 'maintenance' },
+  });
+
+  return {
+    paths: mappedPaths,
+    fallback: true,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const site = params.site;
+  const locale = 'en-US';
+
+  let siteMetadata = {};
+
+  const { errors, data } = await hasuraGetSiteMetadata({
+    url: apiUrl,
+    site: site,
+    localeCode: locale,
+  });
+  if (errors || !data) {
+    return {
+      notFound: true,
+    };
+    // throw errors;
+  } else {
+    siteMetadata = data.site_metadatas[0].site_metadata_translations[0].data;
+
+    const post = getPostBySlug('maintenance', ['title', 'content']);
+    if (!post) {
+      return {
+        notFound: true,
+      };
+    }
+    const content = await markdownToHtml(post.content || '');
+
+    return {
+      props: {
+        locale,
+        siteMetadata,
+        post,
+        content,
+      },
+    };
+  }
+}


### PR DESCRIPTION
I thought that having the ability to put the sites into maintenance mode would be useful, especially when rolling out the new version of the platform.

* set the MAINTENANCE env var to `1` to turn on
* set it to anything else to turn off (but `0` or `false` would make sense)

Unless... the sites all being statically generated means we don't really need this? What do you think @TylerFisher?