### PR TITLE
bugfix: encode article headlines to prevent xml parsing errors in sitemap

### DIFF
--- a/pages/_sites/[site]/sitemap.xml.js
+++ b/pages/_sites/[site]/sitemap.xml.js
@@ -1,5 +1,23 @@
 import { hasuraGetSiteData } from '../../../script/shared.js';
 
+// Function from https://stackoverflow.com/a/27979933
+function escapeXml(unsafe) {
+  return unsafe.replace(/[<>&'"]/g, function (c) {
+    switch (c) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+    }
+  });
+}
+
 function generateSiteMap(data) {
   const siteURL =
     data.site_metadatas[0].site_metadata_translations[0].data.siteUrl;
@@ -44,6 +62,7 @@ function generateSiteMap(data) {
         const slug = article.slug;
         const lastmod = article.article_translations[0].last_published_at;
         const headline = article.article_translations[0].headline;
+        const encodedHeadline = escapeXml(headline);
         const publicationDate =
           article.article_translations[0].first_published_at;
 
@@ -60,7 +79,7 @@ function generateSiteMap(data) {
             <news:language>en</news:language>
           </news:publication>
           <news:publication_date>${publicationDate}</news:publication_date>
-          <news:title>${headline}</news:title>
+          <news:title>${encodedHeadline}</news:title>
         </news:news>
       </url>`;
       })}


### PR DESCRIPTION
Closes #1157