### PR TITLE
Added logging to newsletter script, filtered out welcome letters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11650,15 +11650,18 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -25518,13 +25521,19 @@
       },
       "dependencies": {
         "tr46": {
-          "version": "0.0.3"
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "webidl-conversions": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"

--- a/script/build-newsletter-editions.js
+++ b/script/build-newsletter-editions.js
@@ -57,7 +57,21 @@ async function getNewsletterEditions() {
       )?.value,
     };
 
-    if (!letterhead['url']) {
+    if (!letterhead['url'] || letterhead['url'].length === 0) {
+      console.log(
+        '> Org#' +
+          organizationId +
+          ' has an invalid Letterhead url, skipping newsletter fetching.'
+      );
+      continue;
+    }
+
+    if (!letterhead['channelSlug'] || letterhead['channelSlug'].length === 0) {
+      console.log(
+        '> Org#' +
+          organizationId +
+          ' has an invalid Letterhead slug, skipping newsletter fetching.'
+      );
       continue;
     }
 
@@ -89,7 +103,7 @@ async function saveNewsletterEditions(organizationId, letterheadData) {
   console.log(
     organizationId,
     'Letterhead returned',
-    letterheadData.length,
+    letterheadData.total,
     'newsletter editions in total:'
   );
 
@@ -104,10 +118,23 @@ async function saveNewsletterEditions(organizationId, letterheadData) {
           ' Newsletter ID#' +
           newsletter.id +
           " '" +
-          newsletter.publicationStatus+
+          newsletter.publicationStatus +
           ' is the publication status ' +
           headline +
           "' is not published, skipping."
+      );
+      continue;
+    }
+
+    if (!newsletter.publicationDate) {
+      console.log(
+        '> Org#' +
+          organizationId +
+          ' Newsletter ID#' +
+          newsletter.id +
+          " '" +
+          headline +
+          "' doesn't have a publish date, skipping."
       );
       continue;
     }
@@ -176,7 +203,7 @@ async function saveNewsletterEditions(organizationId, letterheadData) {
           "' was published at " +
           newsletter.publicationDate +
           " '" +
-          newsletter.publicationStatus+
+          newsletter.publicationStatus +
           ' is the publication status ' +
           ', saved in Hasura with slug: ' +
           result.data.insert_newsletter_editions_one.slug


### PR DESCRIPTION
- Added a separate clause to filter out newsletters that don't have a publication date. Welcome letters returned by the Letterhead API have empty publicationDate values. 
- Fixed issue with undefined variable `length` in the loglines. 
- Minor spacing changes from Prettier.