### PR TITLE
bugfix: use date from GA dimensions; startDate not defined

### DIFF
--- a/script/ga.js
+++ b/script/ga.js
@@ -306,7 +306,7 @@ function storeData(params, rows) {
           count: 0,
           label: 'isDonor',
           dimension: 'dimension4',
-          date: startDate,
+          date: row.dimensions[1],
         })
         .then((result) => {
           console.log('hasura insert result:', result);


### PR DESCRIPTION
Closes #1180 

Not sure how this error hasn't been triggered earlier, but the insert of "donor" analytics from GA was failing because it was trying to use a var that's not defined (`startDate`) instead of doing what all the other inserts do, which is use the date from the GA `dimensions` data as requested.

This PR is a straightforward fix.