### PR TITLE
Bugfix/debug revalidate issue

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,18 +24,14 @@ export const IMAGE_DIMENSIONS_DATE = new Date('02/11/2022 12:00:00 AM');
 export async function revalidate(params) {
   const { lambdaURL, paths, site } = params;
 
-  // console.log(
-  //   'process.env.NEXT_PUBLIC_APP_API_URL',
-  //   process.env.NEXT_PUBLIC_APP_API_URL,
-  //   'lambdaURL',
-  //   lambdaURL
-  // );
   let revalidateURL = new URL(
     `/api/revalidate`,
     process.env.NEXT_PUBLIC_APP_API_URL
   ).toString();
 
   try {
+    console.debug(lambdaURL, revalidateURL, paths);
+
     await fetch(lambdaURL, {
       method: 'POST',
       headers: {

--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -4,24 +4,38 @@ export default function middleware(req) {
   const url = req.nextUrl.clone(); // clone the request url
   const { pathname, searchParams } = req.nextUrl; // get pathname of request (e.g. /blog-slug)
   const hostname = req.headers.get('host'); // get hostname of request (e.g. demo.vercel.pub)
+  console.log('host header:', hostname);
 
   if (pathname.includes('/en-US')) {
     url.pathname = pathname.replace('/en-US', '');
     return NextResponse.redirect(url);
   }
 
-  let currentHost = hostname
-    .replace(`.localhost:3000`, '')
-    .replace(`.tinynewsco.dev:3000`, '')
-    .replace(`.tinynewsco.org:3000`, '')
-    .replace(`.tinynewsco.dev`, '')
-    .replace(`.tinynewsco.org`, '')
-    .replace(`.vercel.app`, '')
-    .replace(`.vercel.app:3000`, ''); // TBD if we need to change this
+  let currentHost;
 
-  // use the query param 'site' if currentHost isn't usable
-  if ((currentHost === 'localhost:3000' || !currentHost) && searchParams) {
+  if (!hostname) {
+    // revalidate requests from lambda come through (intermittently) without the 'host' header,
+    // despite us setting it explicitly on revalidate requests to the /api/revalidate endpoint
     currentHost = searchParams.get('site');
+  } else {
+    currentHost = hostname
+      .replace(`.localhost:3000`, '')
+      .replace(`.tinynewsco.dev:3000`, '')
+      .replace(`.tinynewsco.org:3000`, '')
+      .replace(`.tinynewsco.dev`, '')
+      .replace(`.tinynewsco.org`, '')
+      .replace(`.vercel.app`, '')
+      .replace(`.vercel.app:3000`, ''); // TBD if we need to change this
+
+    // use the query param 'site' if currentHost isn't usable
+    if (
+      (currentHost === 'localhost:3000' ||
+        currentHost.includes('ngrok.io') ||
+        !currentHost) &&
+      searchParams
+    ) {
+      currentHost = searchParams.get('site');
+    }
   }
 
   if (

--- a/pages/_sites/[site]/about.js
+++ b/pages/_sites/[site]/about.js
@@ -103,6 +103,6 @@ export async function getStaticProps({ params }) {
       site,
     },
 
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/_sites/[site]/index.js
+++ b/pages/_sites/[site]/index.js
@@ -219,6 +219,6 @@ export async function getStaticProps(context) {
       monkeypodLink,
       site,
     },
-    revalidate: 1,
+    // revalidate: 1,
   };
 }

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -4,6 +4,7 @@ export default async function handler(req, res) {
   const apiUrl = process.env.HASURA_API_URL;
 
   if (!req.query.site) {
+    console.error('Missing required ?site=subdomain query string parameter');
     return res
       .status(401)
       .json({ message: 'Missing required ?site=subdomain query param' });
@@ -25,21 +26,26 @@ export default async function handler(req, res) {
 
   // Check for secret to confirm this is a valid request
   if (req.query.secret !== apiToken) {
+    console.error('Invalid token');
     return res.status(401).json({ message: 'Invalid token' });
   }
 
   const pathToRevalidate = `${req.query.path}?site=${site}`;
   if (!pathToRevalidate) {
+    console.error(
+      'Missing required ?path=/to/revalidate query string parameter'
+    );
     return res
       .status(401)
       .json({ message: 'Missing required ?path=/to/revalidate query param' });
   }
 
   try {
+    console.log('revalidating:', pathToRevalidate);
     await res.unstable_revalidate(pathToRevalidate);
     return res.json({ revalidated: true });
   } catch (err) {
-    console.error(err);
+    console.error('failed revalidating', pathToRevalidate, err);
     // If there was an error, Next.js will continue
     // to show the last successfully generated page
     return res.status(500).send('Error revalidating');


### PR DESCRIPTION
This PR goes with https://github.com/news-catalyst/revalidate-paths/pull/1 in the lambda for sending revalidate requests to the next.js api endpoint:

* update to the middleware: 
  * I saw some errors in the lambda cloudwatch logs and front-end site logs that the next.js api was complaining about a lack of a `host` header
  * that revalidate-paths lambda now sends the `host` header
  * the frontend's middleware now falls back to the `site` parameter if present and treats ngrok requests the same as localhost, which helps to debug before deploying live
* the revalidate function debug-logs info relevant to sorting out issues
* the revalidate api endpoint console.error's in addition to responding with error messages in order to facilitate debugging
* to test, I commented out the `revalidate` directive on the home page and the static about page

Running my modified front-end (this PR) api locally, behind ngrok, then setting the following:

* `NEXT_PUBLIC_APP_API_URL`: my ngrok https url
* `REVALIDATE_LAMBDA_URL`: the staging revalidate-paths lambda endpoint, which is `https://wx945l8i10.execute-api.us-east-1.amazonaws.com/staging/`

I then made changes to the nav, watching the requests go into the lambda then my local API endpoint. You should see them come through and one by one get compiled, which takes a bit. The nav builder requests all pages get revalidated. 

Useful link: [the cloudwatch logs for the staging revalidate-paths lambda](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Frevalidate-paths-staging-app)

The tricky part is testing for changes, which, I think, because I'm running in dev mode will get picked up no matter what revalidation request we do. So I guess I'm opening this PR because, after making these changes and doing the best testing I could do from here, I'm wondering if you want to try in staging again, testing the About and home pages?