### PR TITLE
Hotfix/author tag setters

### DIFF
--- a/pages/api/sidebar/documents/[id]/publish.js
+++ b/pages/api/sidebar/documents/[id]/publish.js
@@ -89,8 +89,8 @@ export default async function Handler(req, res) {
 
       delete articleData.first_published_at;
       delete articleData.last_published_at;
-      delete articleData.article_tags;
-      delete articleData.article_authors;
+      // delete articleData.article_tags;
+      // delete articleData.article_authors;
 
       articleData['category_id'] = parseInt(articleData['category_id']);
       // console.log(JSON.stringify(articleData));


### PR DESCRIPTION
We discussed these delete statements previously, but I found they are causing authors/tags to not get published on new articles, as seen on these Harvey World articles:

- https://harveyworld.org/articles/arts-culture-entertainment/restoration-ministries-reimagining-what-we-could-be
- https://harveyworld.org/articles/business-economy/construction-on-147th-metra-station-begins-next-month