### PR TITLE
Pages no longer use `revalidate` setting

### DIFF
--- a/pages/_sites/[site]/about.js
+++ b/pages/_sites/[site]/about.js
@@ -103,6 +103,6 @@ export async function getStaticProps({ params }) {
       site,
     },
 
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/articles/[category]/[slug].js
+++ b/pages/_sites/[site]/articles/[category]/[slug].js
@@ -158,6 +158,6 @@ export async function getStaticProps({ params }) {
     },
     // Re-generate the post at most once per second
     // if a request comes in
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/donate.js
+++ b/pages/_sites/[site]/donate.js
@@ -225,6 +225,6 @@ export async function getStaticProps({ params }) {
       monkeypodLink,
       site,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/index.js
+++ b/pages/_sites/[site]/index.js
@@ -122,7 +122,7 @@ export async function getStaticProps(context) {
         pages,
         site,
       },
-      revalidate: 1,
+      // revalidate: 1,
     };
   }
 
@@ -219,6 +219,6 @@ export async function getStaticProps(context) {
       monkeypodLink,
       site,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/preview/donate.js
+++ b/pages/_sites/[site]/preview/donate.js
@@ -144,6 +144,6 @@ export async function getStaticProps(context) {
       siteMetadata,
       site,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/preview/staff.js
+++ b/pages/_sites/[site]/preview/staff.js
@@ -80,6 +80,6 @@ export async function getStaticProps(context) {
       sections,
       siteMetadata,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/staff.js
+++ b/pages/_sites/[site]/staff.js
@@ -113,6 +113,6 @@ export async function getStaticProps({ params }) {
       site,
     },
 
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/static/[slug].js
+++ b/pages/_sites/[site]/static/[slug].js
@@ -121,6 +121,6 @@ export async function getStaticProps({ params }) {
       siteMetadata,
       site,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }


### PR DESCRIPTION
This PR comments out the `revalidate: 1` directive in order to test the new revalidate via lambda batch processing approach in staging.