### PR TITLE
Only build and deploy stable branch in production

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-# Don't build anything!
-echo "🛑 - Build cancelled in env '$VERCEL_ENV' on branch '$VERCEL_GIT_COMMIT_REF'"
-exit 0;
+# Only build the stable branch
+if [[ "$VERCEL_GIT_COMMIT_REF" == "stable" ]] ; then
+  # Proceed with the build
+  echo "✅ - Stable build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Preview builds not supported"
+  exit 0;
+fi


### PR DESCRIPTION
Closes #1149 

This updates the deploy script so that only the stable branch will be deployed. Once this PR is merged, we'll need to update [the "Ignore Build Step" Git setting in Vercel](https://vercel.com/news-catalyst/tiny-news-sites/settings/git) to have the value `bash deploy.sh`.

This closes the linked issue only in part, really - the other part of satisfying that issue is creating a staging project in Vercel.