### PR TITLE
Fixing issue where run is defined more than once

### DIFF
--- a/.github/workflows/import-data-from-ga-cj-test-jul-11a.yml
+++ b/.github/workflows/import-data-from-ga-cj-test-jul-11a.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/setup-node@v1
       - run: npm install --no-optional
       - run: echo "🖥️ repo and node are setup"
+      - run: echo "[DEBUG] the GOOGLE_CREDENTIALS_EMAIL is ${{secrets.GOOGLE_CREDENTIALS_EMAIL}}"
+      - run: echo "[DEBUG] the GOOGLE_CREDENTIALS_PRIVATE_KEY is ${{secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY}}"
       - name: article-sessions
-        run: echo "[DEBUG] the GOOGLE_CREDENTIALS_EMAIL is ${{secrets.GOOGLE_CREDENTIALS_EMAIL}}"
-        run: echo "[DEBUG] the GOOGLE_CREDENTIALS_PRIVATE_KEY is ${{secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY}}"
         run: node script/ga.js -d article-sessions
       - name: donate-clicks
         run: node script/ga.js -d donate-clicks


### PR DESCRIPTION
We got an error in the workflow console (screenshot below), so I moved the run commands above the article-sessions.
![Screen Shot 2022-07-11 at 6 28 57 PM](https://user-images.githubusercontent.com/108034069/178388486-1fdd823d-aa33-48ff-a907-98d54e793b13.png)

