### PR TITLE
Bugfix/canonical url settings

### DIFF
--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -64,6 +64,7 @@ export default function AboutPage({
       page={page}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <article className="container">
         <SectionContainer>

--- a/components/AboutPage.js
+++ b/components/AboutPage.js
@@ -21,6 +21,7 @@ export default function AboutPage({
   sections,
   siteMetadata,
   monkeypodLink,
+  site,
   isAmp,
 }) {
   const locale = 'en-US';

--- a/components/Article.js
+++ b/components/Article.js
@@ -58,6 +58,7 @@ export default function Article({
       sections={sections}
       renderFooter={renderFooter}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <div className="post">
         <ArticleHeader

--- a/components/Homepage.js
+++ b/components/Homepage.js
@@ -49,6 +49,7 @@ export default function Homepage({
         sections={sections}
         locale={locale}
         monkeypodLink={monkeypodLink}
+        site={site}
       >
         {!selectedLayout && <Placeholder />}
         {selectedLayout.name === 'Big Featured Story' && (

--- a/components/LandingPage.js
+++ b/components/LandingPage.js
@@ -50,6 +50,7 @@ export default function LandingPage({
       sections={sections}
       renderNav={false}
       locale={locale}
+      site={site}
     >
       <Container>
         {logo ? LogoComponent : <Title>{title}</Title>}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -5,6 +5,7 @@ import CookieConsentWrapper from './nav/CookieConsentWrapper.js';
 import { useAmp } from 'next/amp';
 import AmpAnalytics from './amp/AmpAnalytics.js';
 import tw, { styled } from 'twin.macro';
+import { trackingIdMapping } from '../lib/utils';
 
 const Main = tw.main`pt-8 pb-24`;
 const ThemeWrapper = styled.div(({ meta }) => ({
@@ -23,6 +24,7 @@ export default function Layout({
   page,
   sections,
   monkeypodLink,
+  site,
   renderNav = true,
   renderFooter = true,
 }) {
@@ -39,6 +41,8 @@ export default function Layout({
   }
 
   // console.log('Layout locale:', locale);
+
+  const siteUrl = meta['siteUrl'];
 
   const metaValues = {
     canonical: meta['canonicalUrl'] || meta['siteUrl'],
@@ -89,9 +93,7 @@ export default function Layout({
   }
 
   if (page && ['about', 'donate', 'thank-you'].includes(page.slug)) {
-    metaValues[
-      'canonical'
-    ] = `${process.env.NEXT_PUBLIC_SITE_URL}/${page.slug}`;
+    metaValues['canonical'] = `${siteUrl}/${page.slug}`;
   }
 
   let pageTitle = meta['homepageTitle'];
@@ -175,7 +177,8 @@ export default function Layout({
 
   const isAmp = useAmp();
 
-  const trackingId = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
+  const mappingSiteTrackingID = trackingIdMapping();
+  const trackingId = mappingSiteTrackingID[site];
 
   // console.log('Layout: returning page', children);
   return (

--- a/components/StaffPage.js
+++ b/components/StaffPage.js
@@ -15,6 +15,7 @@ export default function StaffPage({
   sections,
   siteMetadata,
   monkeypodLink,
+  site,
   isAmp,
 }) {
   if (!authors) {
@@ -28,6 +29,7 @@ export default function StaffPage({
       meta={siteMetadata}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <article className="container">
         <SectionContainer>

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -13,9 +13,15 @@ import StaticMainImage from '../components/articles/StaticMainImage';
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
-export default function StaticPage({ siteMetadata, sections, page, isAmp }) {
+export default function StaticPage({
+  siteMetadata,
+  sections,
+  page,
+  site,
+  isAmp,
+}) {
   const locale = 'en-US';
-  let baseUrl = process.env.NEXT_PUBLIC_SITE_URL || siteMetadata['siteUrl'];
+  let baseUrl = siteMetadata['siteUrl'];
   // this is used for the canonical link tag in the Layout component
   let canonicalPageUrl = generatePageUrl(baseUrl, page);
   siteMetadata['canonicalUrl'] = canonicalPageUrl;

--- a/components/StaticPage.js
+++ b/components/StaticPage.js
@@ -45,7 +45,7 @@ export default function StaticPage({ siteMetadata, sections, page, isAmp }) {
   }
 
   return (
-    <Layout meta={siteMetadata} page={page} sections={sections}>
+    <Layout meta={siteMetadata} page={page} sections={sections} site={site}>
       <SectionContainer>
         <ArticleTitle meta={siteMetadata} tw="text-center">
           {localisedPage.headline}

--- a/components/articles/MainImage.js
+++ b/components/articles/MainImage.js
@@ -17,8 +17,6 @@ export default function MainImage({ articleContent, isAmp, updatedAt }) {
   }
 
   let constrainedImageWidth = 1080;
-
-  console.log(updatedAt);
   // if we can trust that the image width is correct, then handle smaller images
   if (Date.parse(updatedAt) > IMAGE_DIMENSIONS_DATE && mainImage.width < 1080) {
     constrainedImageWidth = mainImage.width;

--- a/components/nav/AdminNav.js
+++ b/components/nav/AdminNav.js
@@ -30,7 +30,7 @@ export default function NewAdminNav(props) {
     ) {
       setCurrentLayoutName(props.hpData.homepage_layout_schema.name);
     } else if (props.homePageEditor) {
-      console.log('is homepage editor AND missing hp data/schema', props);
+      console.error('is homepage editor AND missing hp data/schema', props);
     }
   }, []);
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -127,7 +127,6 @@ module.exports = (on, config) => {
       if (errors) {
         console.error('errors:', errors);
       }
-      console.log('data:', data);
       return data;
     },
 

--- a/lib/cached.js
+++ b/lib/cached.js
@@ -8,10 +8,10 @@ export async function cachedContents(name, params, cb) {
     const fileContents = fs.readFileSync(cachedFile, 'utf8');
     data = JSON.parse(fileContents);
   } catch (e) {
-    console.error(
-      'failed reading from cache, requesting data from API now:',
-      e
-    );
+    // console.error(
+    //   'failed reading from cache, requesting data from API now:',
+    //   e
+    // );
     data = await cb(params);
   }
   return data;

--- a/lib/document.js
+++ b/lib/document.js
@@ -266,7 +266,7 @@ export async function processDocumentContents(
         }
         // Find existing element with the same list ID
         let listID = element.paragraph.bullet.listId;
-        console.log('listID:', listID, element.paragraph.elements.length);
+        // console.log('listID:', listID, element.paragraph.elements.length);
 
         let findListElement = (element) =>
           element.type === 'list' && element.listId === listID;
@@ -282,10 +282,10 @@ export async function processDocumentContents(
           element.paragraph.elements.forEach((subElement) => {
             let subElementContent = cleanContent(subElement.textRun.content);
             if (!subElementContent) {
-              console.log(
-                'error skipping blank list item',
-                JSON.stringify(subElement)
-              );
+              // console.log(
+              //   'error skipping blank list item',
+              //   JSON.stringify(subElement)
+              // );
               return;
             }
             // append list items to the main list element's children
@@ -429,10 +429,10 @@ export async function processDocumentContents(
               let markup = await getFacebookMarkup(linkUrl);
               eleData.link = linkUrl;
               eleData.html = markup;
-              console.log(
-                'facebook eleData stored with html:',
-                JSON.stringify(eleData)
-              );
+              // console.log(
+              //   'facebook eleData stored with html:',
+              //   JSON.stringify(eleData)
+              // );
               orderedElements.push(eleData);
             } else {
               eleData.link = linkUrl;
@@ -579,7 +579,7 @@ export async function processDocumentContents(
               let imageHeight = null;
               let imageWidth = null;
 
-              console.log('storedImageData', storedImageData);
+              // console.log('storedImageData', storedImageData);
               // check for the new format. if it's the old format, reupload to force getting new data
               if (typeof storedImageData === 'object') {
                 s3Url = storedImageData.url;
@@ -610,11 +610,11 @@ export async function processDocumentContents(
                 !articleSlugMatches ||
                 !assetDomainMatches
               ) {
-                console.log(
-                  'attempting to upload image to s3...',
-                  fullImageData.inlineObjectProperties.embeddedObject
-                    .imageProperties.contentUri
-                );
+                // console.log(
+                //   'attempting to upload image to s3...',
+                //   fullImageData.inlineObjectProperties.embeddedObject
+                //     .imageProperties.contentUri
+                // );
 
                 const data = await TinyS3.upload(
                   oauthToken,
@@ -656,7 +656,7 @@ export async function processDocumentContents(
                 ),
               };
 
-              console.log('childImage:', childImage);
+              // console.log('childImage:', childImage);
 
               if (eleData.type === 'mainImage') {
                 mainImageElement = {
@@ -1446,7 +1446,7 @@ const HASURA_UNPUBLISH_ARTICLE = `mutation FrontendUnpublishArticle($article_id:
 }`;
 
 export async function unpublishArticle(params) {
-  console.log('unpublishArticle params:', params);
+  // console.log('unpublishArticle params:', params);
   return fetchGraphQL({
     url: params['url'],
     site: params['site'],
@@ -1466,7 +1466,7 @@ const HASURA_UNPUBLISH_PAGE = `mutation FrontendUnpublishPage($page_id: Int!, $l
 }`;
 
 export async function unpublishPage(params) {
-  console.log('unpublishPage params:', params);
+  // console.log('unpublishPage params:', params);
   return fetchGraphQL({
     url: params['url'],
     site: params['site'],

--- a/lib/hooks/useAnalytics.js
+++ b/lib/hooks/useAnalytics.js
@@ -1,7 +1,7 @@
 import ReactGA from 'react-ga';
 import storage from 'local-storage-fallback';
 import { getCookieConsentValue } from 'react-cookie-consent';
-import { getQueryVariable, getSite } from '../utils.js';
+import { getQueryVariable, getSite, trackingIdMapping } from '../utils.js';
 
 export const trackReadingHistoryWithPageView = (hookObj) => {
   hookObj.logReadingHistory();
@@ -10,16 +10,6 @@ export const trackReadingHistoryWithPageView = (hookObj) => {
   return {
     dimension2: readingHistory,
   };
-};
-
-const trackingIdMapping = {
-  'blackbygod.org': 'UA-166777432-39',
-  'harveyworld.org': 'UA-166777432-38',
-  'www.austinvida.com': 'UA-166777432-43',
-  fivewardsmedia: 'UA-166777432-45',
-  'angdiaryo.org': 'UA-166777432-51',
-  'www.spotlightschools.com': 'UA-166777432-37',
-  'next-tinynewsdemo': 'UA-166777432-1',
 };
 
 export const initialize = (hookObj) => {
@@ -73,8 +63,8 @@ export const useAnalytics = () => {
     init: (host) => {
       if (getCookieConsentValue()) {
         const site = getSite(host);
-        const trackingId = trackingIdMapping[site];
-        console.log(site, trackingId);
+        const mappingSiteTrackingID = trackingIdMapping();
+        const trackingId = mappingSiteTrackingID[site];
         ReactGA.initialize(trackingId);
       }
     },

--- a/lib/tiny_s3.js
+++ b/lib/tiny_s3.js
@@ -35,7 +35,7 @@ export default {
     const AWS_BUCKET = findSetting(settings, 'TNC_AWS_BUCKET_NAME');
 
     const assetsDomain = process.env.NEXT_PUBLIC_ASSETS_DOMAIN;
-    console.log('TINYS3 Assets Domain:', assetsDomain, AWS_BUCKET);
+    // console.log('TINYS3 Assets Domain:', assetsDomain, AWS_BUCKET);
 
     const s3 = new AWS.S3({
       accessKeyId: AWS_ACCESS_KEY_ID,
@@ -87,20 +87,20 @@ export default {
     params.ContentType = imageExtension.mime;
     params.ACL = 'public-read';
 
-    console.log('uploading image:', params, imageDimensions);
+    // console.log('uploading image:', params, imageDimensions);
 
     const imageS3Url = `https://${assetsDomain}/${destinationPath}`;
 
     try {
       // console.log('token:', oauthToken);
       const data = await s3.upload(params).promise();
-      console.log('uploadImage const data:', data);
+      // console.log('uploadImage const data:', data);
       let imageData = {
         s3Url: imageS3Url,
         height: imageDimensions.height,
         width: imageDimensions.width,
       };
-      console.log('uploaded data:', imageData);
+      // console.log('uploaded data:', imageData);
       return imageData;
     } catch (err) {
       console.error('Error uploading to S3:', err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -617,3 +617,15 @@ export const getSite = (host) => {
     .replace(`.vercel.app`, '')
     .replace(`.vercel.app:3000`, '');
 };
+
+export const trackingIdMapping = () => {
+  return {
+    'blackbygod.org': 'UA-166777432-39',
+    'harveyworld.org': 'UA-166777432-38',
+    'www.austinvida.com': 'UA-166777432-43',
+    fivewardsmedia: 'UA-166777432-45',
+    'angdiaryo.org': 'UA-166777432-51',
+    'www.spotlightschools.com': 'UA-166777432-37',
+    'next-tinynewsdemo': 'UA-166777432-1',
+  };
+};

--- a/pages/_sites/[site]/404.js
+++ b/pages/_sites/[site]/404.js
@@ -2,9 +2,7 @@
 import Layout from '../../../components/Layout';
 import { hasuraGetLayout, generateAllDomainPaths } from '../../../lib/settings';
 
-export default function Custom404({ sections, siteMetadata }) {
-  const locale = 'en-US';
-
+export default function Custom404({ sections, siteMetadata, site }) {
   let title;
   if (siteMetadata && siteMetadata.title404) {
     title = siteMetadata.title404;
@@ -21,7 +19,7 @@ export default function Custom404({ sections, siteMetadata }) {
   }
 
   return (
-    <Layout meta={siteMetadata} sections={sections}>
+    <Layout meta={siteMetadata} sections={sections} site={site}>
       <div className="post">
         <article className="container">
           <section key="title" className="section post__header">
@@ -90,6 +88,7 @@ export async function getStaticProps({ params }) {
     props: {
       sections,
       siteMetadata,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/about.js
+++ b/pages/_sites/[site]/about.js
@@ -39,7 +39,6 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params }) {
   const apiUrl = process.env.HASURA_API_URL;
   const site = params.site;
-  const locale = 'en-US';
 
   const settingsResult = await getOrgSettings({
     url: apiUrl,
@@ -70,8 +69,6 @@ export async function getStaticProps({ params }) {
     // throw errors;
   } else {
     if (!data.page_slug_versions || !data.page_slug_versions[0]) {
-      console.error('About: returning 404, !data.page_slug_versions', data);
-
       return {
         notFound: true,
       };
@@ -92,6 +89,7 @@ export async function getStaticProps({ params }) {
       sections,
       siteMetadata,
       monkeypodLink,
+      site,
     },
     revalidate: 1,
   };

--- a/pages/_sites/[site]/articles/archive/[pageNumber].js
+++ b/pages/_sites/[site]/articles/archive/[pageNumber].js
@@ -31,6 +31,7 @@ export default function ArticlesArchivePage({
   siteMetadata,
   expandedAds,
   monkeypodLink,
+  site,
 }) {
   const [pageNumbers, setPageNumbers] = useState(range(totalPageCount, 1));
 
@@ -76,6 +77,7 @@ export default function ArticlesArchivePage({
       meta={siteMetadata}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <ArticleStream
         sections={sections}
@@ -207,6 +209,7 @@ export async function getStaticProps(context) {
       siteMetadata,
       expandedAds,
       monkeypodLink,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/authors/[slug].js
+++ b/pages/_sites/[site]/authors/[slug].js
@@ -23,6 +23,7 @@ export default function AuthorPage({
   siteMetadata,
   expandedAds,
   monkeypodLink,
+  site,
 }) {
   const router = useRouter();
   const isAmp = false;
@@ -70,6 +71,7 @@ export default function AuthorPage({
       meta={siteMetadata}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <ProfileHeaderDiv>
         {authorPhoto && <ProfileImage src={authorPhoto}></ProfileImage>}
@@ -201,6 +203,7 @@ export async function getStaticProps({ params }) {
       siteMetadata,
       expandedAds,
       monkeypodLink,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/categories/[category].js
+++ b/pages/_sites/[site]/categories/[category].js
@@ -47,6 +47,7 @@ export default function CategoryPage(props) {
       sections={props.sections}
       renderFooter={props.renderFooter}
       monkeypodLink={props.monkeypodLink}
+      site={props.site}
     >
       <ArticleStream
         articles={props.articles}
@@ -167,6 +168,7 @@ export async function getStaticProps({ params }) {
       expandedAds,
       renderFooter,
       monkeypodLink,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/cookies.js
+++ b/pages/_sites/[site]/cookies.js
@@ -11,12 +11,12 @@ import {
 
 const SectionContainer = tw.div`flex flex-col flex-nowrap items-center px-5 mx-auto max-w-7xl w-full`;
 
-export default function Cookies({ siteMetadata, post, content }) {
+export default function Cookies({ siteMetadata, post, content, site }) {
   if (!post) {
     return null;
   }
   return (
-    <Layout meta={siteMetadata} sections={{}}>
+    <Layout meta={siteMetadata} sections={{}} site={site}>
       <SectionContainer>
         <div key="title" className="section post__header">
           <ArticleTitle meta={siteMetadata}>{post.title}</ArticleTitle>
@@ -101,6 +101,7 @@ export async function getStaticProps({ params }) {
         siteMetadata,
         post,
         content,
+        site,
       },
     };
   }

--- a/pages/_sites/[site]/donate.js
+++ b/pages/_sites/[site]/donate.js
@@ -28,6 +28,7 @@ export default function Donate({
   sections,
   siteMetadata,
   monkeypodLink,
+  site,
 }) {
   const isAmp = false;
   const router = useRouter();
@@ -76,6 +77,7 @@ export default function Donate({
       page={page}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <SectionContainer>
         <article className="container">
@@ -175,6 +177,7 @@ export async function getStaticProps({ params }) {
       sections,
       siteMetadata,
       monkeypodLink,
+      site,
     },
     revalidate: 1,
   };

--- a/pages/_sites/[site]/newsletters/[slug].js
+++ b/pages/_sites/[site]/newsletters/[slug].js
@@ -50,6 +50,7 @@ export default function NewsletterEditionPage(props) {
       meta={props.siteMetadata}
       sections={props.sections}
       renderFooter={props.renderFooter}
+      site={props.site}
     >
       <SectionContainer>
         <ArticleTitle meta={props.siteMetadata} tw="text-center">
@@ -161,6 +162,7 @@ export async function getStaticProps({ params }) {
       expandedAds,
       renderFooter,
       settings,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/newsletters/index.js
+++ b/pages/_sites/[site]/newsletters/index.js
@@ -19,6 +19,7 @@ export default function NewsletterIndexPage(props) {
       meta={props.siteMetadata}
       sections={props.sections}
       renderFooter={props.renderFooter}
+      site={props.site}
     >
       <ArticleStream
         sections={props.sections}
@@ -122,6 +123,7 @@ export async function getStaticProps({ params }) {
       sections,
       siteMetadata,
       expandedAds,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/preview/donate.js
+++ b/pages/_sites/[site]/preview/donate.js
@@ -20,7 +20,7 @@ const WideContainer = styled.div(() => ({
   maxWidth: '1280px',
 }));
 
-export default function Donate({ page, sections, siteMetadata }) {
+export default function Donate({ page, sections, siteMetadata, site }) {
   const isAmp = false;
   const router = useRouter();
 
@@ -43,7 +43,7 @@ export default function Donate({ page, sections, siteMetadata }) {
   );
 
   return (
-    <Layout meta={siteMetadata} page={page} sections={sections}>
+    <Layout meta={siteMetadata} page={page} sections={sections} site={site}>
       <SectionContainer>
         <article className="container">
           <ArticleTitle meta={siteMetadata} tw="text-center">
@@ -135,6 +135,7 @@ export async function getStaticProps(context) {
       page,
       sections,
       siteMetadata,
+      site,
     },
     revalidate: 1,
   };

--- a/pages/_sites/[site]/preview/thank-you.js
+++ b/pages/_sites/[site]/preview/thank-you.js
@@ -53,7 +53,7 @@ export default function ThankYou({ referrer, page, sections, siteMetadata }) {
   );
 
   return (
-    <Layout meta={siteMetadata} page={page} sections={sections}>
+    <Layout meta={siteMetadata} page={page} sections={sections} site={site}>
       <SectionContainer>
         <ArticleTitle meta={siteMetadata} tw="text-center">
           {localisedPage.headline}
@@ -81,7 +81,7 @@ export async function getServerSideProps(context) {
   }
 
   const apiUrl = process.env.HASURA_API_URL;
-  const apiToken = process.env.ORG_SLUG;
+  const site = context.params.site;
 
   const referrer = context.req.headers['referer'];
 
@@ -91,7 +91,7 @@ export async function getServerSideProps(context) {
 
   const { errors, data } = await hasuraGetPage({
     url: apiUrl,
-    orgSlug: apiToken,
+    site: site,
     slug: 'thank-you',
   });
   if (errors || !data) {
@@ -120,6 +120,7 @@ export async function getServerSideProps(context) {
       page,
       sections,
       siteMetadata,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/sitemap.xml.js
+++ b/pages/_sites/[site]/sitemap.xml.js
@@ -47,7 +47,7 @@ function generateSiteMap(data) {
         const publicationDate =
           article.article_translations[0].first_published_at;
 
-        console.log(lastmod);
+        // console.log(lastmod);
 
         return `<url>
         <loc>${siteURL}/articles/${category}/${slug}</loc>
@@ -129,9 +129,9 @@ export async function getServerSideProps(context) {
 
   const siteURL =
     response.data.site_metadatas[0].site_metadata_translations[0].data.siteUrl;
-  console.log(
-    response.data.site_metadatas[0].site_metadata_translations[0].data.siteUrl
-  );
+  // console.log(
+  //   response.data.site_metadatas[0].site_metadata_translations[0].data.siteUrl
+  // );
 
   // We generate the XML sitemap with the posts data
   const sitemap = generateSiteMap(response.data);

--- a/pages/_sites/[site]/staff.js
+++ b/pages/_sites/[site]/staff.js
@@ -78,6 +78,7 @@ export async function getStaticProps({ params }) {
       sections,
       siteMetadata,
       monkeypodLink,
+      site,
     },
     revalidate: 1,
   };

--- a/pages/_sites/[site]/static/[slug].js
+++ b/pages/_sites/[site]/static/[slug].js
@@ -6,7 +6,7 @@ import {
 } from '../../../../lib/pages.js';
 import StaticPage from '../../../../components/StaticPage';
 
-export default function Static({ page, sections, siteMetadata }) {
+export default function Static({ page, sections, siteMetadata, site }) {
   const router = useRouter();
   const isAmp = false;
 
@@ -25,6 +25,7 @@ export default function Static({ page, sections, siteMetadata }) {
         page={page}
         sections={sections}
         siteMetadata={siteMetadata}
+        site={site}
       />
     </>
   );
@@ -90,6 +91,7 @@ export async function getStaticProps({ params }) {
       page,
       sections,
       siteMetadata,
+      site,
     },
     revalidate: 1,
   };

--- a/pages/_sites/[site]/static/[slug].js
+++ b/pages/_sites/[site]/static/[slug].js
@@ -7,7 +7,6 @@ import {
 import StaticPage from '../../../../components/StaticPage';
 
 export default function Static({ page, sections, siteMetadata, site }) {
-  console.log('<Static> site:', site);
   const router = useRouter();
   const isAmp = false;
 

--- a/pages/_sites/[site]/static/[slug].js
+++ b/pages/_sites/[site]/static/[slug].js
@@ -7,6 +7,7 @@ import {
 import StaticPage from '../../../../components/StaticPage';
 
 export default function Static({ page, sections, siteMetadata, site }) {
+  console.log('<Static> site:', site);
   const router = useRouter();
   const isAmp = false;
 

--- a/pages/_sites/[site]/tags/[slug].js
+++ b/pages/_sites/[site]/tags/[slug].js
@@ -20,6 +20,7 @@ export default function TagPage({
   siteMetadata,
   expandedAds,
   monkeypodLink,
+  site,
 }) {
   const router = useRouter();
   const isAmp = false;
@@ -40,6 +41,7 @@ export default function TagPage({
       meta={siteMetadata}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <ArticleStream
         articles={articles}
@@ -147,6 +149,7 @@ export async function getStaticProps({ params }) {
       siteMetadata,
       ads,
       monkeypodLink,
+      site,
     },
   };
 }

--- a/pages/_sites/[site]/thank-you.js
+++ b/pages/_sites/[site]/thank-you.js
@@ -83,6 +83,7 @@ export default function ThankYou({
       page={page}
       sections={sections}
       monkeypodLink={monkeypodLink}
+      site={site}
     >
       <SectionContainer>
         <ArticleTitle meta={siteMetadata} tw="text-center">

--- a/pages/_sites/[site]/tinycms/analytics/dashboard.js
+++ b/pages/_sites/[site]/tinycms/analytics/dashboard.js
@@ -121,14 +121,13 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;
   const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
 
   const host = context.req.headers.host; // will give you localhost:3000
-  console.log('host:', host);
 
   return {
     props: {

--- a/pages/_sites/[site]/tinycms/analytics/donations.js
+++ b/pages/_sites/[site]/tinycms/analytics/donations.js
@@ -101,14 +101,13 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;
   const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
 
   const host = context.req.headers.host; // will give you localhost:3000
-  console.log('host:', host);
 
   return {
     props: {

--- a/pages/_sites/[site]/tinycms/analytics/index.js
+++ b/pages/_sites/[site]/tinycms/analytics/index.js
@@ -167,14 +167,14 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;
   const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
 
   const host = context.req.headers.host; // will give you localhost:3000
-  console.log('host:', host);
+
   return {
     props: {
       apiUrl: apiUrl,

--- a/pages/_sites/[site]/tinycms/analytics/newsletter.js
+++ b/pages/_sites/[site]/tinycms/analytics/newsletter.js
@@ -101,14 +101,14 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;
   const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
 
   const host = context.req.headers.host; // will give you localhost:3000
-  console.log('host:', host);
+
   return {
     props: {
       apiUrl,

--- a/pages/_sites/[site]/tinycms/analytics/pageviews.js
+++ b/pages/_sites/[site]/tinycms/analytics/pageviews.js
@@ -118,7 +118,7 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;

--- a/pages/_sites/[site]/tinycms/analytics/sessions.js
+++ b/pages/_sites/[site]/tinycms/analytics/sessions.js
@@ -128,7 +128,7 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   const settings = settingsResult.data.settings;

--- a/pages/_sites/[site]/tinycms/authors/[id].js
+++ b/pages/_sites/[site]/tinycms/authors/[id].js
@@ -280,7 +280,7 @@ export async function getServerSideProps(context) {
   });
 
   if (settingsResult.errors) {
-    console.log('error:', settingsResult);
+    console.error('error:', settingsResult);
     throw settingsResult.errors;
   }
   let settings = settingsResult.data.settings;


### PR DESCRIPTION
Closes #1147 

* lots of console.log cleanup
* also commented out the console.error on missing ads.json - it makes it hard to find real errors in the builds
* layout now pulls the base URL for constructing canonical URLs from the site info settings (tinycms) on special static pages
* tracking ids for GA also now using map for sites, shared with useAnalytics