### PR TITLE
Updated data importers for the new auth webhook

### DIFF
--- a/.github/workflows/import-data-from-ga-ang-diaryo.yml
+++ b/.github/workflows/import-data-from-ga-ang-diaryo.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_ang-diaryo
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://angdiaryo.org
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: angdiaryo
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 254158738
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/.github/workflows/import-data-from-ga-austin-vida.yml
+++ b/.github/workflows/import-data-from-ga-austin-vida.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_austin-vida
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://www.austinvida.com
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: austin-vida
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 251814724
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/.github/workflows/import-data-from-ga-black-by-god.yml
+++ b/.github/workflows/import-data-from-ga-black-by-god.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_black-by-god
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://blackbygod.org
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: blackbygod
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 251501102
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/.github/workflows/import-data-from-ga-five-wards-media.yml
+++ b/.github/workflows/import-data-from-ga-five-wards-media.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_five-wards-media
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://fivewardsmedia.tinynewsco.org
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: fivewardsmedia
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 253255036
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/.github/workflows/import-data-from-ga-harvey-world-herald.yml
+++ b/.github/workflows/import-data-from-ga-harvey-world-herald.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_harvey-world-herald
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://harveyworld.org
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: harveyworld
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 251252201
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/.github/workflows/import-data-from-ga-spotlight-schools.yml
+++ b/.github/workflows/import-data-from-ga-spotlight-schools.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: data_import_spotlight-schools
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_SITE_URL: https://www.spotlightschools.com
       HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
-      ORG_SLUG: ${{ secrets.ORG_SLUG }}
+      SITE: spotlightschools
       GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
       GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
-      NEXT_PUBLIC_ANALYTICS_VIEW_ID: ${{ secrets.NEXT_PUBLIC_ANALYTICS_VIEW_ID }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: 251032854
       TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
     steps:
       - run: echo "🔎 Running GA data importer"

--- a/script/ga.js
+++ b/script/ga.js
@@ -189,7 +189,7 @@ function storeData(params, rows) {
     require('dotenv').config({ path: '.env.local' });
   }
   const apiUrl = process.env.HASURA_API_URL;
-  const apiToken = process.env.ORG_SLUG;
+  const site = process.env.SITE;
 
   if (params['data'] === 'reading-frequency') {
     let objects = [];
@@ -204,7 +204,7 @@ function storeData(params, rows) {
     shared
       .hasuraInsertReadingFrequency({
         url: apiUrl,
-        orgSlug: apiToken,
+        site: site,
         objects: objects,
       })
       .then((result) => {
@@ -255,7 +255,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertReadingDepth({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           date: cd['date'],
           path: path,
           read_25: read25,
@@ -285,7 +285,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertDonationClick({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           path: shared.sanitizePath(row.dimensions[3]),
           date: row.dimensions[4],
@@ -308,7 +308,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertCustomDimension({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: 0,
           label: 'isDonor',
           dimension: 'dimension4',
@@ -331,7 +331,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertGeoSession({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           region: `${row.dimensions[0]}-${row.dimensions[1]}`,
           count: row.metrics[0].values[0],
           date: row.dimensions[2],
@@ -353,7 +353,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertNewsletterImpression({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           impressions: row.metrics[0].values[0],
           path: shared.sanitizePath(row.dimensions[3]),
           date: row.dimensions[4],
@@ -376,7 +376,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertCustomDimension({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           date: row.dimensions[4],
           label: row.dimensions[3],
@@ -399,7 +399,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertPageView({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           date: row.dimensions[1],
           path: shared.sanitizePath(row.dimensions[0]),
@@ -434,7 +434,7 @@ function storeData(params, rows) {
           shared
             .hasuraInsertArticleSession({
               url: apiUrl,
-              orgSlug: apiToken,
+              site: site,
               count: sessionCount,
               date: sessionDate,
               path: path,
@@ -460,7 +460,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertReferralSession({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           date: row.dimensions[1],
           source: row.dimensions[0],
@@ -483,7 +483,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertSessionDuration({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           seconds: row.metrics[0].values[0],
           date: row.dimensions[0],
         })
@@ -504,7 +504,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertSession({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           date: row.dimensions[0],
         })
@@ -526,7 +526,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertCustomDimension({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           label: 'isSubscriber',
           dimension: 'dimension5',
@@ -550,7 +550,7 @@ function storeData(params, rows) {
       shared
         .hasuraInsertDonorReadingFrequency({
           url: apiUrl,
-          orgSlug: apiToken,
+          site: site,
           count: row.metrics[0].values[0],
           label: row.dimensions[3],
           date: row.dimensions[4],
@@ -579,7 +579,7 @@ async function importDataFromGA(params) {
   }
 
   const apiUrl = process.env.HASURA_API_URL;
-  const apiToken = process.env.ORG_SLUG;
+  const site = process.env.SITE;
 
   let { startDate, endDate } = params;
 
@@ -602,8 +602,6 @@ async function importDataFromGA(params) {
       startDate: startDate,
       endDate: endDate,
       data: params['data'],
-      // viewID: googleAnalyticsViewID,
-      // apiUrl: apiUrl,
       requireDotEnv: params['requireDotEnv'],
     });
   } catch (e) {
@@ -622,7 +620,7 @@ async function importDataFromGA(params) {
 
     shared
       .hasuraInsertDataImport({
-        orgSlug: apiToken,
+        site: site,
         url: apiUrl,
         end_date: endDate,
         start_date: startDate,
@@ -646,7 +644,7 @@ async function importDataFromGA(params) {
     shared
       .hasuraInsertDataImport({
         url: apiUrl,
-        orgSlug: apiToken,
+        site: site,
         end_date: endDate,
         start_date: startDate,
         table_name: params['data'],


### PR DESCRIPTION
closes #1152 

* org-specific public values are now specified in directly in the yml environment section. 
* shared values continue to be pulled from GH secrets; I also made sure these were set as env vars in the tiny-news-sites vercel project as a couple were not there.
* ga.js script now uses `site` instead of `orgSlug` on hasura requests

tested locally for BBG, but the real question is how will these run in the GH actions env.