### PR TITLE
Testing one more org with a different GitHub env API call

### DIFF
--- a/.github/workflows/import-data-from-ga-cj-test-17.yml
+++ b/.github/workflows/import-data-from-ga-cj-test-17.yml
@@ -1,0 +1,52 @@
+name: GA Data Importer cj-test-17
+'on':
+  schedule:
+    - cron: 5 9 * * *
+  workflow_dispatch: null
+jobs:
+  GA-Data-Importer:
+    runs-on: ubuntu-latest
+    environment: data_import_cj-test-17
+    env:
+      NEXT_PUBLIC_SITE_URL: https://cjtestj17.dev
+      HASURA_API_URL: ${{ secrets.HASURA_API_URL }}
+      SITE: cj-test-17
+      GOOGLE_CREDENTIALS_EMAIL: ${{ secrets.GOOGLE_CREDENTIALS_EMAIL }}
+      GOOGLE_CREDENTIALS_PRIVATE_KEY: ${{ secrets.GOOGLE_CREDENTIALS_PRIVATE_KEY }}
+      NEXT_PUBLIC_ANALYTICS_VIEW_ID: '271047277'
+      TINYMCE_API_KEY: ${{ secrets.TINYMCE_API_KEY }}
+    steps:
+      - run: echo "🔎 Running GA data importer"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - run: npm install --no-optional
+      - run: echo "🖥️ repo and node are setup"
+      - name: article-sessions
+        run: node script/ga.js -d article-sessions
+      - name: donate-clicks
+        run: node script/ga.js -d donate-clicks
+      - name: donor-reading-frequency
+        run: node script/ga.js -d donor-reading-frequency
+      - name: donors
+        run: node script/ga.js -d donors
+      - name: geo-sessions
+        run: node script/ga.js -d geo-sessions
+      - name: newsletter-impressions
+        run: node script/ga.js -d newsletter-impressions
+      - name: newsletters
+        run: node script/ga.js -d newsletters
+      - name: page-views
+        run: node script/ga.js -d page-views
+      - name: reading-depth
+        run: node script/ga.js -d reading-depth
+      - name: reading-frequency
+        run: node script/ga.js -d reading-frequency
+      - name: referral-sessions
+        run: node script/ga.js -d referral-sessions
+      - name: session-duration
+        run: node script/ga.js -d session-duration
+      - name: sessions
+        run: node script/ga.js -d sessions
+      - name: subscribers
+        run: node script/ga.js -d subscribers
+      - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
I want to test whether the API call we currently use is causing issues with the GA API key. So I'm gonna swap it out for a different API call that does the same thing. 

In bootstrap.js, I locally changed lines 212-221 from:
```
const secretResult = await octokit.rest.actions.createOrUpdateEnvironmentSecret(
        {
          repository_id: repoID,
          environment_name: environmentName,
          secret_name: secretName,
          encrypted_value: encryptedValue,
          key_id: pubKeyID,
        }
```

to:

```
const secretResult = await octokit.request(
        'PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}',
        {
          repository_id: repoID,
          environment_name: environmentName,
          secret_name: secretName,
          encrypted_value: encryptedValue,
          key_id: pubKeyID,
        }
      );
```

Then I ran the boostrap script locally. The script went through as expected. Now, I'm uploading this new org's yml file to see if the workflow will run. If it does, that means the API we were previously using was not correctly saving the API key. 
