### PR TITLE
Updated new organization onboarding / bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Releases
 
+- [0.3.0](https://github.com/news-catalyst/next-tinynewsdemo/issues/1204): newsletter archives, custom signup message, bugfixes for publish dates and analytics sessions chart
 - [0.2.1](https://github.com/news-catalyst/next-tinynewsdemo/issues/1209): next-seo adjustments PR #1201
 - [0.2.0](https://github.com/news-catalyst/next-tinynewsdemo/issues/1187): improvements to SEO and tinycms security
 - 0.1.1 hotfix: deploy only stable branch

--- a/components/common/CommonStyles.js
+++ b/components/common/CommonStyles.js
@@ -26,5 +26,6 @@ export const SectionContainer = tw.div`md:grid md:grid-cols-packageLayoutTablet 
 export const Block = tw.div`w-full`;
 export const AddButton = tw.a`hidden md:flex w-full md:w-auto px-4 py-2 text-right bg-blue-900 hover:bg-blue-500 text-white md:rounded`;
 export const DeleteButton = tw.button`bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded`;
+export const PlainButton = tw.button`px-4 py-2 text-right bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded`;
 
 export const HorizontalRule = tw.hr`border-0 bg-gray-500 text-gray-500 h-px max-w-full my-8`;

--- a/components/tinycms/TinyFormElements.js
+++ b/components/tinycms/TinyFormElements.js
@@ -120,7 +120,7 @@ TinyYesNoField.displayName = 'TinyYesNoField';
 export const TinyTextArea = ({ name, label, value, onChange, ...props }) => {
   return (
     <label htmlFor="bio">
-      <span tw="block font-medium text-gray-700">{label}</span>
+      <span tw="block font-bold">{label}</span>
       <TextArea
         tw="mt-1 block w-full"
         rows="3"

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,5 +1,25 @@
 import { fetchGraphQL } from './graphql';
 
+const LIST_ORGANIZATIONS = `query FrontendAdminListOrganizations {
+  organizations(order_by: {name: asc}) {
+    created_at
+    id
+    name
+    slug
+    customDomain
+    subdomain
+  }
+}`;
+
+export async function getOrganizations(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    adminSecret: process.env.HASURA_ADMIN_SECRET,
+    query: LIST_ORGANIZATIONS,
+    name: 'FrontendAdminListOrganizations',
+  });
+}
+
 const LIST_SETTINGS = `query FrontendGetOrgSettings {
   settings {
     name
@@ -19,6 +39,27 @@ export async function getOrgSettings(params) {
     site: params['site'],
     query: LIST_SETTINGS,
     name: 'FrontendGetOrgSettings',
+  });
+}
+
+const INSERT_SETTINGS = `mutation FrontendInsertSettings($objects: [settings_insert_input!] = {}) {
+  insert_settings(objects: $objects, on_conflict: {constraint: settings_organization_id_name_key, update_columns: value}) {
+    returning {
+      id
+      name
+      organization_id
+      value
+    }
+  }
+}`;
+
+export async function insertSettings(params) {
+  return fetchGraphQL({
+    url: params['url'],
+    site: params['site'],
+    query: INSERT_SETTINGS,
+    name: 'FrontendInsertSettings',
+    variables: { objects: params['settings'] },
   });
 }
 

--- a/pages/_sites/[site]/tinycms/admin/[subdomain].js
+++ b/pages/_sites/[site]/tinycms/admin/[subdomain].js
@@ -1,0 +1,947 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import tw, { styled } from 'twin.macro';
+import {
+  findSetting,
+  getOrgSettings,
+  insertSettings,
+} from '../../../../../lib/settings.js';
+import AdminLayout from '../../../../../components/AdminLayout.js';
+import AdminNav from '../../../../../components/nav/AdminNav';
+import {
+  TinyInputField,
+  TinyTextArea,
+} from '../../../../../components/tinycms/TinyFormElements';
+
+import Notification from '../../../../../components/tinycms/Notification';
+import {
+  AddButton,
+  PlainButton,
+} from '../../../../../components/common/CommonStyles.js';
+import { setConfig } from 'next/config';
+
+const Container = tw.div`flex flex-wrap -mx-2`;
+const MainContent = tw.div`w-full lg:w-3/4 px-4 py-4`;
+
+export default function AdminSetup({
+  apiUrl,
+  settings,
+  site,
+  subdomain,
+  siteUrl,
+  host,
+  authorizedEmailDomains,
+}) {
+  const [notificationMessage, setNotificationMessage] = useState('');
+  const [notificationType, setNotificationType] = useState('');
+  const [showNotification, setShowNotification] = useState(false);
+
+  const [airbrakeProjectId, setAirbrakeProjectId] = useState('');
+  const [airbrakeProjectKey, setAirbrakeProjectKey] = useState('');
+  const [analyticsClientId, setAnalyticsClientId] = useState('');
+  const [analyticsClientSecret, setAnalyticsClientSecret] = useState('');
+  const [apiToken, setApiToken] = useState('');
+  const [cypressApiToken, setCypressApiToken] = useState('');
+  //GA_ACCOUNT_ID
+  const [gaAccountId, setGaAccountId] = useState('');
+  const [dbAuthorizedEmailDomains, setDbAuthorizedEmailDomains] = useState('');
+  const [githubToken, setGithubToken] = useState('');
+  const [gitRepo, setGitRepo] = useState('');
+  const [
+    googleCredentialsPrivateKey,
+    setGoogleCredentialsPrivateKey,
+  ] = useState('');
+  const [googleClientId, setGoogleClientId] = useState('');
+  const [googleClientSecret, setGoogleClientSecret] = useState('');
+  const [googleCredentialsEmail, setGoogleCredentialsEmail] = useState('');
+  const [letterheadApiKey, setLetterheadApiKey] = useState('');
+  const [letterheadApiUrl, setLetterheadApiUrl] = useState('');
+  const [letterheadChannelSlug, setLetterheadChannelSlug] = useState('');
+  const [analyticsViewId, setAnalyticsViewId] = useState('');
+  const [analyticsTrackingId, setAnalyticsTrackingId] = useState('');
+  const [dbSiteUrl, setDbSiteUrl] = useState('');
+  const [orgName, setOrgName] = useState('');
+  const [previewToken, setPreviewToken] = useState('');
+  const [tinymceApiKey, setTinyMceApiKey] = useState('');
+  const [awsAccessId, setAwsAccessId] = useState('');
+  const [awsAccessKey, setAwsAccessKey] = useState('');
+  const [awsDirName, setAwsDirName] = useState('');
+  const [awsRegion, setAwsRegion] = useState('');
+  const [awsBucketName, setAwsBucketName] = useState('');
+  const [vercelToken, setVercelToken] = useState('');
+  const [vercelDeployHook, setVercelDeployHook] = useState('');
+  const [fbAppId, setFbAppId] = useState('');
+  const [fbClientToken, setFbClientToken] = useState('');
+  const [monkeypodUrl, setMonkeypodUrl] = useState('');
+  const [stripePublishableKey, setStripePublishableKey] = useState('');
+  const [stripeSecretKey, setStripeSecretKey] = useState('');
+  const [stripeWebhookSecret, setStripeWebhookSecret] = useState('');
+
+  const [configureSite, setConfigureSite] = useState(subdomain);
+
+  // const router = useRouter();
+  // const { action } = router.query;
+
+  useEffect(() => {
+    if (subdomain) {
+      setConfigureSite(subdomain);
+    }
+    if (settings) {
+      if (findSetting(settings, 'AIRBRAKE_PROJECT_ID')) {
+        setAirbrakeProjectId(findSetting(settings, 'AIRBRAKE_PROJECT_ID'));
+      }
+
+      if (findSetting(settings, 'AIRBRAKE_PROJECT_KEY')) {
+        setAirbrakeProjectKey(findSetting(settings, 'AIRBRAKE_PROJECT_KEY'));
+      }
+
+      if (findSetting(settings, 'ANALYTICS_CLIENT_ID')) {
+        setAnalyticsClientId(findSetting(settings, 'ANALYTICS_CLIENT_ID'));
+      }
+
+      if (findSetting(settings, 'ANALYTICS_CLIENT_SECRET')) {
+        setAnalyticsClientSecret(
+          findSetting(settings, 'ANALYTICS_CLIENT_SECRET')
+        );
+      }
+
+      if (findSetting(settings, 'GA_ACCOUNT_ID')) {
+        setGaAccountId(findSetting(settings, 'GA_ACCOUNT_ID'));
+      }
+
+      if (findSetting(settings, 'NEXT_PUBLIC_ANALYTICS_VIEW_ID')) {
+        setAnalyticsViewId(
+          findSetting(settings, 'NEXT_PUBLIC_ANALYTICS_VIEW_ID')
+        );
+      }
+
+      if (findSetting(settings, 'NEXT_PUBLIC_GA_TRACKING_ID')) {
+        setAnalyticsTrackingId(
+          findSetting(settings, 'NEXT_PUBLIC_GA_TRACKING_ID')
+        );
+      }
+
+      if (findSetting(settings, 'NEXT_PUBLIC_FB_APP_ID')) {
+        setAnalyticsTrackingId(findSetting(settings, 'NEXT_PUBLIC_FB_APP_ID'));
+      }
+
+      if (findSetting(settings, 'NEXT_PUBLIC_FB_CLIENT_TOKEN')) {
+        setAnalyticsTrackingId(
+          findSetting(settings, 'NEXT_PUBLIC_FB_CLIENT_TOKEN')
+        );
+      }
+
+      if (findSetting(settings, 'API_TOKEN')) {
+        setApiToken(findSetting(settings, 'API_TOKEN'));
+        setCypressApiToken(findSetting(settings, 'API_TOKEN'));
+      }
+
+      if (findSetting(settings, 'GOOGLE_CLIENT_ID')) {
+        setGoogleClientId(findSetting(settings, 'GOOGLE_CLIENT_ID'));
+      }
+
+      if (findSetting(settings, 'GOOGLE_CLIENT_SECRET')) {
+        setGoogleClientSecret(findSetting(settings, 'GOOGLE_CLIENT_SECRET'));
+      }
+
+      if (findSetting(settings, 'GOOGLE_CREDENTIALS_EMAIL')) {
+        setGoogleCredentialsEmail(
+          findSetting(settings, 'GOOGLE_CREDENTIALS_EMAIL')
+        );
+      }
+
+      if (findSetting(settings, 'GOOGLE_CREDENTIALS_PRIVATE_KEY')) {
+        setGoogleCredentialsPrivateKey(
+          findSetting(settings, 'GOOGLE_CREDENTIALS_PRIVATE_KEY')
+        );
+      }
+
+      if (findSetting(settings, 'PREVIEW_TOKEN')) {
+        setPreviewToken(findSetting(settings, 'PREVIEW_TOKEN'));
+      }
+
+      if (findSetting(settings, 'GIT_REPO')) {
+        setGitRepo(findSetting(settings, 'GIT_REPO'));
+      }
+
+      if (findSetting(settings, 'GITHUB_TOKEN')) {
+        setGithubToken(findSetting(settings, 'GITHUB_TOKEN'));
+      }
+
+      if (findSetting(settings, 'LETTERHEAD_API_KEY')) {
+        setLetterheadApiKey(findSetting(settings, 'LETTERHEAD_API_KEY'));
+      }
+      if (findSetting(settings, 'LETTERHEAD_API_URL')) {
+        setLetterheadApiUrl(findSetting(settings, 'LETTERHEAD_API_URL'));
+      }
+      if (findSetting(settings, 'LETTERHEAD_CHANNEL_SLUG')) {
+        setLetterheadChannelSlug(
+          findSetting(settings, 'LETTERHEAD_CHANNEL_SLUG')
+        );
+      }
+      if (findSetting(settings, 'ORG_NAME')) {
+        setOrgName(findSetting(settings, 'ORG_NAME'));
+      }
+      if (findSetting(settings, 'AUTHORIZED_EMAIL_DOMAINS')) {
+        setDbAuthorizedEmailDomains(
+          findSetting(settings, 'AUTHORIZED_EMAIL_DOMAINS')
+        );
+      }
+      if (findSetting(settings, 'TINYMCE_API_KEY')) {
+        setTinyMceApiKey(findSetting(settings, 'TINYMCE_API_KEY'));
+      }
+      if (findSetting(settings, 'TNC_AWS_ACCESS_ID')) {
+        setAwsAccessId(findSetting(settings, 'TNC_AWS_ACCESS_ID'));
+      }
+      if (findSetting(settings, 'TNC_AWS_ACCESS_KEY')) {
+        setAwsAccessKey(findSetting(settings, 'TNC_AWS_ACCESS_KEY'));
+      }
+      if (findSetting(settings, 'TNC_AWS_BUCKET_NAME')) {
+        setAwsBucketName(findSetting(settings, 'TNC_AWS_BUCKET_NAME'));
+      }
+      if (findSetting(settings, 'TNC_AWS_REGION')) {
+        setAwsRegion(findSetting(settings, 'TNC_AWS_REGION'));
+      }
+      if (findSetting(settings, 'TNC_AWS_DIR_NAME')) {
+        setAwsDirName(findSetting(settings, 'TNC_AWS_DIR_NAME'));
+      }
+      if (findSetting(settings, 'NEXT_PUBLIC_MONKEYPOD_URL')) {
+        setMonkeypodUrl(findSetting(settings, 'NEXT_PUBLIC_MONKEYPOD_URL'));
+      }
+      if (findSetting(settings, 'STRIPE_SECRET_KEY')) {
+        setStripeSecretKey(findSetting(settings, 'STRIPE_SECRET_KEY'));
+      }
+      if (findSetting(settings, 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY')) {
+        setStripePublishableKey(
+          findSetting(settings, 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY')
+        );
+      }
+      if (findSetting(settings, 'STRIPE_WEBHOOK_SECRET')) {
+        setStripeWebhookSecret(findSetting(settings, 'STRIPE_WEBHOOK_SECRET'));
+      }
+      if (findSetting(settings, 'VERCEL_DEPLOY_HOOK')) {
+        setVercelDeployHook(findSetting(settings, 'VERCEL_DEPLOY_HOOK'));
+      }
+      if (findSetting(settings, 'VERCEL_TOKEN')) {
+        setVercelToken(findSetting(settings, 'VERCEL_TOKEN'));
+      }
+      if (findSetting(settings, 'NEXT_PUBLIC_SITE_URL')) {
+        setDbSiteUrl(findSetting(settings, 'NEXT_PUBLIC_SITE_URL'));
+      }
+    }
+  }, [settings]);
+
+  async function handleSubmit(ev) {
+    ev.preventDefault();
+
+    let settingsObjects = [
+      {
+        name: 'GIT_REPO',
+        value: gitRepo,
+      },
+      {
+        name: 'GITHUB_TOKEN',
+        value: githubToken,
+      },
+      {
+        name: 'LETTERHEAD_API_KEY',
+        value: letterheadApiKey,
+      },
+      {
+        name: 'LETTERHEAD_API_URL',
+        value: letterheadApiUrl,
+      },
+      {
+        name: 'LETTERHEAD_CHANNEL_SLUG',
+        value: letterheadChannelSlug,
+      },
+      {
+        name: 'ORG_NAME',
+        value: orgName,
+      },
+      {
+        name: 'AUTHORIZED_EMAIL_DOMAINS',
+        value: dbAuthorizedEmailDomains,
+      },
+      {
+        name: 'TINYMCE_API_KEY',
+        value: tinymceApiKey,
+      },
+      {
+        name: 'NEXT_PUBLIC_SITE_URL',
+        value: dbSiteUrl,
+      },
+      {
+        name: 'AIRBRAKE_PROJECT_ID',
+        value: airbrakeProjectId,
+      },
+      {
+        name: 'AIRBRAKE_PROJECT_KEY',
+        value: airbrakeProjectKey,
+      },
+      {
+        name: 'ANALYTICS_CLIENT_ID',
+        value: analyticsClientId,
+      },
+      {
+        name: 'ANALYTICS_CLIENT_SECRET',
+        value: analyticsClientSecret,
+      },
+      {
+        name: 'GA_ACCOUNT_ID',
+        value: gaAccountId,
+      },
+      {
+        name: 'NEXT_PUBLIC_ANALYTICS_VIEW_ID',
+        value: analyticsViewId,
+      },
+      {
+        name: 'NEXT_PUBLIC_GA_TRACKING_ID',
+        value: analyticsTrackingId,
+      },
+      {
+        name: 'NEXT_PUBLIC_FB_APP_ID',
+        value: fbAppId,
+      },
+      {
+        name: 'NEXT_PUBLIC_FB_CLIENT_TOKEN',
+        value: fbClientToken,
+      },
+      {
+        name: 'API_TOKEN',
+        value: apiToken,
+      },
+      {
+        name: 'CYPRESS_API_TOKEN',
+        value: cypressApiToken,
+      },
+      {
+        name: 'GOOGLE_CLIENT_ID',
+        value: googleClientId,
+      },
+      {
+        name: 'GOOGLE_CLIENT_SECRET',
+        value: googleClientSecret,
+      },
+      {
+        name: 'GOOGLE_CREDENTIALS_EMAIL',
+        value: googleCredentialsEmail,
+      },
+      {
+        name: 'GOOGLE_CREDENTIALS_PRIVATE_KEY',
+        value: googleCredentialsPrivateKey,
+      },
+      {
+        name: 'PREVIEW_TOKEN',
+        value: previewToken,
+      },
+      {
+        name: 'TNC_AWS_ACCESS_ID',
+        value: awsAccessId,
+      },
+      {
+        name: 'TNC_AWS_ACCESS_KEY',
+        value: awsAccessKey,
+      },
+      {
+        name: 'TNC_AWS_BUCKET_NAME',
+        value: awsBucketName,
+      },
+      {
+        name: 'TNC_AWS_REGION',
+        value: awsRegion,
+      },
+      {
+        name: 'TNC_AWS_DIR_NAME',
+        value: awsDirName,
+      },
+      {
+        name: 'NEXT_PUBLIC_MONKEYPOD_URL',
+        value: monkeypodUrl,
+      },
+      {
+        name: 'STRIPE_SECRET_KEY',
+        value: stripeSecretKey,
+      },
+      {
+        name: 'NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY',
+        value: stripePublishableKey,
+      },
+      {
+        name: 'STRIPE_WEBHOOK_SECRET',
+        value: stripeWebhookSecret,
+      },
+      {
+        name: 'VERCEL_DEPLOY_HOOK',
+        value: vercelDeployHook,
+      },
+      {
+        name: 'VERCEL_TOKEN',
+        value: vercelToken,
+      },
+    ];
+
+    let params = {
+      url: apiUrl,
+      site: configureSite,
+      settings: settingsObjects,
+    };
+
+    const { errors, data } = await insertSettings(params);
+
+    if (errors) {
+      console.error(errors);
+      setNotificationMessage(JSON.stringify(errors));
+      setNotificationType('error');
+      setShowNotification(true);
+    } else {
+      // display success message
+      setNotificationMessage('Updated settings.');
+      setNotificationType('success');
+      setShowNotification(true);
+    }
+
+    window.scrollTo(0, 0);
+  }
+  return (
+    <AdminLayout
+      host={host}
+      siteUrl={siteUrl}
+      authorizedEmailDomains={authorizedEmailDomains}
+    >
+      <AdminNav homePageEditor={false} showConfigOptions={true} />
+
+      <Container>
+        <MainContent>
+          <div tw="px-10 pt-5">
+            <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight">
+              Edit Organization Config
+            </h1>
+          </div>
+          <form onSubmit={handleSubmit} className={`settings-form`}>
+            {showNotification && (
+              <Notification
+                message={notificationMessage}
+                setShowNotification={setShowNotification}
+                notificationType={notificationType}
+              />
+            )}
+            <div tw="flex mb-4 pt-5 pl-10">
+              <div tw="w-full space-x-4 space-y-8">
+                <table tw="w-full table-auto">
+                  <tbody>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Authorized Email Domains (for tinycms login)
+                      </th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="dbAuthorizedEmailDomains"
+                          value={dbAuthorizedEmailDomains}
+                          onChange={(ev) => {
+                            setDbAuthorizedEmailDomains(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Organization Name</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="orgName"
+                          value={orgName}
+                          onChange={(ev) => {
+                            setOrgName(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Site URL</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="dbSiteUrl"
+                          value={dbSiteUrl}
+                          onChange={(ev) => {
+                            setDbSiteUrl(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        TinyNewsCo Platform API Token
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="apiToken"
+                          value={apiToken}
+                          onChange={(ev) => {
+                            setApiToken(ev.target.value);
+                            setCypressApiToken(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        TinyNewsCo Platform Preview Article/Page Token
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="previewToken"
+                          value={previewToken}
+                          onChange={(ev) => {
+                            setPreviewToken(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Airbrake Project ID</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="airbrakeProjectId"
+                          value={airbrakeProjectId}
+                          onChange={(ev) => {
+                            setAirbrakeProjectId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Airbrake Project Key</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="airbrakeProjectKey"
+                          value={airbrakeProjectKey}
+                          onChange={(ev) => {
+                            setAirbrakeProjectKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">AWS Access Key ID</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="awsAccessId"
+                          value={awsAccessId}
+                          onChange={(ev) => {
+                            setAwsAccessId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">AWS Secret Access Key</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="awsAccessKey"
+                          value={awsAccessKey}
+                          onChange={(ev) => {
+                            setAwsAccessKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">AWS Bucket Name</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="awsBucketName"
+                          value={awsBucketName}
+                          onChange={(ev) => {
+                            setAwsBucketName(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">AWS Folder Name</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="awsDirName"
+                          value={awsDirName}
+                          onChange={(ev) => {
+                            setAwsDirName(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">AWS Region</th>
+                      <td tw=" align-middle pt-2">
+                        <TinyInputField
+                          name="awsRegion"
+                          value={awsRegion}
+                          onChange={(ev) => {
+                            setAwsRegion(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Facebook App ID</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="fbAppId"
+                          value={fbAppId}
+                          onChange={(ev) => {
+                            setFbAppId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Facebook Client Token</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="fbClientToken"
+                          value={fbClientToken}
+                          onChange={(ev) => {
+                            setFbClientToken(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Github Repo</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="gitRepo"
+                          value={gitRepo}
+                          onChange={(ev) => {
+                            setGitRepo(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Github API Token</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="githubToken"
+                          value={githubToken}
+                          onChange={(ev) => {
+                            setGithubToken(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Google Analytics Client ID</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="analyticsClientId"
+                          value={analyticsClientId}
+                          onChange={(ev) => {
+                            setAnalyticsClientId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google Analytics Client Secret
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="analyticsClientSecret"
+                          value={analyticsClientSecret}
+                          onChange={(ev) => {
+                            setAnalyticsClientSecret(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Google Analytics Account ID</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="gaAccountId"
+                          value={gaAccountId}
+                          onChange={(ev) => {
+                            setGaAccountId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Google Analytics Tracking ID</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="analyticsTrackingId"
+                          value={analyticsTrackingId}
+                          onChange={(ev) => {
+                            setAnalyticsTrackingId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Google Analytics View ID</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="analyticsViewId"
+                          value={analyticsViewId}
+                          onChange={(ev) => {
+                            setAnalyticsViewId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google OAuth Client ID (for tinycms login)
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="googleClientId"
+                          value={googleClientId}
+                          onChange={(ev) => {
+                            setGoogleClientId(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google OAuth Client Secret (for tinycms login)
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="googleClientSecret"
+                          value={googleClientSecret}
+                          onChange={(ev) => {
+                            setGoogleClientSecret(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google Credentials Email (for Data Importer Jobs)
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="googleCredentialsEmail"
+                          value={googleCredentialsEmail}
+                          onChange={(ev) => {
+                            setGoogleCredentialsEmail(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google Credentials Private Key (for Data Importer Jobs)
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyTextArea
+                          name="googleCredentialsPrivateKey"
+                          value={googleCredentialsPrivateKey}
+                          onChange={(ev) => {
+                            setGoogleCredentialsPrivateKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">
+                        Google OAuth Client Secret (for tinycms login)
+                      </th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="googleClientSecret"
+                          value={googleClientSecret}
+                          onChange={(ev) => {
+                            setGoogleClientSecret(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+
+                    <tr tw="border">
+                      <th tw="text-right px-2">Letterhead API Key</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="letterheadApiKey"
+                          value={letterheadApiKey}
+                          onChange={(ev) => {
+                            setLetterheadApiKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Letterhead API URL</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="letterheadApiUrl"
+                          value={letterheadApiUrl}
+                          onChange={(ev) => {
+                            setLetterheadApiUrl(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Letterhead Channel Slug</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="letterheadChannelSlug"
+                          value={letterheadChannelSlug}
+                          onChange={(ev) => {
+                            setLetterheadChannelSlug(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Monkeypod URL</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="monkeypodUrl"
+                          value={monkeypodUrl}
+                          onChange={(ev) => {
+                            setMonkeypodUrl(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Stripe Publishable Key</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="stripePublishableKey"
+                          value={stripePublishableKey}
+                          onChange={(ev) => {
+                            setStripePublishableKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Stripe Secret Key</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="stripeSecretKey"
+                          value={stripeSecretKey}
+                          onChange={(ev) => {
+                            setStripeSecretKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Stripe Webhook Secret</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="stripeWebhookSecret"
+                          value={stripeWebhookSecret}
+                          onChange={(ev) => {
+                            setStripeWebhookSecret(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">TinyMCE API Key</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="tinymceApiKey"
+                          value={tinymceApiKey}
+                          onChange={(ev) => {
+                            setTinyMceApiKey(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Vercel Deploy Hook</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="vercelDeployHook"
+                          value={vercelDeployHook}
+                          onChange={(ev) => {
+                            setVercelDeployHook(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-right px-2">Vercel Token</th>
+                      <td tw="align-middle pt-2">
+                        <TinyInputField
+                          name="vercelToken"
+                          value={vercelToken}
+                          onChange={(ev) => {
+                            setVercelToken(ev.target.value);
+                          }}
+                        />
+                      </td>
+                    </tr>
+                    <tr tw="border">
+                      <th tw="text-center px-4"></th>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </form>
+        </MainContent>
+
+        <MainContent>
+          <div tw="flex justify-end">
+            <AddButton tw="mr-2" onClick={handleSubmit}>
+              Save
+            </AddButton>
+            <PlainButton tw="mr-2">
+              <Link href={`/tinycms/admin`} passHref>
+                <a>Back to orgs list</a>
+              </Link>
+            </PlainButton>
+          </div>
+        </MainContent>
+      </Container>
+    </AdminLayout>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const site = context.params.site;
+
+  const subdomain = context.params.subdomain;
+
+  const settingsResult = await getOrgSettings({
+    url: apiUrl,
+    site: subdomain,
+  });
+
+  if (settingsResult.errors) {
+    console.error('error:', settingsResult);
+    throw settingsResult.errors;
+  }
+
+  let settings = settingsResult.data.settings;
+  const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
+
+  // only NC/TNC staff allowed to admin
+  const authorizedEmailDomains = 'newscatalyst.org,tinynewsco.org';
+
+  const host = context.req.headers.host;
+
+  return {
+    props: {
+      apiUrl: apiUrl,
+      site: site,
+      subdomain: subdomain,
+      settings: settings,
+      siteUrl: siteUrl,
+      host: host,
+      authorizedEmailDomains: authorizedEmailDomains,
+    },
+  };
+}

--- a/pages/_sites/[site]/tinycms/admin/index.js
+++ b/pages/_sites/[site]/tinycms/admin/index.js
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+import tw, { styled } from 'twin.macro';
+import {
+  findSetting,
+  getOrgSettings,
+  getOrganizations,
+} from '../../../../../lib/settings.js';
+import AdminLayout from '../../../../../components/AdminLayout.js';
+import AdminNav from '../../../../../components/nav/AdminNav';
+
+const Container = tw.div`flex flex-wrap -mx-2`;
+const MainContent = tw.div`w-full lg:w-3/4 px-4 py-4`;
+
+export default function AdminSetupIndex({
+  organizations,
+  siteUrl,
+  host,
+  authorizedEmailDomains,
+}) {
+  const [orgRows, setOrgRows] = useState([]);
+
+  let orgLinks = [];
+
+  useEffect(() => {
+    orgLinks = organizations
+      .filter((org) => org.subdomain)
+      .map((org) => (
+        <tr tw="border" key={org.subdomain}>
+          <td tw="p-3">
+            <Link href={`/tinycms/admin/${org.subdomain}`} passHref>
+              <a>{org.name || org.subdomain}</a>
+            </Link>
+          </td>
+          <td tw="p-3 border">{org.subdomain}</td>
+          <td tw="p-3 border">{org.customDomain}</td>
+        </tr>
+      ));
+
+    setOrgRows(orgLinks);
+  }, [organizations]);
+
+  return (
+    <AdminLayout
+      host={host}
+      siteUrl={siteUrl}
+      authorizedEmailDomains={authorizedEmailDomains}
+    >
+      <AdminNav homePageEditor={false} showConfigOptions={true} />
+
+      <Container>
+        <MainContent>
+          <div tw="px-10 pt-5">
+            <h1 tw="inline-block text-3xl font-extrabold text-gray-900 tracking-tight mb-5">
+              Organizations Admin
+            </h1>
+
+            <p tw="mx-4 mb-5 px-2">
+              Configure an organization's settings for AWS, Facebook, Google
+              Analytics, Letterhead, Vercel, and tiny news platform specifics
+              like organization name, site URL, API tokens and tinycms
+              authentication options.
+            </p>
+
+            <table tw="w-full table-auto mx-3">
+              <thead>
+                <tr tw="border p-3">
+                  <th tw="border p-3">Name</th>
+                  <th tw="border p-3">Subdomain</th>
+                  <th tw="border p-3">Custom Domain</th>
+                </tr>
+              </thead>
+              <tbody>{orgRows}</tbody>
+            </table>
+          </div>
+        </MainContent>
+      </Container>
+    </AdminLayout>
+  );
+}
+
+export async function getServerSideProps(context) {
+  const apiUrl = process.env.HASURA_API_URL;
+  const adminSecret = process.env.HASURA_ADMIN_SECRET;
+
+  const { errors, data } = await getOrganizations({
+    url: apiUrl,
+    adminSecret: adminSecret,
+  });
+
+  if (errors) {
+    console.error('error:', errors);
+    throw errors;
+  }
+
+  const organizations = data.organizations;
+
+  const site = context.params.site;
+
+  const settingsResult = await getOrgSettings({
+    url: apiUrl,
+    site: site,
+  });
+
+  if (settingsResult.errors) {
+    console.error('error:', settingsResult);
+    throw settingsResult.errors;
+  }
+
+  let settings = settingsResult.data.settings;
+  const siteUrl = findSetting(settings, 'NEXT_PUBLIC_SITE_URL');
+
+  // only NC/TNC staff allowed to admin
+  const authorizedEmailDomains = 'newscatalyst.org,tinynewsco.org';
+
+  const host = context.req.headers.host;
+
+  return {
+    props: {
+      organizations: organizations,
+      siteUrl: siteUrl,
+      host: host,
+      authorizedEmailDomains: authorizedEmailDomains,
+    },
+  };
+}

--- a/script/shared.js
+++ b/script/shared.js
@@ -151,10 +151,12 @@ function hasuraInsertDonationClick(params) {
   });
 }
 
-const INSERT_ORGANIZATION_MUTATION = `mutation FrontendInsertOrganization($subdomain: String, $name: String) {
-  insert_organizations_one(object: {name: $name, subdomain: $subdomain}, on_conflict: {constraint: organizations_subdomain_key, update_columns: [name, subdomain]}) {
+const INSERT_ORGANIZATION_MUTATION = `mutation FrontendInsertOrganization($subdomain: String, $name: String, $customDomain: String, $slug: String) {
+  insert_organizations_one(object: {name: $name, subdomain: $subdomain, slug: $slug, customDomain: $customDomain}, on_conflict: {constraint: organizations_subdomain_key, update_columns: [name, customDomain, slug, subdomain]}) {
     id
+    customDomain
     name
+    slug
     subdomain
   }
 }`;
@@ -168,6 +170,8 @@ function hasuraInsertOrganization(params) {
     variables: {
       name: params['name'],
       subdomain: params['subdomain'],
+      slug: params['slug'],
+      customDomain: params['customDomain'],
     },
   });
 }


### PR DESCRIPTION
Some new stuff that will hopefully make adding a new org to the platform a bit easier.

Closes #1033 

1. The bootstrap script works again - it had to be updated for the current version of the platform. This is step one of the process.
2. There is now an **admin** section in the TinyCMS - it requires you to be authenticated with a newscatalyst.org or tinynewsco.org email address. Currently there are only two pages: a list of orgs (with subdomains) and a form to configure each org's values in the settings table. Previously you'd have to edit this directly in Hasura and/or write a script to do it.
3. The howto Google Doc is updated with the latest instructions plus additional context on the tech setup: https://docs.google.com/document/d/1sSvtRTYkk2PoixMrWPT3FSM6qO_5zseqdCXv4LmP7Rc/edit#

- [x] update script/bootstrap.js to work in current platform setup
- [x] add configuration of all values in `settings` table
- [x] update [How to Launch](https://docs.google.com/document/d/1sSvtRTYkk2PoixMrWPT3FSM6qO_5zseqdCXv4LmP7Rc/edit#heading=h.8904i1cnakxb) google doc with correct instructions

New bootstrap command:

```
node script/bootstrap -n "Full Org Name" -s short-org-slug -u https://org-url.tinynewsco.dev -b org-subdomain -c org-customDomain.org

node script/bootstrap -n "April News 6" -s april-news-6 -u https://april-news-6.tinynewsco.dev -b april-news-6 -c aprilnews6.org
```

I ran the above command, then started my dev server locally, and I was able to follow the instructions outlined in the Google Doc.

The tinycms admin section works by ignoring the subdomain (I kept it on next-tinynewsdemo.localhost) and instead using the subdomain param (context.params.subdomain) to lookup and update records in Hasura.
