### PR TITLE
instagram reel embed support

### DIFF
--- a/components/nodes/EmbedNode.js
+++ b/components/nodes/EmbedNode.js
@@ -49,7 +49,11 @@ export default function EmbedNode({ node, amp }) {
       el = <Facebook node={node} amp={amp} />;
       break;
     case 'instagram.com':
-      el = <Instagram node={node} amp={amp} />;
+      if (url.pathname.match(/^\/reel/)) {
+        el = <Facebook node={node} amp={amp} />;
+      } else {
+        el = <Instagram node={node} amp={amp} />;
+      }
       break;
     case 'open.spotify.com':
       el = <Spotify node={node} amp={amp} />;

--- a/lib/document.js
+++ b/lib/document.js
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch';
 import { fetchGraphQL, slugify } from './graphql';
-import { getFacebookMarkup } from './embeds';
+import { getFacebookMarkup, getInstagramReelMarkup } from './embeds';
 import TinyS3 from './tiny_s3';
 
 const HASURA_LOOKUP_GOOGLE_DOC = `query ApiLookupGoogleDoc($document_id: String!) {
@@ -427,6 +427,17 @@ export async function processDocumentContents(
               // special case to grab the html from Facebook as doing this in the Embed node is ridiculous/doesn't work
             } else if (/facebook\.com/.test(linkUrl)) {
               let markup = await getFacebookMarkup(linkUrl);
+              eleData.link = linkUrl;
+              eleData.html = markup;
+              // console.log(
+              //   'facebook eleData stored with html:',
+              //   JSON.stringify(eleData)
+              // );
+              orderedElements.push(eleData);
+
+              // special case to grab the html from Instagram for Reels
+            } else if (/instagram\.com\/reel/.test(linkUrl)) {
+              let markup = await getInstagramReelMarkup(linkUrl);
               eleData.link = linkUrl;
               eleData.html = markup;
               // console.log(

--- a/lib/embeds.js
+++ b/lib/embeds.js
@@ -34,3 +34,19 @@ export async function getFacebookMarkup(link) {
   // console.log('returning html:', data.html);
   return data.html;
 }
+
+export async function getInstagramReelMarkup(link) {
+  let fbApiUrl = `https://graph.facebook.com/v13.0/instagram_oembed?omitscript=true&url=${link}`;
+  const fbAccessToken = `${FB_APP_ID}|${FB_CLIENT_TOKEN}`;
+
+  const res = await fetch(fbApiUrl, {
+    headers: {
+      Authorization: `Bearer ${fbAccessToken}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'GET',
+  });
+
+  const data = await res.json();
+  return data.html;
+}


### PR DESCRIPTION
Closes #1169 

This adds support for IG Reels, which afaict, no open source IG embed tool currently supports. Definitely not the one we're using for regular IG posts. 

This PR has the following changes:

* publishing a doc with an IG Reel link (regex: `/instagram\.com\/reel/`) triggers a request to Facebook's [instagram oembed endpoint](https://developers.facebook.com/docs/graph-api/reference/instagram-oembed/) for the Reel's markup - this is almost exactly how we handle embeds for FB posts and videos
* displaying the published article with an IG Reel link reuses the rather generic "Facebook" embed component to render the markup along with the sdk.js (which handles styling)

To test, I added an IG reel link to the [Social Embeds Test](https://docs.google.com/document/d/1t9Zsm2uFHHmozUz4BRVKUKyv1Ao-qn3Cz-_GIMb2UgU/edit) document, pointed the sidebar at my localhost version of the API under development using [an ngrok-supplied URL](https://ngrok.com/), published the article, then viewed it on my localhost version of the front-end site running this PR code.

