### PR TITLE
Bugfixes for sessions page in tinycms analytics

### DIFF
--- a/components/tinycms/analytics/DailySessions.js
+++ b/components/tinycms/analytics/DailySessions.js
@@ -54,7 +54,7 @@ const DailySessions = (props) => {
         dailyRef.current.scrollIntoView({ behavior: 'smooth' });
       }
     }
-  }, [props.startDate, props.endDate, chartData, props.site, props.apiUrl]);
+  }, [props.startDate, props.endDate]);
 
   return (
     <>

--- a/components/tinycms/analytics/GeoSessions.js
+++ b/components/tinycms/analytics/GeoSessions.js
@@ -22,7 +22,6 @@ const GeoSessions = (props) => {
     };
 
     const fetchGeoSessions = async () => {
-      console.log('this is firing');
       const { errors, data } = await hasuraGetGeoSessions(sessionParams);
 
       if (errors && !data) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -65,7 +65,7 @@ export async function hasuraGetGeoSessions(params) {
 }
 
 const HASURA_GET_SESSIONS = `query FrontendGetSessions($startDate: date!, $endDate: date!) {
-  ga_sessions(order_by: {date: asc, count: desc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
+  ga_sessions(order_by: {date: asc}, where: {date: {_gte: $startDate, _lte: $endDate}}) {
     count
     date
   }


### PR DESCRIPTION
Closes #1192
Closes #1193

1. the graphql query was trying to sort the daily session stats by both date and session count; corrected to sort only by date, which fixes the chart x axis.
2. that page's useEffect had a silly collection of triggers defined that resulted in it being fired over and over; fixed to figure only on start/end date change