### PR TITLE
fix for fb embeds

### DIFF
--- a/components/nodes/embeds/Facebook.js
+++ b/components/nodes/embeds/Facebook.js
@@ -7,17 +7,14 @@ export default function Facebook({ node }) {
   useEffect(() => {
     if (node.html) {
       setMarkup(node.html);
-      // console.log('Set markup to the node.html:', node.html);
-    } else {
-      console.error('No markup found for the facebook embed...', node);
     }
-  }, [node.link]);
+  }, []);
 
   return (
     <div>
       <Script
-        src="https://connect.facebook.net/en_US/sdk.js"
-        strategy="lazyOnload"
+        src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"
+        strategy="afterInteractive"
       />
       <div dangerouslySetInnerHTML={{ __html: markup }} />
     </div>


### PR DESCRIPTION
* the sdk url seems to require hash/query params - found these [in facebook developer docs](https://developers.facebook.com/docs/plugins/embedded-posts) 
* i also updated strategy to use the default, while trying to make the sdk load

Note: our platform handles Facebook embeds slightly differently than other embeds - when you publish the article, we make a request to FB for any embedded content and store the html in our database. We do this live, basically, for every other platform; FB's API has far more restrictive rules that prevent us from doing this though.

You can see the regex for which domains in a link in the Google Doc for an article will trigger embed-handling [on line 404 of the document lib](https://github.com/news-catalyst/next-tinynewsdemo/blob/main/lib/document.js#L404). The special handling of Facebook links [happens a few lines later](https://github.com/news-catalyst/next-tinynewsdemo/blob/main/lib/document.js#L427-L436). Finally, the actual rendering of the Facebook embed is found in [the Facebook embed component](https://github.com/news-catalyst/next-tinynewsdemo/blob/main/components/nodes/embeds/Facebook.js).