### PR TITLE
useAnalytics tracking ID

### DIFF
--- a/components/LandingPage.js
+++ b/components/LandingPage.js
@@ -44,7 +44,6 @@ export default function LandingPage({
     );
   }
 
-  console.log('site:', site);
   return (
     <Layout
       meta={siteMetadata}

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -1,7 +1,7 @@
 import ReactGA from 'react-ga';
 import storage from 'local-storage-fallback';
 import { getCookieConsentValue } from 'react-cookie-consent';
-import { getQueryVariable } from '../utils.js';
+import { getQueryVariable, getSite } from '../utils.js';
 
 export const trackReadingHistoryWithPageView = (hookObj) => {
   hookObj.logReadingHistory();
@@ -10,6 +10,16 @@ export const trackReadingHistoryWithPageView = (hookObj) => {
   return {
     dimension2: readingHistory,
   };
+};
+
+const trackingIdMapping = {
+  blackbygod: 'UA-166777432-39',
+  harveyworld: 'UA-166777432-38',
+  'austin-vida': 'UA-166777432-43',
+  fivewardsmedia: 'UA-166777432-45',
+  angdiaryo: 'UA-166777432-51',
+  spotlightschools: 'UA-166777432-37',
+  'next-tinynewsdemo': 'UA-166777432-1',
 };
 
 export const initialize = (hookObj) => {
@@ -37,7 +47,7 @@ export const initialize = (hookObj) => {
     }
   }
 
-  init(process.env.NEXT_PUBLIC_GA_TRACKING_ID);
+  init(window.location.host);
   let readingDimensionsData = trackReadingHistoryWithPageView(hookObj);
   let newsletterDimensionsData = trackNewsletterVisits(trackMailChimpParams);
 
@@ -60,9 +70,10 @@ export const initialize = (hookObj) => {
 
 export const useAnalytics = () => {
   return {
-    init: (trackingId) => {
+    init: (host) => {
       if (getCookieConsentValue()) {
-        // console.log('Initialising ReactGA with trackingId:', trackingId);
+        const site = getSite(host);
+        const trackingId = trackingIdMapping[site];
         ReactGA.initialize(trackingId);
       }
     },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -606,3 +606,14 @@ export const parseDonorViews = (queryResult, limit) => {
   });
   return dv;
 };
+
+export const getSite = (host) => {
+  return host
+    .replace(`.localhost:3000`, '')
+    .replace(`.tinynewsco.dev:3000`, '')
+    .replace(`.tinynewsco.org:3000`, '')
+    .replace(`.tinynewsco.dev`, '')
+    .replace(`.tinynewsco.org`, '')
+    .replace(`.vercel.app`, '')
+    .replace(`.vercel.app:3000`, '');
+};

--- a/pages/_sites/[site]/index.js
+++ b/pages/_sites/[site]/index.js
@@ -21,7 +21,6 @@ export default function Home(props) {
     return <CurriculumHomepage {...props} />;
   }
 
-  console.log('props.site:', props.site);
   // console.log('streamArticles:', props.streamArticles);
   const component =
     (props.siteMetadata && props.siteMetadata.landingPage === 'on') ||
@@ -59,7 +58,6 @@ export async function getStaticProps(context) {
     throw new Error('Missing required site param');
   }
 
-  console.log('SITE:', site);
   const apiUrl = process.env.HASURA_API_URL;
 
   const settingsResult = await getOrgSettings({


### PR DESCRIPTION
Closes #1146 

the issue was that this library was relying on an environment variable to determine the tracking ID for Google Analytics. however, I didn't and really couldn't see a way to add an `await getOrgSettings()` in this client side call that's used on every page. 

I thought about it, and since this was a `NEXT_PUBLIC` variable, its value was viewable publicly. It's also not going to change once configured for each org. 

So, I think the best option is to dynamically figure out the `site`, which we can do from the `window.location` that is available here, and look up the tracking ID in a static/harcoded mapping.

This PR updates the init for useAnalytics to determine the current site, using the same logic as found in the middleware, and then find the tracking ID in the mapping variable. 

I tested this on all subdomain localhost sites and saw it grab the right tracking ID for each. I took these values from the settings table in production Hasura.

This means we'll have to deploy in order to configure a new site's tracking ID, but we'll only have to do that once. I felt this was acceptable, but I'm happy to review tomorrow with fresh eyes / hear about a better way, if you think of one @TylerFisher :)

Note: I thought it would be best if both the middleware and useAnalytics lib called a shared function, which I defined in utils as `getSite`, to do the hostname wrangling; however, I ran into a weird error once I tried importing `import { getSite } from '../lib/utils'` in the middleware. I ended up leaving the middleware unchanged, so that means we have a small duplication of code. I'll review this with fresh eyes tomorrow and see if I can figure it out.